### PR TITLE
Update link to Securing Software

### DIFF
--- a/src/content/7/fi/osa7e.md
+++ b/src/content/7/fi/osa7e.md
@@ -258,7 +258,7 @@ Kuten [osan 6](/osa6/connect#redux-ja-komponenttien-tila) lopussa mainittiin, Re
 
 ### React/node-sovellusten tietoturva
 
-Emme ole vielä maininneet kurssilla sanaakaan tietoturvaan liittyen. Kovin paljon ei nytkään ole aikaa, ja onneksi laitoksella on MOOC-kurssi [Securing Software](https://cybersecuritybase.github.io/securing/) tähän tärkeään aihepiiriin.
+Emme ole vielä maininneet kurssilla sanaakaan tietoturvaan liittyen. Kovin paljon ei nytkään ole aikaa, ja onneksi laitoksella on MOOC-kurssi [Securing Software](https://cybersecuritybase.mooc.fi/module-2.1) tähän tärkeään aihepiiriin.
 
 Katsotaan kuitenkin muutamaa kurssispesifistä seikkaa.
 


### PR DESCRIPTION
The previous link is no longer valid and leads to a 404 error page