### PR TITLE
Removed unnecessary rendering from App.js

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -474,11 +474,6 @@ const App = ({ notes }) => {
   )
 }
 
-ReactDOM.render(
-  <App notes={notes} />,
-  document.getElementById('root')
-)
-
 export default App // highlight-line
 ```
 


### PR DESCRIPTION
In the Refactoring Module section (Part 2a), the App component is moved into a new module named App.js. accidentally, the rendering was copied from the index.js. We are not importing react-dom in App.js and that was creating an error.