### PR TITLE
[Incorrect- please delete] Correcting the install bcrypt command

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -291,7 +291,7 @@ Do not save passwords to the database as clear text, but use the <i>bcrypt</i> l
 **NB** Some Windows users have had problems with <i>bcrypt</i>. If you run into problems, remove the library with command 
 
 ```bash
-npm uninstall bcrypt --save 
+npm install bcrypt --save 
 ```
 
 and install [bcryptjs](https://www.npmjs.com/package/bcryptjs) instead. 


### PR DESCRIPTION
Starting exercise 4.15: bloglist expansion, step4
it stats advising to save encrypted password and as that fact adds the command to install the bcryptjs package. The command uses uninstall as for uninstalling the package.
It should be installing or i.