### PR TITLE
refactor: use expect(array).toHaveLength() instead of expect(array.length).toBe()

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -221,7 +221,7 @@ Let's write a few more tests:
 test('there are two notes', async () => {
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(2)
+  expect(response.body).toHaveLength(2)
 })
 
 test('the first note is about HTTP methods', async () => {
@@ -241,7 +241,7 @@ const res = await api.get('/api/notes')
 
 // execution gets here only after the HTTP request is complete
 // the result of HTTP request is saved in variable res
-expect(res.body.length).toBe(2)
+expect(res.body).toHaveLength(2)
 ```
 
 <!-- HTTP-pyyntöjen tiedot konsoliin kirjoittava middleware häiritsee hiukan testien tulostusta. Muutetaan loggeria siten, että testausmoodissa lokiviestit eivät tulostu konsoliin: -->
@@ -311,7 +311,7 @@ Let's also make the following changes to the last two tests:
 test('all notes are returned', async () => {
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(initialNotes.length) // highlight-line
+  expect(response.body).toHaveLength(initialNotes.length) // highlight-line
 })
 
 test('a specific note is within the returned notes', async () => {
@@ -475,7 +475,7 @@ test('a valid note can be added ', async () => {
 
   const contents = response.body.map(r => r.content)
 
-  expect(response.body.length).toBe(initialNotes.length + 1)
+  expect(response.body).toHaveLength(initialNotes.length + 1)
   expect(contents).toContain(
     'async/await simplifies making async calls'
   )
@@ -499,7 +499,7 @@ test('note without content is not added', async () => {
 
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(initialNotes.length)
+  expect(response.body).toHaveLength(initialNotes.length)
 })
 ```
 
@@ -578,7 +578,7 @@ test('notes are returned as json', async () => {
 test('all notes are returned', async () => {
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(helper.initialNotes.length) // highlight-line
+  expect(response.body).toHaveLength(helper.initialNotes.length) // highlight-line
 })
 
 test('a specific note is within the returned notes', async () => {
@@ -603,7 +603,7 @@ test('a valid note can be added ', async () => {
     .expect('Content-Type', /application\/json/)
 
   const notesAtEnd = await helper.notesInDb() // highlight-line
-  expect(notesAtEnd.length).toBe(helper.initialNotes.length + 1) // highlight-line
+  expect(notesAtEnd).toHaveLength(helper.initialNotes.length + 1) // highlight-line
 
   const contents = notesAtEnd.map(n => n.content) // highlight-line
   expect(contents).toContain(
@@ -623,7 +623,7 @@ test('note without content is not added', async () => {
 
   const notesAtEnd = await helper.notesInDb() // highlight-line
 
-  expect(notesAtEnd.length).toBe(helper.initialNotes.length) // highlight-line
+  expect(notesAtEnd).toHaveLength(helper.initialNotes.length) // highlight-line
 })
 
 afterAll(() => {
@@ -716,7 +716,7 @@ test('a note can be deleted', async () => {
 
   const notesAtEnd = await helper.notesInDb()
 
-  expect(notesAtEnd.length).toBe(
+  expect(notesAtEnd).toHaveLength(
     helper.initialNotes.length - 1
   )
 
@@ -1079,7 +1079,7 @@ describe('when there is initially some notes saved', () => {
   test('all notes are returned', async () => {
     const response = await api.get('/api/notes')
 
-    expect(response.body.length).toBe(helper.initialNotes.length)
+    expect(response.body).toHaveLength(helper.initialNotes.length)
   })
 
   test('a specific note is within the returned notes', async () => {
@@ -1139,7 +1139,7 @@ describe('when there is initially some notes saved', () => {
 
 
       const notesAtEnd = await helper.notesInDb()
-      expect(notesAtEnd.length).toBe(helper.initialNotes.length + 1)
+      expect(notesAtEnd).toHaveLength(helper.initialNotes.length + 1)
 
       const contents = notesAtEnd.map(n => n.content)
       expect(contents).toContain(
@@ -1159,7 +1159,7 @@ describe('when there is initially some notes saved', () => {
 
       const notesAtEnd = await helper.notesInDb()
 
-      expect(notesAtEnd.length).toBe(helper.initialNotes.length)
+      expect(notesAtEnd).toHaveLength(helper.initialNotes.length)
     })
   })
 
@@ -1174,7 +1174,7 @@ describe('when there is initially some notes saved', () => {
 
       const notesAtEnd = await helper.notesInDb()
 
-      expect(notesAtEnd.length).toBe(
+      expect(notesAtEnd).toHaveLength(
         helper.initialNotes.length - 1
       )
 

--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -322,7 +322,7 @@ describe('when there is initially one user at db', () => {
       .expect('Content-Type', /application\/json/)
 
     const usersAtEnd = await helper.usersInDb()
-    expect(usersAtEnd.length).toBe(usersAtStart.length + 1)
+    expect(usersAtEnd).toHaveLength(usersAtStart.length + 1)
 
     const usernames = usersAtEnd.map(u => u.username)
     expect(usernames).toContain(newUser.username)
@@ -376,7 +376,7 @@ describe('when there is initially one user at db', () => {
     expect(result.body.error).toContain('`username` to be unique')
 
     const usersAtEnd = await helper.usersInDb()
-    expect(usersAtEnd.length).toBe(usersAtStart.length)
+    expect(usersAtEnd).toHaveLength(usersAtStart.length)
   })
 })
 ```

--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -201,7 +201,7 @@ Tehdään pari testiä lisää:
 test('there are two notes', async () => {
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(2)
+  expect(response.body).toHaveLength(2)
 })
 
 test('the first note is about HTTP methods', async () => {
@@ -220,7 +220,7 @@ const response = await api.get('/api/notes')
 
 // tänne tullaan vasta kun edellinen komento eli HTTP-pyyntö on suoritettu
 // muuttujassa response on nyt HTTP-pyynnön tulos
-expect(response.body.length).toBe(2)
+expect(response.body).toHaveLength(2)
 ```
 
 HTTP-pyyntöjen tiedot konsoliin kirjoittava middleware häiritsee hiukan testien tulostusta. Muutetaan loggeria siten, että testausmoodissa lokiviestit eivät tulostu konsoliin:
@@ -289,7 +289,7 @@ Muutetaan kahta jälkimmäistä testiä vielä seuraavasti:
 test('all notes are returned', async () => {
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(initialNotes.length) // highlight-line
+  expect(response.body).toHaveLength(initialNotes.length) // highlight-line
 })
 
 test('a specific note is within the returned notes', async () => {
@@ -447,7 +447,7 @@ test('a valid note can be added ', async () => {
 
   const contents = response.body.map(r => r.content)
 
-  expect(response.body.length).toBe(initialNotes.length + 1)
+  expect(response.body).toHaveLength(initialNotes.length + 1)
   expect(contents).toContain(
     'async/await simplifies making async calls'
   )
@@ -471,7 +471,7 @@ test('note without content is not added', async () => {
 
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(initialNotes.length)
+  expect(response.body).toHaveLength(initialNotes.length)
 })
 ```
 
@@ -550,7 +550,7 @@ test('notes are returned as json', async () => {
 test('all notes are returned', async () => {
   const response = await api.get('/api/notes')
 
-  expect(response.body.length).toBe(helper.initialNotes.length) // highlight-line
+  expect(response.body).toHaveLength(helper.initialNotes.length) // highlight-line
 })
 
 test('a specific note is within the returned notes', async () => {
@@ -576,7 +576,7 @@ test('a valid note can be added ', async () => {
 
 
   const notesAtEnd = await helper.notesInDb() // highlight-line
-  expect(notesAtEnd.length).toBe(helper.initialNotes.length + 1) // highlight-line
+  expect(notesAtEnd).toHaveLength(helper.initialNotes.length + 1) // highlight-line
 
   const contents = notesAtEnd.map(n => n.content) // highlight-line
   expect(contents).toContain(
@@ -596,7 +596,7 @@ test('note without content is not added', async () => {
 
   const notesAtEnd = await helper.notesInDb() // highlight-line
 
-  expect(notesAtEnd.length).toBe(helper.initialNotes.length) // highlight-line
+  expect(notesAtEnd).toHaveLength(helper.initialNotes.length) // highlight-line
 })
 
 afterAll(() => {
@@ -689,7 +689,7 @@ test('a note can be deleted', async () => {
 
   const notesAtEnd = await helper.notesInDb()
 
-  expect(notesAtEnd.length).toBe(
+  expect(notesAtEnd).toHaveLength(
     helper.initialNotes.length - 1
   )
 
@@ -1015,7 +1015,7 @@ describe('when there is initially some notes saved', () => {
   test('all notes are returned', async () => {
     const response = await api.get('/api/notes')
 
-    expect(response.body.length).toBe(helper.initialNotes.length)
+    expect(response.body).toHaveLength(helper.initialNotes.length)
   })
 
   test('a specific note is within the returned notes', async () => {
@@ -1076,7 +1076,7 @@ describe('when there is initially some notes saved', () => {
 
 
       const notesAtEnd = await helper.notesInDb()
-      expect(notesAtEnd.length).toBe(helper.initialNotes.length + 1)
+      expect(notesAtEnd).toHaveLength(helper.initialNotes.length + 1)
 
       const contents = notesAtEnd.map(n => n.content)
       expect(contents).toContain(
@@ -1096,7 +1096,7 @@ describe('when there is initially some notes saved', () => {
 
       const notesAtEnd = await helper.notesInDb()
 
-      expect(notesAtEnd.length).toBe(helper.initialNotes.length)
+      expect(notesAtEnd).toHaveLength(helper.initialNotes.length)
     })
   })
 
@@ -1111,7 +1111,7 @@ describe('when there is initially some notes saved', () => {
 
       const notesAtEnd = await helper.notesInDb()
 
-      expect(notesAtEnd.length).toBe(
+      expect(notesAtEnd).toHaveLength(
         helper.initialNotes.length - 1
       )
 

--- a/src/content/4/fi/osa4c.md
+++ b/src/content/4/fi/osa4c.md
@@ -286,7 +286,7 @@ describe('when there is initially one user at db', () => {
       .expect('Content-Type', /application\/json/)
 
     const usersAtEnd = await helper.usersInDb()
-    expect(usersAtEnd.length).toBe(usersAtStart.length + 1)
+    expect(usersAtEnd).toHaveLength(usersAtStart.length + 1)
 
     const usernames = usersAtEnd.map(u => u.username)
     expect(usernames).toContain(newUser.username)
@@ -338,7 +338,7 @@ describe('when there is initially one user at db', () => {
     expect(result.body.error).toContain('`username` to be unique')
 
     const usersAtEnd = await helper.usersInDb()
-    expect(usersAtEnd.length).toBe(usersAtStart.length)
+    expect(usersAtEnd).toHaveLength(usersAtStart.length)
   })
 })
 ```

--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -287,7 +287,7 @@ test('clicking the button calls event handler once', () => {
   const button = component.getByText('make not important')
   fireEvent.click(button)
 
-  expect(mockHandler.mock.calls.length).toBe(1)
+  expect(mockHandler.mock.calls).toHaveLength(1)
 })
 ```
 
@@ -310,7 +310,7 @@ Clicking happens with the [fireEvent](https://testing-library.com/docs/api-event
 The expectation of the test verifies that the <i>mock function</i> has been called exactly once.
 
 ```js
-expect(mockHandler.mock.calls.length).toBe(1)
+expect(mockHandler.mock.calls).toHaveLength(1)
 ```
 
 
@@ -528,7 +528,7 @@ test('<NoteForm /> updates parent state and calls onSubmit', () => {
   })
   fireEvent.submit(form)
 
-  expect(createNote.mock.calls.length).toBe(1)
+  expect(createNote.mock.calls).toHaveLength(1)
   expect(createNote.mock.calls[0][0].content).toBe('testing of forms could be easier' )
 })
 ```

--- a/src/content/5/fi/osa5c.md
+++ b/src/content/5/fi/osa5c.md
@@ -262,7 +262,7 @@ test('clicking the button calls event handler once', async () => {
   const button = component.getByText('make not important')
   fireEvent.click(button)
 
-  expect(mockHandler.mock.calls.length).toBe(1)
+  expect(mockHandler.mock.calls).toHaveLength(1)
 })
 ```
 
@@ -284,7 +284,7 @@ Klikkaaminen tapahtuu metodin [fireEvent](https://testing-library.com/docs/api-e
 Testin ekspektaatio varmistaa, että <i>mock-funktiota</i> on kutsuttu täsmälleen kerran:
 
 ```js
-expect(mockHandler.mock.calls.length).toBe(1)
+expect(mockHandler.mock.calls).toHaveLength(1)
 ```
 
 [Mockoliot ja -funktiot](https://en.wikipedia.org/wiki/Mock_object) ovat testauksessa yleisesti käytettyjä valekomponentteja, joiden avulla korvataan testattavien komponenttien riippuvuuksia, eli niiden tarvitsemia muita komponentteja. Mockit mahdollistavat mm. kovakoodattujen syötteiden palauttamisen sekä niiden metodikutsujen lukumäärän sekä parametrien testauksen aikaisen tarkkailun.
@@ -481,7 +481,7 @@ test('<NoteForm /> updates parent state and calls onSubmit', () => {
   })
   fireEvent.submit(form)
 
-  expect(createNote.mock.calls.length).toBe(1)
+  expect(createNote.mock.calls).toHaveLength(1)
   expect(createNote.mock.calls[0][0].content).toBe('testing of forms could be easier' )
 })
 ```

--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -419,7 +419,7 @@ describe('noteReducer', () => {
     deepFreeze(state)
     const newState = noteReducer(state, action)
 
-    expect(newState.length).toBe(1)
+    expect(newState).toHaveLength(1)
     expect(newState).toContainEqual(action.data)
   })
 })
@@ -457,7 +457,7 @@ test('returns new state with action TOGGLE_IMPORTANCE', () => {
   deepFreeze(state)
   const newState = noteReducer(state, action)
 
-  expect(newState.length).toBe(2)
+  expect(newState).toHaveLength(2)
 
   expect(newState).toContainEqual(state[0])
 

--- a/src/content/6/fi/osa6a.md
+++ b/src/content/6/fi/osa6a.md
@@ -373,7 +373,7 @@ describe('noteReducer', () => {
     deepFreeze(state)
     const newState = noteReducer(state, action)
 
-    expect(newState.length).toBe(1)
+    expect(newState).toHaveLength(1)
     expect(newState).toContainEqual(action.data)
   })
 })
@@ -411,7 +411,7 @@ test('returns new state with action TOGGLE_IMPORTANCE', () => {
   deepFreeze(state)
   const newState = noteReducer(state, action)
 
-  expect(newState.length).toBe(2)
+  expect(newState).toHaveLength(2)
 
   expect(newState).toContainEqual(state[0])
 


### PR DESCRIPTION
`expect(array).toHaveLength()` [provides better failure messages](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-have-length.md) than `expect(array.length).toBe()`:

```
    expect(received).toHaveLength(expected)

    Expected length: 3
    Received length: 2
    Received array:  [{"id": "1", "name": "test"}, {"id": "2", "name": "lint"}]
```
vs.
```
    expect(received).toBe(expected) // Object.is equality

    Expected: 3
    Received: 2
```

I found the [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) to be quite educative. Perhaps it should be introduced in the ESLint section?