### PR TITLE
Update build scripts in part3b.md

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -218,6 +218,7 @@ To create a new production build of the frontend without extra manual work, let'
 ```json
 {
   "scripts": {
+    //...
     "build:ui": "rm -rf build && cd ../../osa2/materiaali/notes-new && npm run build --prod && cp -r build ../../../osa3/notes-backend/",
     "deploy": "git push heroku master",
     "deploy:full": "npm run build:ui && git add . && git commit -m uibuild && npm run deploy",    


### PR DESCRIPTION
Current example suggests replacing Start and Dev npm scripts which are needed for later exercise. Adds elipses to indicate new scripts are placed after the existing ones.