### PR TITLE
Add warning about json modules to en/part9c

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -11,7 +11,7 @@ lang: en
 Now that we have a basic understanding of how TypeScript works and how to create small projects with it, it's time to start creating something actually useful. We are now going to create a new project with a bit more realistic use cases in mind.
 
 <!-- One major change from the previous part is that <i>we're not going to use ts-node anymore</i>. ts-node is a handy tool, with which it is very easy to get started, but in the long run it is suggested to use the official TypeScript compiler that comes with the <i>typescript</i> npm-package. With this compiler the basic JavaScript files are generated and packaged from the .ts files so that the built <i>production version</i> of the project won't contain any TypeScript code. This is exactly what we are aiming for in the end, since TypeScript in itself is not runnable by browsers or Node. -->
-One major change from the previous part is that <i>we're not going to use ts-node anymore</i>. It is a handy tool and helps you get started, but in the long run it is advicable to use the official TypeScript compiler that comes with the <i>typescript</i> npm-package. The official compiler generates and packages JavaScript files from the .ts files so that the built <i>production version</i> won't contain any TypeScript code anymore. This is the exact outcome we are aiming for, since TypeScript itself is not executable by browsers or Node. 
+One major change from the previous part is that <i>we're not going to use ts-node anymore</i>. It is a handy tool and helps you get started, but in the long run it is advicable to use the official TypeScript compiler that comes with the <i>typescript</i> npm-package. The official compiler generates and packages JavaScript files from the .ts files so that the built <i>production version</i> won't contain any TypeScript code anymore. This is the exact outcome we are aiming for, since TypeScript itself is not executable by browsers or Node.
 
 ### Setting up the project
 
@@ -23,8 +23,8 @@ Let's start by creating our first real project 'Ilari's flight diaries'. As usua
 
 <!-- TypeScript's native <i>tsc</i> compiler offers us help initialising our project with the command <i>tsc --init</i>. To be able to run this, we need to add the <i>tsc</i> command to runnable scripts in the package.json file unless we have installed <i>typescript</i> globally. And even if you would have installed typescript globally, you should always include the package as a dev-dependency in your project. -->
 TypeScript's native <i>tsc</i> compiler can help us to initialize our project with the command <i>tsc --init</i>.
-First we need to add the <i>tsc</i> command to the list of executable scripts in the package.json file (unless you have installed <i>typescript</i> globally ). 
-Even if you have installed TypeScript globally, you should always include it as a dev-dependency in your project. 
+First we need to add the <i>tsc</i> command to the list of executable scripts in the package.json file (unless you have installed <i>typescript</i> globally ).
+Even if you have installed TypeScript globally, you should always include it as a dev-dependency in your project.
 
 The npm script for running <i>tsc</i> is set as follows:
 
@@ -48,11 +48,11 @@ The npm script for running <i>tsc</i> is set as follows:
  npm run tsc -- --init
 ```
 
- **Notice** the extra -- before the actual argument! Arguments before the -- are interpreted for the command <i>npm</i> and ones after are for the command that is run through the script. 
+ **Notice** the extra -- before the actual argument! Arguments before the -- are interpreted for the command <i>npm</i> and ones after are for the command that is run through the script.
 
 <!-- The created <i>tsconfig.json</i> contains a lengthy list of all of the possible configurations available to use, but  only a few of those are uncommented. Studying the initial <i>tsconfig.json</i> file might be useful for finding some configuration options you might need. It is also completely okay to keep the commented rows in the file just in case you might someday need to expand your configuration settings.  -->
-Running the script creates an <i>tsconfig.json</i> file, which contains a lengthy list of every configuration available to us. However only a few have not been commented out. 
-Studying the initial <i>tsconfig.json</i> file might be useful for finding some configuration options you might need. 
+Running the script creates an <i>tsconfig.json</i> file, which contains a lengthy list of every configuration available to us. However only a few have not been commented out.
+Studying the initial <i>tsconfig.json</i> file might be useful for finding some configuration options you might need.
 It is also completely okay to keep the commented rows in the file just in case you might someday need to expand your configuration settings.
 
 
@@ -66,7 +66,7 @@ The settings we want right now are the following:
     "module": "commonjs",
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,       
+    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true
@@ -74,7 +74,7 @@ The settings we want right now are the following:
 }
 ```
 
-Let's go through each configuration: 
+Let's go through each configuration:
 
 <!-- The <i>target</i> parameter tells the compiler which ECMAScript version the generated JavaScript should be generated into. ES6 is supported by most browsers and therefore is a good and pretty safe option. -->
 The <i>target</i> configuration tells the compiler which ECMAScript version to use for the generated JavaScript. ES6 is supported by most browsers, and it is a good, pretty safe option.
@@ -82,14 +82,14 @@ The <i>target</i> configuration tells the compiler which ECMAScript version to u
 <i>outDir</i> tells where the compiled code should be placed.
 
 <!-- <i>module</i> tells the compiler that we want to use <i>commonjs</i> modules in compiled code, so the code uses _require_ instead of _import_ that is not supported in older Node.js versions such as the version 10.  -->
-<i>module</i> tells the compiler we want to use <i>commonjs</i> modules in the compiled code. This means we can use _require_ instead of _import_, which is not supported in older Node.js versions such as the version 10. 
+<i>module</i> tells the compiler we want to use <i>commonjs</i> modules in the compiled code. This means we can use _require_ instead of _import_, which is not supported in older Node.js versions such as the version 10.
 
-<i>strict</i> is actually a shorthand for multiple separate options: 
+<i>strict</i> is actually a shorthand for multiple separate options:
 <!-- <i>noImplicitAny, noImplicitThis, alwaysStrict, strictBindCallApply, strictNullChecks, strictFunctionTypes and strictPropertyInitialization</i>. These all guide our coding style to use TypeScript features more strictly. The most important for us is perhaps the already familiar [noImplicitAny](https://www.typescriptlang.org/v2/en/tsconfig#noImplicitAny) that restricts implicitly setting type <i>any</i>, which happens for example if you don't type the expected parameters of a function. The rest of the options can all be studied more closely on the [tsconfig documentation](https://www.typescriptlang.org/v2/en/tsconfig#strict). Using <i>strict</i> is suggested by the official documentation. -->
 <i>noImplicitAny, noImplicitThis, alwaysStrict, strictBindCallApply, strictNullChecks, strictFunctionTypes and strictPropertyInitialization</i>.
-These guide our coding style to use the TypeScript features more strictly. 
-For us perhaps the most important is the already familiar [noImplicitAny](https://www.typescriptlang.org/en/tsconfig#noImplicitAny). It prevents implicitly setting type <i>any</i>, which can happen if you don't type the parameters of a function for example. 
-Details of the rest of the configurations can be found from the [tsconfig documentation](https://www.typescriptlang.org/en/tsconfig#strict). 
+These guide our coding style to use the TypeScript features more strictly.
+For us perhaps the most important is the already familiar [noImplicitAny](https://www.typescriptlang.org/en/tsconfig#noImplicitAny). It prevents implicitly setting type <i>any</i>, which can happen if you don't type the parameters of a function for example.
+Details of the rest of the configurations can be found from the [tsconfig documentation](https://www.typescriptlang.org/en/tsconfig#strict).
 Using <i>strict</i> is suggested by the official documentation.
 
 <!-- <i>noUnusedLocals</i> gives an error if a local variable is unused and <i>noUnusedParameters</i> when a function has unused parameters.  -->
@@ -106,7 +106,7 @@ npm install express
 npm install --save-dev eslint @types/express @typescript-eslint/eslint-plugin @typescript-eslint/parser
 ```
 
-Now our <i>package.json</i> should look something like this: 
+Now our <i>package.json</i> should look something like this:
 
 ```json
 {
@@ -163,8 +163,8 @@ We also create <i>.eslintrc</i> with the following content:
 }
 ```
 
-<!-- Now we only need to set up our development environment properly, and then we are ready to start writing some serious code. There are many different options and we could use the familiar <i>nodemon</i> with <i>ts-node</i>, but as we saw before, </i>ts-node-dev</i> does the exact same thing and we can continue using it. So, let's install <i>ts-node-dev</i> --> 
-Now we just need to set up our development environment, and we are ready to start writing some serious code. 
+<!-- Now we only need to set up our development environment properly, and then we are ready to start writing some serious code. There are many different options and we could use the familiar <i>nodemon</i> with <i>ts-node</i>, but as we saw before, </i>ts-node-dev</i> does the exact same thing and we can continue using it. So, let's install <i>ts-node-dev</i> -->
+Now we just need to set up our development environment, and we are ready to start writing some serious code.
 There are many different options for this. We could use the familiar <i>nodemon</i> with <i>ts-node</i>, but as we saw earlier, </i>ts-node-dev</i> does the exact same thing and we can continue using it.
 So, let's install <i>ts-node-dev</i>
 
@@ -188,12 +188,12 @@ And we are ready to start writing some code after defining still a couple of mor
 
 <!-- There is a lot of stuff to go through before you can even start the actual coding. When working with a real project, careful preparations support your development process to a great length, so take the time to create a good setting for yourself and your team so that in the long run everything runs smoothly. -->
 There is a lot of stuff to go through before you can start actual coding. When you are working with a real project, careful preparations support your development process a great deal.
-Take the time to create a good setting for yourself and your team so in the long run everything runs smoothly. 
+Take the time to create a good setting for yourself and your team so in the long run everything runs smoothly.
 
 ### Let there be code
 
 <!-- Now we can finally start coding! As always, we will at start create a ping-endpoint, just to make sure everything is working. -->
-Now we can finally start coding! As always, we start by creating a a ping-endpoint, just to make sure everything is working. 
+Now we can finally start coding! As always, we start by creating a a ping-endpoint, just to make sure everything is working.
 
 The contents of the <i>index.ts</i> file:
 
@@ -204,11 +204,11 @@ app.use(express.json());
 
 const PORT = 3000;
 
-app.get('/ping', (_req, res) => { 
+app.get('/ping', (_req, res) => {
   console.log('someone pinged here');
   res.send('pong');
 });
-  
+
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
@@ -218,13 +218,13 @@ app.listen(PORT, () => {
 Now if we run the app with <i>npm run dev</i> we can verify that a request to http://localhost:3000/ping gives a response <i>pong</i>, so our configuration is set!
 
 <!-- When starting the app with <i>npm run dev</i>, it is running in development mode, and for sure that is not suitable when we later on operate the app in production.  -->
-When starting the app with <i>npm run dev</i>, it runs in development mode. 
-The development mode is not suitable at all when we later operate the app in production. 
+When starting the app with <i>npm run dev</i>, it runs in development mode.
+The development mode is not suitable at all when we later operate the app in production.
 
 <!-- Let us now try to create the <i>production build</i> by running the TypeScript compiler. Since we have defined the <i>outdir</i> in our tsconfig.json, there's really nothing else to do, but run the script <i>npm run tsc</i>. -->
 Let's try to create a <i>production build</i> by running the TypeScript compiler. Since we have defined the <i>outdir</i> in our tsconfig.json, there's really nothing else to do but run the script <i>npm run tsc</i>.
 
-Just like magic a native runnable JavaScript production build of the express backend is created into the directory <i>build</i>.  
+Just like magic a native runnable JavaScript production build of the express backend is created into the directory <i>build</i>.
 
 <!-- Currently if we run eslint it will also interpret the files in the <i>build</i> directory, which we don't want, since that is compiler generated code. We can prevent this by creating a file <i>.eslintignore</i> with the content we want eslint to ignore, similarly as in <i>gitignore</i>. -->
 Currently, if we run eslint it will also interpret the files in the <i>build</i> directory. We don't want that, since the code there is compiler generated. We can prevent this by creating a  <i>.eslintignore</i> file  which lists the content we want eslint to ignore, just like we do with git and <i>gitignore</i>.
@@ -251,7 +251,7 @@ When we run app with <i>npm start</i> we can verify that also the production bui
 
 
 <!-- Now we have a minimal working pipeline, with which we can develop our project, and with the help from our compiler and eslint also ensure that a good code quality is maintained. With this base we can actually start creating an app that we could later on deploy into a production environment.  -->
-Now we have a minimal working pipeline for developing our project. 
+Now we have a minimal working pipeline for developing our project.
 With the help of our compiler and eslint it also ensures that a good code quality is maintained. With this base we can actually start creating an app that we could later on deploy into a production environment.
 
 </div>
@@ -268,7 +268,7 @@ The [frontend](https://github.com/fullstack-hy2020/patientor) has already been b
 
 #### 9.8: Patientor backend, step1
 
-Initialise project that will be used by the frontend. Configure eslint and tsconfig with the same configurations that are used in the material. Define an endpoint that responses to HTTP GET requests to route <i>/ping</i>.   
+Initialise project that will be used by the frontend. Configure eslint and tsconfig with the same configurations that are used in the material. Define an endpoint that responses to HTTP GET requests to route <i>/ping</i>.
 
 The project should be runnable with npm scripts both in development mode and as compiled code in production mode.
 
@@ -276,7 +276,7 @@ The project should be runnable with npm scripts both in development mode and as 
 
 Fork and clone the project [patientor](https://github.com/fullstack-hy2020/patientor). Start the project with the help of the README file. You should be able to use the frontend without a functioning backend.
 
-Ensure that backend answers to the ping request that <i>frontend</i> has made on startup. Check developer tool to make sure it really works: 
+Ensure that backend answers to the ping request that <i>frontend</i> has made on startup. Check developer tool to make sure it really works:
 
 ![](../../images/9/16a.png)
 
@@ -291,7 +291,7 @@ You might also want to have a look at the tab <i>console</i>. If something fails
 Finally we are ready to start writing some code.
 
 <!-- Let's start from basics. Ilari wants to keep track of his experiences on his flight journeys. -->
-Let's start from the basics. Ilari wants to be able to keep track of his experiences on his flight journeys. 
+Let's start from the basics. Ilari wants to be able to keep track of his experiences on his flight journeys.
 <!-- What he wants to be able to save are </i>diary entries</i> that include:  -->
 <!-- - Date of the entry -->
 <!-- - Weather conditions (either good, windy, rainy or stormy) -->
@@ -324,22 +324,22 @@ The data looks like the following
     "weather": "sunny",
     "visibility": "good",
     "comment": "Everything went better than expected, I'm learning much"
-  },  
+  },
   // ...
 ]
 ```
 
-Let's start by creating an endpoint which returns all flight diary entries. 
+Let's start by creating an endpoint which returns all flight diary entries.
 
 <!-- First we shall make some decision on how to structure our source code. It is better to put all the source code -->
 <!-- under the directory <i>src</i>, so that the source  code is not mixed up with configuration files. We will move also  -->
 <!-- <i>index.ts</i> there and make the corresponding changes to npm scripts. -->
-First we need to make some decisions on how to structure our source code. It is better to place all source code under <i>src</i> directory, so source code is not mixed with configuration files. 
-We will move <i>index.ts</i> there and make the necessary changes to the npm scripts. 
+First we need to make some decisions on how to structure our source code. It is better to place all source code under <i>src</i> directory, so source code is not mixed with configuration files.
+We will move <i>index.ts</i> there and make the necessary changes to the npm scripts.
 
 <!-- We'll decide to put all [routers](/en/part4/structure_of_backend_application_introduction_to_testing) that is the  -->
 <!-- modules that take care of handling a set of specific resources such as <i>diaries</i> under the directory <i>src/routes</i>. This differs a bit from the convention of [part 4](/en/part4), where we used directory <i>src/controllers</i>. -->
-We will place all [routers](/en/part4/structure_of_backend_application_introduction_to_testing), modules which are responsible for handling a set of specific resources such as <i>diaries</i>, under the directory <i>src/routes</i>. 
+We will place all [routers](/en/part4/structure_of_backend_application_introduction_to_testing), modules which are responsible for handling a set of specific resources such as <i>diaries</i>, under the directory <i>src/routes</i>.
 This is a bit different than what we did  in [part 4](/en/part4), where we used directory <i>src/controllers</i>.
 
 <!-- The routes taking care of diary endpoints in <i>src/routes/diaries.ts</i> looks like this: -->
@@ -379,7 +379,7 @@ app.get('/ping', (_req, res) => {
 
 app.use('/api/diaries', diaryRouter); // highlight-line
 
-  
+
 app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
 });
@@ -392,12 +392,12 @@ And now if we make a HTTP GET request to http://localhost:3000/api/diaries we sh
 Next wee need to start serving the seed data (found [here](https://github.com/fullstack-hy2020/misc/blob/master/diaryentries.json)) from the app. We will fetch the data and save it to <i>data/diaries.json</i>.
 
 <!-- We will not write the code that does the actual data manipulation to the router, but instead create a <i>service</i> that takes care of the data manipulation. It is quite a common pattern to separate the "business logic" from router code to own modules that are quite often called <i>services</i>. The name service originates from [Domain driven design](https://en.wikipedia.org/wiki/Domain-driven_design) and was made popular by the [Spring](https://spring.io/) framework. -->
-We won't be writing the code for the actual data manipulations on the router. We will create a <i>service</i> which takes care of the data manipulation instead. 
-It is quite common practice to separate the "business logic" from the router code into its own modules, which are quite often called <i>services</i>. 
+We won't be writing the code for the actual data manipulations on the router. We will create a <i>service</i> which takes care of the data manipulation instead.
+It is quite common practice to separate the "business logic" from the router code into its own modules, which are quite often called <i>services</i>.
 The name service originates from [Domain driven design](https://en.wikipedia.org/wiki/Domain-driven_design) and was made popular by the [Spring](https://spring.io/) framework.
 
 <!-- Let us create directory <i>src/services</i> and inside it the file <i>diaryService.ts</i> with two functions that are needed in fetching and saving the diaries: -->
-Let's create a <i>src/services</i> directory and 
+Let's create a <i>src/services</i> directory and
 place the <i>diaryService.ts</i> file in it.
 The file contains two functions for fetching and saving diary entries:
 
@@ -423,17 +423,17 @@ But something is not right
 
 ![](../../images/9/17c.png)
 
-The hint says we might want to use <i>resolveJsonModule</i>. Let's add it to our tsconfig:  
+The hint says we might want to use <i>resolveJsonModule</i>. Let's add it to our tsconfig:
 
 ```json
 {
   "compilerOptions": {
     "target": "ES6",
-    "outDir": "./build/", 
-    "module": "commonjs",  
+    "outDir": "./build/",
+    "module": "commonjs",
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,       
+    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
@@ -451,18 +451,18 @@ And our problem is solved.
 <!-- As before we've seen how the compiler can decide the type of a variable by the value it is being assigned to and in a similar way the compiler interprets larger data sets consisting of objects and arrays. This is why the compiler actually can warn us if we are trying to do something suspicious to the json data we are currently handling. If we're handling an array that includes specific types of objects and we're trying to add an object there that doesn't have all of the fields that the other objects have or is having type conflicts (for example a number where should be a string) the compiler can give us a warning.  -->
 Earlier we saw how the compiler can decide the type of a variable by the value it is assigned.
 Similarly the compiler can interpret large data sets consisting of objects and arrays.
-Due to this the compiler can actually warn us if we try to do something suspicious with the json data we are handling. 
-For example if we are handling an array containing objects of specific type, and we try to add an object which does not have all the fields the other objects have, or has type conflicts (for example a number where there should be a string), the compiler can give us a warning. 
+Due to this the compiler can actually warn us if we try to do something suspicious with the json data we are handling.
+For example if we are handling an array containing objects of specific type, and we try to add an object which does not have all the fields the other objects have, or has type conflicts (for example a number where there should be a string), the compiler can give us a warning.
 
 <!-- Even though the compiler is pretty intelligent in making sure to not to do anything unwanted, it is safer to create the correct types to the data yourself. -->
 Even though the compiler is pretty good at making sure we don't do anything unwanted, it is safer to define the types for the data ourselves.
 
 <!-- Now we have a basic working TypeScript express app but there's barely any actual <i>typings</i> in the code. Since we now have a clear definition on what type of data should be accepted for the weather and visibility fields, there is no reason for us not to include also those types in the code. -->
-Currently we have a basic working TypeScript express app, but there are barely any actual <i>typings</i> in the code. 
+Currently we have a basic working TypeScript express app, but there are barely any actual <i>typings</i> in the code.
 Since we know what type of data should be accepted for the weather and visibility fields, there is no reason for us not to include their types to the code.
 
 <!-- Let's create our type-exclusive file <i>types.ts</i> in which we'll put all our types for this project. -->
-Let's create a file for our types, <i>types.ts</i>, where we'll define all our types for this project. 
+Let's create a file for our types, <i>types.ts</i>, where we'll define all our types for this project.
 
 <!-- First let's type the allowed <i>Weather</i> and <i>Visibility</i> values through a [union type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#union-types) with allowed strings:  -->
 First, let's type the <i>Weather</i> and <i>Visibility</i> values using a [union type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#union-types) of the allowed strings:
@@ -483,10 +483,10 @@ export interface DiaryEntry {
   weather: Weather;
   visibility: Visibility;
   comment: string;
-} 
+}
 ```
 
-We can now try to type our imported json: 
+We can now try to type our imported json:
 
 ```js
 import diaryData from '../../data/diaries.json';
@@ -514,11 +514,11 @@ But since the json already has its values declared, assigning a type for the dat
 ![](../../images/9/19b.png)
 
 <!-- The end of the error message reveals the reason, the <i>weather</i> fields are incompatible. In <i>DiaryEntry</i> we specified that the type is <i>Weather</i> but TypeScript compiler inferred that the field in json has type <i>string</i>. -->
-The end of the error message reveals the problem: the <i>weather</i> fields are incompatible. In <i>DiaryEntry</i> we specified that its type is  <i>Weather</i>, but 
+The end of the error message reveals the problem: the <i>weather</i> fields are incompatible. In <i>DiaryEntry</i> we specified that its type is  <i>Weather</i>, but
 TypeScript compiler had inferred its type to be <i>string</i>.
 
 <!-- This can be surpassed if we are certain that we know what we are doing by [type assertion](http://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions). When we assert the type of the variable <i>diaryData</i> to be <i>DiaryData</i> with the keyword <i>as</i>, everything should work:  -->
-We can fix the problem by doing [type assertion](http://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions). This should be done only if we are certain we know what we are doing. 
+We can fix the problem by doing [type assertion](http://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions). This should be done only if we are certain we know what we are doing.
 If we assert the type of the variable <i>diaryData</i> to be <i>DiaryEntry</i> with the keyword <i>as</i>, everything should work:
 
 ```js
@@ -530,11 +530,11 @@ const diaries: Array<DiaryEntry> = diaryData as Array<DiaryEntry>; // highlight-
 
 const getEntries = (): Array<DiaryEntry> => {
   return diaries;
-} 
+}
 
 const addEntry = () => {
   return null
-} 
+}
 
 export default {
   getEntries,
@@ -544,10 +544,10 @@ export default {
 
 <!-- Type assertion should not be used unless there's no other way to proceed since there's always the danger of asserting an unfit type to an object and then perhaps causing a nasty runtime error. While the compiler trusts you to know when using <i>as</i>, at the same time it leaves the intelligence of the whole TypeScript to manual interpretation.  -->
 We should never use type assertion unless there is no other way to proceed, as there is always the danger we assert an unfit type to an object and cause a nasty runtime error.
-While the compiler trusts you to know what you are doing when using <i>as</i>, doing this we are not using the full power of TypeScript but relying on the coder to secure the code. 
+While the compiler trusts you to know what you are doing when using <i>as</i>, doing this we are not using the full power of TypeScript but relying on the coder to secure the code.
 
 <!-- In our case we could change our data exportation method so that we could have the typing happen naturally within the file where the data resides. Since typings can not be used in a JSON-file, we should convert the json-file to a ts-file which exports the typed  data in the following way:  -->
-In our case we could change how we export our data so we can type it within the data file. 
+In our case we could change how we export our data so we can type it within the data file.
 Since we cannot use typings in a JSON-file, we should convert the json-file to a ts-file which exports the typed data like so:
 
 ```js
@@ -578,11 +578,11 @@ import { DiaryEntry } from '../types';
 
 const getEntries = (): Array<DiaryEntry> => {
   return diaries;
-} 
+}
 
 const addEntry = () => {
   return null;
-} 
+}
 
 export default {
   getEntries,
@@ -600,50 +600,101 @@ export interface DiaryEntry {
   weather: Weather;
   visibility: Visibility;
   comment?: string;
-} 
+}
 ```
+
+### Node and JSON modules
+
+It is important to take note of a problem that may arise when using the tsconfig [resolveJsonModule](https://www.typescriptlang.org/en/tsconfig#resolveJsonModule) option:
+
+```json
+{
+  "compilerOptions": {
+    // ...
+    "resolveJsonModule": true // highlight-line
+  }
+}
+```
+
+According to the node documentation for [file modules](https://nodejs.org/api/modules.html#modules_file_modules),
+node will try to resolve modules in order of extensions:
+
+```sh
+ ["js", "json", "node"]
+```
+
+In addition to that, by default, <i>ts-node</i> and <i>ts-node-dev</i> extend the list of possible node module extensions to:
+
+```sh
+ ["js", "json", "node", "ts", "tsx"]
+```
+
+> **NB**: The validity of <i>.js</i>, <i>.json</i> and <i>.node</i> files as modules in Typescript depend on environment configuration, including <i>tsconfig</i> options such as <i>allowJs</i> and <i>resolveJsonModule</i>.
+
+Consider a flat folder structure containing files:
+
+```sh
+  ├── myModule.json
+  └── myModule.ts
+```
+
+In typescript, with the <i>resolveJsonModule</i> option set to true, the file <i>myModule.json</i> becomes a valid node module. Now, imagine a scenario where we wish to take the file <i>myModule.ts</i> into use:
+
+```js
+import myModule from "./myModule";
+```
+
+Looking closely at the order of node module extensions:
+
+```sh
+ ["js", "json", "node", "ts", "tsx"]
+```
+
+We notice that the <i>.json</i> file extension takes precedence over <i>.ts</i> and so <i>myModule.json</i> will be imported and not <i>myModule.ts</i>.
+
+In order to avoid time eating bugs, it is recommended that within a flat directory, each file with a valid node module extension has a unique filename.
 
 ### Utility Types
 
 <!-- Sometimes we end up in a situation where we want to use a specific modification of a type. For example consider using a general listing page for data that has some non-sensitive and some  sensitive data. In a common listing page we might want to be sure that no sensitive data is being used or shown so we might only <i>pick</i> the fields of a type we allow to be used in that situation. For that we use the utility type [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk). -->
-Sometimes we might want to use a specific modification of a type. 
+Sometimes we might want to use a specific modification of a type.
 For example, consider a page for listing some data, some of which is sensitive and some of which is non-sensitive.
-We might want to be sure that no sensitive data is used or displayed. We could <i>pick</i> the fields of a type we allow to be used to enforce this. 
+We might want to be sure that no sensitive data is used or displayed. We could <i>pick</i> the fields of a type we allow to be used to enforce this.
 We can do that by using the utility type [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk).
 
-In our project we should consider that Ilari might want to create a listing of all his diary entries <i>excluding</i> the comment field, since during a very scary flight he might end up writing something he wouldn't necessarily want to show anyone else. 
+In our project we should consider that Ilari might want to create a listing of all his diary entries <i>excluding</i> the comment field, since during a very scary flight he might end up writing something he wouldn't necessarily want to show anyone else.
 
 <!-- The [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk) utility type allows us to choose what fields of a type we want to use of an existing type. Pick can be used to construct a completely new type or just in time when informing a function what it should return. Utility types are special kinds of type tools, but they are used exactly as regular types. -->
-The [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk) utility type allows us to choose which fields of an existing type we want to use. 
-Pick can be used to either construct a completely new type, or to inform a function what it should return on runtime. 
+The [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk) utility type allows us to choose which fields of an existing type we want to use.
+Pick can be used to either construct a completely new type, or to inform a function what it should return on runtime.
 Utility types are a special kinds of type tools, but they can be used just like regular types.
 
 <!-- In our case, in order to create this kind of "narrowed" version of the <i>DiaryEntry</i> type we could just use the Pick in the function declaration: -->
 In our case, in order to create a "censored" version of the  <i>DiaryEntry</i> for public displays, we can use Pick in the function declaration:
 
 ```js
-const getNonSensitiveEntries = 
+const getNonSensitiveEntries =
   (): Array<Pick<DiaryEntry, 'id' | 'date' | 'weather' | 'visibility'>> => {
     // ...
   }
 ```
 
 <!-- and it would expect the function to return an array of the modification of DiaryEntry type which includes only the four declared fields.  -->
-and the compiler would expect the function to return an array of values of the modified DiaryEntry type, which include only the four selected fields. 
+and the compiler would expect the function to return an array of values of the modified DiaryEntry type, which include only the four selected fields.
 
 <!-- Since [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk) requires the type it modifies to be given as a [type variable](http://www.typescriptlang.org/docs/handbook/generics.html#working-with-generic-type-variables), similar as the Array, we have now two nested type variables and the syntax looks already a bit odd. We can improve the readability by using the [alternative](http://www.typescriptlang.org/docs/handbook/basic-types.html#array) syntax of arrays: -->
-Since [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk) requires the type it modifies to be given as a [type variable](http://www.typescriptlang.org/docs/handbook/generics.html#working-with-generic-type-variables), just like Array does, we now have two nested type variables and the syntax is starting to look a bit odd. 
+Since [Pick](http://www.typescriptlang.org/docs/handbook/utility-types.html#picktk) requires the type it modifies to be given as a [type variable](http://www.typescriptlang.org/docs/handbook/generics.html#working-with-generic-type-variables), just like Array does, we now have two nested type variables and the syntax is starting to look a bit odd.
 We can improve the code's readability by using the [alternative](http://www.typescriptlang.org/docs/handbook/basic-types.html#array) array syntax:
 
 ```js
-const getNonSensitiveEntries = 
+const getNonSensitiveEntries =
   (): Pick<DiaryEntry, 'id' | 'date' | 'weather' | 'visibility'>[] => {
     // ...
   }
 ```
 
 <!-- Even better in this case when we want to exclude only one field, would be to use the [Omit](http://www.typescriptlang.org/docs/handbook/utility-types.html#omittk) utility type, for which you can declare what fields to exclude: -->
-In this case we want to exclude only one field, 
+In this case we want to exclude only one field,
 so even better would be to use the [Omit](http://www.typescriptlang.org/docs/handbook/utility-types.html#omittk) utility type, which we can use to declare which fields to exclude:
 
 ```js
@@ -651,7 +702,7 @@ const getNonSensitiveEntries = (): Omit<DiaryEntry, 'comment'>[] => {
   // ...
 }
 ```
- Another way would be to declare a completely new type for the <i>NonSensitiveDiaryEntry</i>: 
+ Another way would be to declare a completely new type for the <i>NonSensitiveDiaryEntry</i>:
 
 ```js
 export type NonSensitiveDiaryEntry = Omit<DiaryEntry, 'comment'>;
@@ -689,7 +740,7 @@ One thing in our application is a cause for concern. In the <i>getNonSensitiveEn
 This happens because [TypeScript only checks](http://www.typescriptlang.org/docs/handbook/type-compatibility.html) whether we have all of the required fields or not, but excess fields are not prohibited. In our case this means that is is <i>not prohibited</i> to return an object of type <i>DiaryEntry[]</i>, but if we were to try to access the <i>comment</i> field, it would not be possible because we would be accessing a field that TypeScript is unaware of even though it exists.
 
 <!-- Unfortunately this can lead to unwanted behaviour if you are not aware of what you are doing; this situation is valid in terms of TypeScript but is most likely allowing use that is not wanted. If we now return all of the diaryEntries from the function <i>getNonSensitiveEntries</i> as they are to <i>frontend</i>, we are actually leaking the unwanted fields for the requesting browser even though our types seem to imply otherwise! -->
-Unfortunately this can lead to unwanted behaviour if you are not aware of what you are doing; the situation is valid as long as TypeScript is concerned, but you are most likely allowing use that is not wanted. 
+Unfortunately this can lead to unwanted behaviour if you are not aware of what you are doing; the situation is valid as long as TypeScript is concerned, but you are most likely allowing use that is not wanted.
 If we were now to return all of the diaryEntries from the <i>getNonSensitiveEntries</i> function to the <i>frontend</i>, we would actually be leaking the unwanted fields to the requesting browser even thought our types seem to imply otherwise!
 
 <!-- Because TypeScript doesn't modify the actual data but only types it, we need to implement the exclusion of the fields: -->
@@ -702,7 +753,7 @@ import { NonSensitiveDiaryEntry, DiaryEntry } from '../types'
 
 const getEntries = () : DiaryEntry[] => {
   return diaries
-} 
+}
 
 // highlight-start
 const getNonSensitiveEntries = (): NonSensitiveDiaryEntry [] => {
@@ -717,7 +768,7 @@ const getNonSensitiveEntries = (): NonSensitiveDiaryEntry [] => {
 
 const addDiary = () => {
   return []
-} 
+}
 
 export default {
   getEntries,
@@ -726,7 +777,7 @@ export default {
 }
 ```
 
-If we now would try to return this data with the basic <i>DiaryEntry</i> type, i.e. if we would type the function as follows 
+If we now would try to return this data with the basic <i>DiaryEntry</i> type, i.e. if we would type the function as follows
 
 
 ```js
@@ -832,12 +883,12 @@ But once again, a new problem emerges:
 ![](../../images/9/23e.png)
 
 <!-- The issue now is, that there is no guarantee that an entry with the specific id can be found. It is good that this potentially problematic issue surfaces already at compile phase, since without TypeScript there would be no indication of this possibility and in the worst case you might end up returning a result of an <i>undefined</i> object instead of informing about the nonexistense of searched item by other means. -->
-The issue is, that there is no guarantee that an entry with the specified id can be found. 
-It is good that we are made aware of this potential problem already at compile phase. Without TypeScript we would not be warned about this problem, and in the worst case scenario we could have ended up returning an <i>undefined</i> object instead of informing the user about the specified entry not being found. 
+The issue is, that there is no guarantee that an entry with the specified id can be found.
+It is good that we are made aware of this potential problem already at compile phase. Without TypeScript we would not be warned about this problem, and in the worst case scenario we could have ended up returning an <i>undefined</i> object instead of informing the user about the specified entry not being found.
 
 <!-- In cases like this we first of all need to decide <i>what is the desired return value</i> if an object is not found, and how to handle the case. The value <i>undefined</i> that is returned by <i>find</i> method of an array is actually fine for us if a result is not found. Thus we could solve our problem by typing the return value as follows -->
-First of all in cases like this we need to decide what the <i>return value</i> should be if an object is not found, and how the case should be handled. 
-The <i>find</i> method of an array returns <i>undefined</i> if the object is not found, and this is actually fine with us. 
+First of all in cases like this we need to decide what the <i>return value</i> should be if an object is not found, and how the case should be handled.
+The <i>find</i> method of an array returns <i>undefined</i> if the object is not found, and this is actually fine with us.
 We can solve our problem by typing the return value as follows
 
 ```js
@@ -901,7 +952,7 @@ import {
 const addEntry = (
     date: string, weather: Weather, visibility: Visibility, comment: string
   ): DiaryEntry => {
-    
+
   const newDiaryEntry = {
     id: Math.max(...diaries.map(d => d.id)) + 1,
     date,
@@ -909,14 +960,14 @@ const addEntry = (
     visibility,
     comment,
   }
-  
+
   diaries.push(newDiaryEntry);
   return newDiaryEntry;
 }
 ```
 
 <!-- As we can see the <i>addDiary</i> function is growing to be pretty hard to read, when having all the fields as separate parameters. It might be better to just send the data as an object to the function: -->
-As you can see, the <i>addDiary</i> function is becoming quite hard to read now that we have all the fields as separate parameters. 
+As you can see, the <i>addDiary</i> function is becoming quite hard to read now that we have all the fields as separate parameters.
 It might be better to just send the data as an object to the function:
 
 ```js
@@ -934,7 +985,7 @@ router.post('/', (req, res) => {
 
 <!-- But wait, what is the type of this object? It is not exactly a <i>DiaryEntry</i>, since it is still missing the <i>id</i> field. It could be useful for us just to create a new type <i>NewDiaryEntry</i> which could work as a type for the not yet saved diary. Let us create that in <i>types.ts</i> using the existing <i>DiaryEntry</i> object with the [Omit](http://www.typescriptlang.org/docs/handbook/utility-types.html#omittk) utility type: -->
 But wait, what is the type of this object? It is not exactly a <i>DiaryEntry</i>, since it is still missing the <i>id</i> field.
-It could be useful to create a new type, <i>NewDiaryEntry</i>, for a not yet saved entry. 
+It could be useful to create a new type, <i>NewDiaryEntry</i>, for a not yet saved entry.
 Let's create that in <i>types.ts</i> using the existing <i>DiaryEntry</i> type and the [Omit](http://www.typescriptlang.org/docs/handbook/utility-types.html#omittk) utility type:
 
 ```js
@@ -942,7 +993,7 @@ export type NewDiaryEntry = Omit<DiaryEntry, 'id'>;
 ```
 
 <!-- And now we can use this type in our DiaryService and we can just destructure the whole new entry object when creating the entry to be saved:  -->
-Now we can use the new type in our DiaryService, 
+Now we can use the new type in our DiaryService,
 and destructure the new entry object when creating an entry to be saved:
 
 ```js
@@ -961,14 +1012,14 @@ const addDiary = ( entry: NewDiaryEntry ): DiaryEntry => {  // highlight-line
 };
 ```
 
-Now the code looks much cleaner! 
+Now the code looks much cleaner!
 
-In order to parse the incoming data we must have the  <i>json</i> middleware configured: 
+In order to parse the incoming data we must have the  <i>json</i> middleware configured:
 
- 
+
 ``` js
 import express from 'express';
-import diaryRouter from './routes/diaries'; 
+import diaryRouter from './routes/diaries';
 const app = express();
 app.use(express.json()); // highlight-line
 
@@ -999,14 +1050,14 @@ In our case this is not apparent in the editor at all, but if we start looking a
 
 <!-- The value of type [any](http://www.typescriptlang.org/docs/handbook/basic-types.html#an) can be assigned to <i>any</i> type of variable since it <i>might be</i> the wanted type. This is definitely not safe to trust, so  -->
 <!-- check the incoming values (regardless whether we are using TypeScript or not). -->
-The value of type [any](http://www.typescriptlang.org/docs/handbook/basic-types.html#an) can be assigned to <i>any</i> type of variable since it <i>might be</i> the wanted type. It's definitely not safe to trust this, so 
+The value of type [any](http://www.typescriptlang.org/docs/handbook/basic-types.html#an) can be assigned to <i>any</i> type of variable since it <i>might be</i> the wanted type. It's definitely not safe to trust this, so
 always check the incoming values (regardless of whether we are using TypeScript or not).
 
 <!-- We could just add simple <i>exists</i> and <i>is-value-valid</i> checks to the function defining the route, but since we also need to ensure that <i>Weather</i> and <i>Visibility</i> values are of the correct form, it is better to write the parsing and validation logic to a separate file <i>utils.ts</i>. -->
 We could just add simple <i>exists</i> and <i>is-value-valid</i> checks to the function defining the route, it is better to write the parsing and validation logic to a separate file <i>utils.ts</i>.
 
 <!-- Our intention is to define a function <i>toNewDiaryEntry</i> that gets the request body as a parameter and returns a properly typed <i>NewDiaryEntry</i>. Route definition uses the function as follows -->
-We need to define a function <i>toNewDiaryEntry</i> that receives the request body as a parameter and returns a properly typed <i>NewDiaryEntry</i> object. 
+We need to define a function <i>toNewDiaryEntry</i> that receives the request body as a parameter and returns a properly typed <i>NewDiaryEntry</i> object.
 The route definition uses the function as follows
 
 ```js
@@ -1017,11 +1068,11 @@ import toNewDiaryEntry from '../utils'; // highlight-line
 router.post('/', (req, res) => {
   try {
     const newDiaryEntry = toNewDiaryEntry(req.body); // highlight-line
-      
+
     const addedEntry = diaryService.addDiary(newDiaryEntry); // highlight-line
     res.json(addedEntry);
   } catch (e) {
-    res.status(400).send(e.message); 
+    res.status(400).send(e.message);
   }
 })
 ```
@@ -1038,9 +1089,9 @@ const toNewDiaryEntry = (object): NewDiaryEntry => {
   const newEntry: NewDiaryEntry = {
     // ...
   }
-  
+
   return newEntry;
-} 
+}
 
 export default toNewDiaryEntry;
 ```
@@ -1049,7 +1100,7 @@ export default toNewDiaryEntry;
 The function should parse each field and make sure that the return value is exactly of type <i>NewDiaryEntry</i>. This means we should check each field separately.
 
 <!-- Once again we have a typing issue: what is the <i>object</i> type? Since the <i>object</i> is in fact the body of a request, Express has typed it with <i>any</i>. Since within this function the whole idea is to map unknown types of fields to correct ones and check whether they are defined as expected, this might be the rare case where we actually <i>want to allow the <i>any</i> type</i>.  -->
-Once again we have a type issue: what is the <i>object</i> type? Since the <i>object</i> is in fact the body of a request, Express has typed it as <i>any</i>. 
+Once again we have a type issue: what is the <i>object</i> type? Since the <i>object</i> is in fact the body of a request, Express has typed it as <i>any</i>.
 Since the idea of this function is to map fields of unknown type to fields of the correct type and check whether they are defined as expected, this might be the rare case where we actually <i>want to allow the <i>any</i> type</i>.
 
 However if we type the object as <i>any</i>, eslint gives us a complaint:
@@ -1057,14 +1108,14 @@ However if we type the object as <i>any</i>, eslint gives us a complaint:
 ![](../../images/9/24e.png)
 
 <!-- The cause for the complaint is the eslint-rule [no-explicit-any](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md) that prevents us from explicitly setting type to be <i>any</i>. Since this is in general a good rule to follow but just in this particular file undesired, it is better to allow using <i>any</i> now by disabling the eslint-rule in the file. This happens by adding the following line at the file: -->
-This is due to the eslint-rule  [no-explicit-any](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md) which prevents us from explicitly setting type to be <i>any</i>. 
+This is due to the eslint-rule  [no-explicit-any](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md) which prevents us from explicitly setting type to be <i>any</i>.
 In general this is a good rule, and undesired just in this particular file. We can allow using <i>any</i> in this file by disabling the eslint-rule in the file. This happens by adding the following line to the file:
 
 ```js
 /* eslint-disable @typescript-eslint/no-explicit-any */
 ```
 
-Let us start creating the parsers for each of the fields of <i>object</i>. 
+Let us start creating the parsers for each of the fields of <i>object</i>.
 
 
 To validate the <i>comment</i> field we need to check that it exists, and to ensure that it is of the type <i>string</i>.
@@ -1101,7 +1152,7 @@ text is string
 
 The general form of a type predicate is _parameterName is Type_ where the _parameterName_ is the name of the function parameter and _Type_ is the targeted type.
 
-If the type guard function returns true, the TypeScript compiler knows that the tested variable has the type that was defined in the type predicate. 
+If the type guard function returns true, the TypeScript compiler knows that the tested variable has the type that was defined in the type predicate.
 
 Before the type guard is called, the actual type of the variable <i>comment</i> is not known:
 
@@ -1128,8 +1179,8 @@ const isString = (text: any): text is string => {
 ```
 
 <!-- The simpler form is most likely good for all practical purposes. However if we want to be absolutely sure, both the conditions are needed, since there are two different means to create string objects in JavaScript and both of these work a bit differently with respect to operators <i>typeof</i> and <i>instanceof</i>: -->
-Most likely the simpler form is good enough for all practical purposes. 
-However, if we want to be absolutely sure, both conditions are needed. 
+Most likely the simpler form is good enough for all practical purposes.
+However, if we want to be absolutely sure, both conditions are needed.
 There are two different ways to create string objects in JavaScript which both work a bit differently with respect to the <i>typeof</i> and <i>instanceof</i> operators:
 
 ```js
@@ -1143,11 +1194,11 @@ b instanceof String; --> returns true
 
 <!-- It is however unlikely that anybody creates strings with a constructor function, so most likely the simpler version of the type guard would be just fine.  -->
 However, it is unlikely that anyone would create a string with a constructor function.
-Most likely the simpler version of the type guard would be just fine. 
+Most likely the simpler version of the type guard would be just fine.
 
 <!-- Next let us consider the field <i>date</i>. Parsing and validating the date object is pretty similar, since TypeScript doesn't really know a type for date, we need to treat it as <i>string</i>. We still definitely should use JavaScript level validation to check whether the date format is acceptable.  -->
-Next, let's consider the <i>date</i> field. 
-Parsing and validating the date object is pretty similar to what we did with comments. 
+Next, let's consider the <i>date</i> field.
+Parsing and validating the date object is pretty similar to what we did with comments.
 Since TypeScript doesn't really know a type for a date, we need to treat is as a <i>string</i>.
 We should however still use JavaScript level validation to check whether the date format is acceptable.
 
@@ -1178,7 +1229,7 @@ We would like the validation and parsing to work as follows:
 const parseWeather = (weather: any): Weather => {
   if (!weather || !isString(weather) || !isWeather(weather)) {
       throw new Error('Incorrect or missing weather: ' + weather)
-  } 
+  }
   return weather;
 };
 ```
@@ -1194,20 +1245,20 @@ const isWeather = (str: any): str is Weather => {
 ```
 
 <!-- This would work just fine but the problem is that list of possible weathers does not necessarily stay in sync with the type definition if that is altered. This is most certainly not a nice thing since we would like to have just a single source for all possible weather types. -->
-This would work just fine, but the problem is that the list of possible weathers does not necessarily stay in sync with the type definitions if the type is altered. 
+This would work just fine, but the problem is that the list of possible weathers does not necessarily stay in sync with the type definitions if the type is altered.
 This is most certainly not good, since we would like to have just one source for all possible weather types.
 
 <!-- A better solution in this case is to improve the actual Weather type and instead of type alias use the TypeScript [enum](https://www.typescriptlang.org/docs/handbook/enums.html) which allows us to use the actual values in the running code, not only in the compilation phase. -->
 In our case a better solution would be to improve the actual Weather type. Instead of a type alias we should use the TypeScript [enum](https://www.typescriptlang.org/docs/handbook/enums.html), which allows us to use the actual values in our code in runtime, not only in the compilation phase.
 
-Let us redefine the type <i>Weather</i> as follows: 
+Let us redefine the type <i>Weather</i> as follows:
 
 ```js
 export enum Weather {
   Sunny = 'sunny',
   Rainy = 'rainy',
   Cloudy = 'cloudy',
-  Stormy = 'stormy', 
+  Stormy = 'stormy',
   Windy = 'windy',
 }
 ```
@@ -1222,7 +1273,7 @@ const isWeather = (param: any): param is Weather => {
 ```
 
 <!-- One thing to notice here is that we have changed the parameter type to <i>any</i>, if it would be string, the <i>includes</i> check would not compile. The change makes sense also if you think about the reusability of the function, by allowing <i>any</i> as a parameter, we can use the function with confidence knowing that whatever we might feed to it, the function answers always to the question of whether the variable is a valid weather or not.  -->
-One thing to notice here is that we have changed the parameter type to <i>any</i>. If it would be string, the <i>includes</i> check would not compile. This makes sense also if you consider the reusability of the function. Allowing <i>any</i> as a parameter, the function can be used with confidence knowing that whatever we might feed to it, the function always tells us whether the variable is a valid weather or not. 
+One thing to notice here is that we have changed the parameter type to <i>any</i>. If it would be string, the <i>includes</i> check would not compile. This makes sense also if you consider the reusability of the function. Allowing <i>any</i> as a parameter, the function can be used with confidence knowing that whatever we might feed to it, the function always tells us whether the variable is a valid weather or not.
 
 The function <i>parseWeather</i> can be simplified a bit
 
@@ -1230,7 +1281,7 @@ The function <i>parseWeather</i> can be simplified a bit
 const parseWeather = (weather: any): Weather => {
   if (!weather || !isWeather(weather)) { // highlight-line
       throw new Error('Incorrect or missing weather: ' + weather);
-  } 
+  }
   return weather;
 };
 ```
@@ -1283,7 +1334,7 @@ export enum Visibility {
   Great = 'great',
   Good = 'good',
   Ok = 'ok',
-  Poor = 'poor', 
+  Poor = 'poor',
 }
 ```
 
@@ -1297,12 +1348,12 @@ const isVisibility = (param: any): param is Visibility => {
 const parseVisibility = (visibility: any): Visibility => {
   if (!visibility || !isVisibility(visibility)) {
       throw new Error('Incorrect or missing visibility: ' + visibility);
-  } 
+  }
   return visibility;
 };
 ```
 
-And finally we can finalize the  <i>toNewDiaryEntry</i> function that takes care of validating and parsing the fields of the post data: 
+And finally we can finalize the  <i>toNewDiaryEntry</i> function that takes care of validating and parsing the fields of the post data:
 
 ```js
 const toNewDiaryEntry = (object: any): NewDiaryEntry => {
@@ -1315,7 +1366,7 @@ const toNewDiaryEntry = (object: any): NewDiaryEntry => {
 };
 ```
 
-The first version of our flight diary application is now completed! 
+The first version of our flight diary application is now completed!
 
 If we now try to create a new diary entry with invalid or missing fields we are getting an appropriate error message
 
@@ -1333,7 +1384,7 @@ Create a POST-endpoint <i>/api/patients</i> for adding patients. Ensure that you
 
 #### 9.13: Patientor backend, step6
 
-Set up safe parsing, validation and type guards to the POST <i>/api/patients</i> request. 
+Set up safe parsing, validation and type guards to the POST <i>/api/patients</i> request.
 
 Refactor the <i>Gender</i> field to use an [enum](http://www.typescriptlang.org/docs/handbook/enums.html) type.
 


### PR DESCRIPTION
While doing [exercise 9.16](https://fullstackopen.com/en/part9/react_with_types#exercises-9-16-9-17) I ran into a problem extending a typescript interface with a new property.

I had a flat directory "data" with contents:

  ├── patients.json
  └── patients.ts

and tried to import the _patients.ts_ file but I hadn't noticed earlier that because I set _resolveJsonModule_ to true in _tsconfig.json_, _patients.json_ would now be included in node module resolution.

So while trying to:

`import patients from "./data/patients"`

Typescript kept compiling the _patients.json_ file instead of  _patients.ts_ so my new object with supposed new properties was using stale data from the _.json_ file and with type assertions it was difficult to track down the exact problem.

I made an edit to the English version of part9c that includes a warning about this behavior.
