### PR TITLE
fixed the odds of Math.random() to be fair

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -234,7 +234,7 @@ const addNote = (event) => {
   const noteObject = {
     content: newNote,
     date: new Date().toISOString(),
-    important: Math.random() > 0.5,
+    important: Math.random() < 0.5,
     id: notes.length + 1,
   }
 


### PR DESCRIPTION
According to the answers in the StackOverflow post here https://stackoverflow.com/questions/44651537/correct-function-using-math-random-to-get-50-50-chance the fair chance is when you check Math.random() < 0.5, not greater than, since Math.random() never returns a value greater than 0.99999.