### PR TITLE
Translate Finnish comment in English source code

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -62,7 +62,7 @@ Extracting logging into its own module is a good idea in more ways than one. If 
 The contents of the <i>index.js</i> file used for starting the application gets simplified as follows:
 
 ```js
-const app = require('./app') // varsinainen Express-sovellus
+const app = require('./app') // the actual Express application
 const http = require('http')
 const config = require('./utils/config')
 const logger = require('./utils/logger')


### PR DESCRIPTION
Replaced Finnish language comment (// varsinainen Express-sovellus) in the English language documentation to reduce confusion.