### PR TITLE
Cypress test description truncated

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -101,7 +101,7 @@ npm run cypress:open
 When we first run Cypress, it creates a <i>cypress</i> directory. It contains a <i>integrations</i> subdirectory, where we will place our tests. Cypress creates a bunch of example tests for us, but we will delete all those and make our own test in file <i>note\_app.speck.js</i>:
 
 ```js
-describe('Note ', function() {
+describe('Note app', function() {
   it('front page can be opened', function() {
     cy.visit('http://localhost:3000')
     cy.contains('Notes')


### PR DESCRIPTION
The text in the Cypress 'describe' statement was changed from 'Note ' to 'Note app' for consistency with the rest of the examples later in the file.