### PR TITLE
Add missing space between note and important

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -1150,7 +1150,7 @@ const Note = ({ note, handleClick }) => {
   return(
     <li onClick={handleClick}>
       {note.content} 
-      <strong>{note.important ? 'important' : ''}</strong>
+      <strong> {note.important ? 'important' : ''}</strong>
     </li>
   )
 }

--- a/src/content/6/fi/osa6a.md
+++ b/src/content/6/fi/osa6a.md
@@ -1041,7 +1041,7 @@ const Note = ({ note, handleClick }) => {
   return(
     <li onClick={handleClick}>
       {note.content} 
-      <strong>{note.important ? 'important' : ''}</strong>
+      <strong> {note.important ? 'important' : ''}</strong>
     </li>
   )
 }


### PR DESCRIPTION
Where `{note.content}` and `<strong>` are on separate lines, an additional space is needed after the opening `<strong>` tag to ensure the note content is separated from the important indicator. The rest of the code examples in this file are already correct and did not require the same fix.