### PR TITLE
Part 7c 'LINK' button text instead of 'login' 

### DIFF
--- a/src/content/7/en/part7c.md
+++ b/src/content/7/en/part7c.md
@@ -481,7 +481,7 @@ The code for the navigation bar is the following
     {user
       ? <em>{user} logged in</em>
       : <Button color="inherit" component={Link} to="/login">
-          LINK
+          login
         </Button>
     }                              
   </Toolbar>

--- a/src/content/7/fi/osa7c.md
+++ b/src/content/7/fi/osa7c.md
@@ -454,7 +454,7 @@ Navigaatiopalkin koodi kokonaisuudessaan on seuraava
     {user
       ? <em>{user} logged in</em>
       : <Button color="inherit" component={Link} to="/login">
-          LINK
+          login
         </Button>
     }                              
   </Toolbar>


### PR DESCRIPTION
Fix source code containing Angular Material Button labeled 'LINK' instead of 'login'.