### PR TITLE
Incorrect WebPack example image link

### DIFF
--- a/src/content/7/en/part7d.md
+++ b/src/content/7/en/part7d.md
@@ -173,7 +173,7 @@ App()
 
 When we bundle the application again with the _npm run build_ command, we notice that webpack has acknowledged both files:
 
-![](../../images/7/2ea.png)
+![](../../images/7/20ea.png)
 
 Our application code can be found at the end of the bundle file in a rather obscure format:
 


### PR DESCRIPTION
In Part 7d (English), the wrong image is being used to demonstrate the WebPack output after adding 'App.js' references. The image link is currently [2ea.png](https://raw.githubusercontent.com/fullstack-hy2020/fullstack-hy2020.github.io/source/src/content/images/7/2ea.png) but should instead be [20ea.png](https://raw.githubusercontent.com/fullstack-hy2020/fullstack-hy2020.github.io/source/src/content/images/7/20ea.png).

The image link in the Finnish document is already using the correct `20ea.png` image.