### PR TITLE
remove error.kind check from middleware

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -762,7 +762,7 @@ Express [error handlers](https://expressjs.com/en/guide/error-handling.html) are
 const errorHandler = (error, request, response, next) => {
   console.error(error.message)
 
-  if (error.name === 'CastError' && error.kind === 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({ error: 'malformatted id' })
   } 
 


### PR DESCRIPTION
When I have a malformatted id, mongoDB throws the following error:

```
MongooseError [CastError]: Cast to ObjectId failed for value "5e9397eb2c3c8217fdda7dda11" at path "_id" for model "Person"
    at new CastError (/home/peter/repos/phone-backend/node_modules/mongoose/lib/error/cast.js:29:11)

// trace...

{
  message: 'Cast to ObjectId failed for value "5e9397eb2c3c8217fdda7dda11" at path "_id" for model "Person"',
  name: 'CastError',
  messageFormat: undefined,
  stringValue: '"5e9397eb2c3c8217fdda7dda11"',
  kind: undefined,
  value: '5e9397eb2c3c8217fdda7dda11',
  path: '_id',
  reason: Error: Argument passed in must be a single String of 12 bytes or a string of 24 hex characters
      at new ObjectID (/home/peter/repos/phone-backend/node_modules/bson/lib/bson/objectid.js:59:11)

// trace...
}

```
Maybe the error has changed, but it doesn't have a defined kind. The check for `error.name === 'CastError' && error.kind === 'ObjectId'` fails because it doesn't have a kind. 