### PR TITLE
part1a: visually fix the link in the footer

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -318,8 +318,7 @@ Also keep in mind that **React component names must be capitalized**. If you try
 const footer = () => {
   return (
     <div>
-      greeting app created by 
-      <a href="https://github.com/mluukkai">mluukkai</a>
+      greeting app created by <a href="https://github.com/mluukkai">mluukkai</a>
     </div>
   )
 }


### PR DESCRIPTION
The "greeting app created by" link is on a new line in the source code, which results in no whitespace rendering between "by" and "mluukkai". I'm sure there's a way to force a whitespace (perhaps using nbsp?) but I'm a react noob and I just noticed that if I bring the link to the same line as the text, the whitespace is rendered.

![image](https://user-images.githubusercontent.com/952340/79083907-00ca8b00-7cff-11ea-9acd-3e40981f5cf4.png)

vs

![image](https://user-images.githubusercontent.com/952340/79083922-0aec8980-7cff-11ea-9c0a-dac972cdfb0c.png)
