### PR TITLE
remove error.kind from error checking

### DIFF
--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -83,7 +83,7 @@ Let's expand the error handler to deal with these validation errors:
 const errorHandler = (error, request, response, next) => {
   console.error(error.message)
 
-  if (error.name === 'CastError' && error.kind == 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({ error: 'malformatted id' })
   } else if (error.name === 'ValidationError') { // highlight-line
     return response.status(400).json({ error: error.message }) // highlight-line

--- a/src/content/3/fi/osa3c.md
+++ b/src/content/3/fi/osa3c.md
@@ -760,7 +760,7 @@ Expressin [virheidenkäsittelijät](https://expressjs.com/en/guide/error-handlin
 const errorHandler = (error, request, response, next) => {
   console.error(error.message)
 
-  if (error.name === 'CastError' && error.kind == 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({ error: 'malformatted id' })
   }
 

--- a/src/content/3/fi/osa3d.md
+++ b/src/content/3/fi/osa3d.md
@@ -75,7 +75,7 @@ Laajennetaan virheenkäsittelijää huomioimaan validointivirheet:
 const errorHandler = (error, request, response, next) => {
   console.error(error.message)
 
-  if (error.name === 'CastError' && error.kind == 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({ error: 'malformatted id' })
   } else if (error.name === 'ValidationError') { // highlight-line
     return response.status(400).json({ error: error.message }) // highlight-line

--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -269,7 +269,7 @@ const unknownEndpoint = (request, response) => {
 const errorHandler = (error, request, response, next) => {
   logger.error(error.message)
 
-  if (error.name === 'CastError' && error.kind === 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({ error: 'malformatted id' })
   } else if (error.name === 'ValidationError') {
     return response.status(400).json({ error: error.message })

--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -239,7 +239,7 @@ const unknownEndpoint = (request, response) => {
 }
 
 const errorHandler = (error, request, response, next) => {
-  if (error.name === 'CastError' && error.kind === 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({
       error: 'malformatted id'
     })

--- a/src/content/4/fi/osa4a.md
+++ b/src/content/4/fi/osa4a.md
@@ -259,7 +259,7 @@ const unknownEndpoint = (request, response) => {
 const errorHandler = (error, request, response, next) => {
   logger.error(error.message)
 
-  if (error.name === 'CastError' && error.kind === 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({ error: 'malformatted id' })
   } else if (error.name === 'ValidationError') {
     return response.status(400).json({ error: error.message })

--- a/src/content/4/fi/osa4d.md
+++ b/src/content/4/fi/osa4d.md
@@ -231,7 +231,7 @@ const unknownEndpoint = (request, response) => {
 }
 
 const errorHandler = (error, request, response, next) => {
-  if (error.name === 'CastError' && error.kind === 'ObjectId') {
+  if (error.name === 'CastError') {
     return response.status(400).send({
       error: 'malformatted id'
     })


### PR DESCRIPTION
I have remove the `error.kind` check because it seems that mongoose now returns an error that doesn't have a `kind` defined. 

See this issue: #246, and this other PR I made: #270