### PR TITLE
Fix lexical declarations in case

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -491,7 +491,7 @@ const noteReducer = (state = [], action) => {
   switch(action.type) {
     case 'NEW_NOTE':
       return state.concat(action.data)
-    case 'TOGGLE_IMPORTANCE':
+    case 'TOGGLE_IMPORTANCE': {
       const id = action.data.id
       const noteToChange = state.find(n => n.id === id)
       const changedNote = { 
@@ -501,6 +501,7 @@ const noteReducer = (state = [], action) => {
       return state.map(note =>
         note.id !== id ? note : changedNote 
       )
+     }
     default:
       return state
   }


### PR DESCRIPTION
There is const declarations in case-clause. It raises https://eslint.org/docs/rules/no-case-declarations error.
Fix with adding braces to the case.