### PR TITLE
Update .eslintrc config in part9d

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -53,7 +53,8 @@ We configure eslint in <i>.eslintrc</i> with following settings:
 {
   "env": {
     "browser": true,
-    "es6": true
+    "es6": true,
+    "jest": true
   },
   "extends": [
     "eslint:recommended",
@@ -67,7 +68,9 @@ We configure eslint in <i>.eslintrc</i> with following settings:
       "version": "detect"
     }
   },
-  "rules": {}
+  "rules": {
+    "@typescript-eslint/explicit-function-return-type": 0
+  }
 }
 ```
 


### PR DESCRIPTION
Just after installing typescript cra app and below the `.eslintrc` configuration text states: 

```Since the return type of basically all React components is JSX.Element or null, we have loosened the default linting rules up a bit by disabling the explicit-function-return-type rule.```

But the `rules` object in the config above is empty and we do get the warnings from linter. I believe we have to add `"@typescript-eslint/explicit-function-return-type": 0` to disable the rule.

Additionally, linter gives even more errors than the two shown in [screenshot here](https://fullstackopen.com/static/3e180d086506e55a63ecfc823a6eb876/14be6/31a.png). One error is `no-undef` for `test` and `expect` in `App.test.tsx`. And to get rid of those we have to add `"jest": true` to `env`.

Another one is as well `no-undef` but this time it's `process` in `serviceWorker.ts` file. We could get rid of that by adding `"globals": {"process": true}` to `.eslintrc` but as text later suggests to remove this file I have not included this property to eslint config. Although to match the screenshot it would be needed.