### PR TITLE
Use fullname in newName variable

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -477,10 +477,10 @@ Issue a warning with the [alert](https://developer.mozilla.org/en-US/docs/Web/AP
 `${newName} is already added to phonebook`
 ```
 
-If the <em>newName</em> variable holds the value <i>arto</i>, the template string expression returns the string
+If the <em>newName</em> variable holds the value <i>Arto Hellas</i>, the template string expression returns the string
 
 ```js
-`arto is already added to phonebook`
+`Arto Hellas is already added to phonebook`
 ```
 
 The same could be done in a more Java-like fashion by using the plus operator:


### PR DESCRIPTION
We are not checking against first or last names, only full names. (Or should we?) Using the full name in the example prevents confusion.