### PR TITLE
Removed false sentence

### DIFF
--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -135,7 +135,7 @@ app.post('/api/notes', (request, response, next) => {
 ```
 
 
-In the first _then_ we receive _savedNote_ object returned by Mongoose and format it. The result of the operation is returned. Then as [we discussed earlier](/en/part2/altering_data_in_server#extracting-communication-with-the-backend-into-a-separate-module), the _then_ method of a promise also returns a promise. This means that when we return _savedNote.toJSON()_ from the callback function, we are actually creating a promise that receives the formatted note as its value. We can access the formatted note by registering a new callback function with the _then_ method.
+In the first _then_ we receive _savedNote_ object returned by Mongoose and format it. The result of the operation is returned. Then as [we discussed earlier](/en/part2/altering_data_in_server#extracting-communication-with-the-backend-into-a-separate-module), the _then_ method of a promise also returns a promise and we can access the formatted note by registering a new callback function with the _then_ method.
 
 We can clean up our code even more by using the more compact syntax for arrow functions:
 


### PR DESCRIPTION
I'm not professional JS dev, but based on my experience from other languages the statement below was incorrect. Removed sentence:
"This means that when we return _savedNote.toJSON()_ from the callback function, we are actually creating a promise that receives the formatted note as its value."

Rationale for removal: `return savedNote.toJSON()` in the callback doesn't create the promise. The promise is created by the wrapping `.then()` call.