### PR TITLE
Update part8d.md - update Apollo cache immutably

### DIFF
--- a/src/content/8/en/part8d.md
+++ b/src/content/8/en/part8d.md
@@ -246,10 +246,12 @@ const PersonForm = ({ setError }) => {
     // highlight-start
     update: (store, response) => {
       const dataInStore = store.readQuery({ query: ALL_PERSONS })
-      dataInStore.allPersons.push(response.data.addPerson)
       store.writeQuery({
         query: ALL_PERSONS,
-        data: dataInStore
+        data: {
+          ...dataInStore,
+          allPersons: [ ...dataInStore.allPersons, response.data.addPerson ]
+        }
       })
     }
     // highlight-end


### PR DESCRIPTION
From Apollo client v3, the cache is immutable by default [(see here)](https://www.apollographql.com/docs/react/v3.0-beta/migrating/apollo-client-3-migration/#breaking-cache-changes), so the example code for updating the cache ourselves does not work.

Instead use immutable data structures, like shown [here](https://www.apollographql.com/blog/whats-new-in-apollo-client-2-6-b3acf28ecad1).