### PR TITLE
Typo fixes in Exercises 5.17 and 5.18 sample codes

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -1163,7 +1163,7 @@ describe('Blog app', function() {
     cy.visit('http://localhost:3000')
   })
 
-  it('Login from is shown', function() {
+  it('Login form is shown', function() {
     // ...
   })
 })
@@ -1191,7 +1191,7 @@ describe('Blog app', function() {
     cy.visit('http://localhost:3000')
   })
 
-  it('Login from is shown', function() {
+  it('Login form is shown', function() {
     // ...
   })
 


### PR DESCRIPTION
I think 'Login _from_ is shown' should be 'Login _form_ is shown'.