### PR TITLE
Removes redundant .toJSON() call

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -426,7 +426,7 @@ Let's respond to the HTTP request with a list of objects formatted with the _toJ
 ```js
 app.get('/api/notes', (request, response) => {
   Note.find({}).then(notes => {
-    response.json(notes.map(note => note.toJSON()))
+    response.json(notes)
   })
 })
 ```


### PR DESCRIPTION
I am not sure, but the returned database object is void of _id & -__v fields without calling .toJSON().