### PR TITLE
part8b - useEffect

### DIFF
--- a/src/content/8/en/part8b.md
+++ b/src/content/8/en/part8b.md
@@ -302,7 +302,7 @@ const Persons = ({ persons }) => {
     if (result.data) {
       setPerson(result.data.findPerson)
     }
-  }, [result.data])
+  }, [result])
   // highlight-end
 
 // highlight-start
@@ -367,11 +367,11 @@ useEffect(() => {
   if (result.data) {
     setPerson(result.data.findPerson)
   }
-}, [result.data])
+}, [result])
 ```
 
 <!-- Hookin toisena parametrina on _result.data_, tämä saa aikaan sen, että hookin ensimmäisenä parametrina oleva funktio suoritetaan <i>aina kun kyselyssä haetaan uuden henkilön tiedot</i>. Jos päivitystä ei hoidettaisi kontrolloidusti hookissa, seuraisi ongelmia sen jälkeen kun yksittäisen henkilön näkymästä palataan kaikkien henkilöiden näkymään. -->
-The hook's second parameter is _result.data_, so function given to the hook as its second parameter is executed <i>every time the query fetches the details of a different person</i>. 
+The hook's second parameter is _result_, so function given to the hook as its second parameter is executed <i>every time the query fetches the details of a different person</i>. 
 Would we not handle the update in a controlled way in a hook, returning from a single person view to a list of all persons would cause problems. 
 
 


### PR DESCRIPTION
When using "result.data" as 2nd parameter, the functionality of the website is broken.
When clicking on the "show address" button 2 times in a row of the same person, the 2nd time the page is not going to be rerendered.
it seems, that "result.data" does not change during the 2nd call of the query, therefore the useEffect is not called.
After changing the 2nd parameter to "result" it is working as expected.