### PR TITLE
Part9b: The horrors of any -- italicized 'any'

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -824,7 +824,7 @@ Things become implicitly any type quite often when one forgets to type functions
 We can also explicitly type things <i>any</i>. The only difference between implicit and explicit any type is how the code looks, the compiler does not care about the difference. 
 
 <!-- However, implicit <i>any</i> and explicit enforcing of the <i>any</i> type onto a variable affects how a programmer sees the code. Implicit typings of <i>any</i> are usually considered problematic, since it  is quite often a matter of the coder simply forgotting to assign types (or being too lazy to do that) and because of that not exploiting the full power TypeScript in the code.  -->
-Programmers however see the code differently when any is explicitly enforced than when it implicitly inferred. 
+Programmers however see the code differently when <i>any</i> is explicitly enforced than when it implicitly inferred. 
 Implicit <i>any</i> typings are usually considered problematic, since it is quite often due to the coder forgetting to assign types (or being too lazy to do it), and it also means that the full power of TypeScript is not properly exploited. 
 
 <!-- This is why the rule [noImplicitAny](https://www.typescriptlang.org/v2/en/tsconfig#noImplicitAny) exists already on compiler level and it is highly recommended to keep it on at all time. In the rare cases where you seriously cannot know what the type of a variable is, you should explicitly state it in the code  -->


### PR DESCRIPTION
The *any* type keyword should be italicized for the sentence: "Programmers however see the code differently when any is explicitly enforced than when it implicitly inferred."