### PR TITLE
removed const http = require('http') from line 66

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -63,7 +63,6 @@ The contents of the <i>index.js</i> file used for starting the application gets 
 
 ```js
 const app = require('./app') // the actual Express application
-const http = require('http')
 const config = require('./utils/config')
 const logger = require('./utils/logger')
 


### PR DESCRIPTION
const http = require('http') is not required since we are already using express which will load this specific module for us on it's own. So the code was redundant. Thank you