### PR TITLE
Part9d Exercise 9.14: fixed broken link

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -245,7 +245,7 @@ To fix the error, we need to add a new linting rule to <i>.eslintrc</i>:
 
 Create a new Create React App with TypeScript, and set up eslint for the project similarly to how we just did.
 
-This exercise is similar to the one you have already done in [Part 1](/en/part1/javascript#exercises-1-3-1-5) of the course, but with TypeScript and some extra tweaks. Start off by modifying the contents of <i>index.tsx</i> to the following:
+This exercise is similar to the one you have already done in [Part 1](/en/part1/java_script#exercises-1-3-1-5) of the course, but with TypeScript and some extra tweaks. Start off by modifying the contents of <i>index.tsx</i> to the following:
 
 ```jsx
 import React from "react";


### PR DESCRIPTION
The link `/en/part1/javascript#exercises-1-3-1-5` lead to 404 Not Found page. The actual page was  `/en/part1/java_script#exercises-1-3-1-5`.
This fixes the broken link, but since the word *javascript* has no space, the wrong link seems to be more appropriate than the path of the actually existing one..