### PR TITLE
Update "no-console" part

### DIFF
--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -467,6 +467,7 @@ You can find the code for our current application in its entirety in the <i>part
 
 #### 3.22: Lint configuration
 
+//'no-console' is not part of 'eslint:recommended' rules.
 
 Add ESlint to your application and fix all the warnings.
 


### PR DESCRIPTION
    'no-console' is not part of 'eslint:recommended' rules.