### PR TITLE
Fix : Partial errors links

### DIFF
--- a/src/content/0/zh/part0b.md
+++ b/src/content/0/zh/part0b.md
@@ -599,7 +599,7 @@ Html 元素也可以有 class 以外的其他属性。 包含 Note 的 div 元�
 <!-- - ...and a JavaScript code file <i>main.js</i> -->
 - 以及 JavaScript 代码文件 main.js
 <!-- - The browser executes the JavaScript code. The code makes an HTTP GET request to the address https://fullstack-exampleapp.herokuapp.com/data.json, which returns the notes as JSON data. -->
-- 浏览器执行 JavaScript 代码，代码向地址https://fullstack-exampleapp.herokuapp.com/data.json发出 HTTP GET 请求，请求返回了包含 note 的 JSON 数据。
+- 浏览器执行 JavaScript 代码，代码向地址https://fullstack-exampleapp.herokuapp.com/data.json 发出 HTTP GET 请求，请求返回了包含 note 的 JSON 数据。
 <!-- - When the data has been fetched, the browser executes an <i>event handler</i>, which renders the notes to the page using the DOM-API. -->
 - 获取数据后，浏览器执行一个*event handler 事件处理程序*, 使用 DOM-API 将 Note 渲染到页面
 
@@ -713,7 +713,7 @@ Notes 页面使用了 AJAX 获取 Notes 数据。 提交表单仍然使用传统
 <!-- The application URLs reflect the old, carefree times. JSON data is fetched from the url <https://fullstack-exampleapp.herokuapp.com/data.json> and new notes are sent to the url <https://fullstack-exampleapp.herokuapp.com/new_note>.   -->
 <!-- Nowadays urls like these would not be considered acceptable, as they don't follow the generally acknowledged conventions of [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer#Applied_to_Web_services) APIs, which we'll look into more in [第3章](/zh/part3) -->
 
-应用的 url 反映了过去无忧无虑的时光。 数据从 url https://fullstack-exampleapp.herokuapp.com/data.JSON 中获取，新的 Note 被发送到 url https://fullstack-exampleapp.herokuapp.com/new_note。 如今，这样的 url 被认为是不可接受的，因为它们没有遵循公认的 RESTful api 约定，我们将在第三章中进一步研究
+应用的 url 反映了过去无忧无虑的时光。 数据从 url https://fullstack-exampleapp.herokuapp.com/data.JSON 中获取，新的 Note 被发送到 url https://fullstack-exampleapp.herokuapp.com/new_note 。 如今，这样的 url 被认为是不可接受的，因为它们没有遵循公认的 RESTful api 约定，我们将在第三章中进一步研究
 
 <!-- The thing termed AJAX is now so commonplace that it's taken for granted. The term has faded into oblivion, and the new generation has not even heard of it. -->
 

--- a/src/content/3/zh/part3a.md
+++ b/src/content/3/zh/part3a.md
@@ -141,12 +141,12 @@ Server running on port 3001
 ```
 
 <!-- We can open our humble application in the browser by visiting the address <http://localhost:3001>: -->
-我们可以在浏览器中通过访问地址 http://localhost:3001打开我们的应用:
+我们可以在浏览器中通过访问地址 http://localhost:3001 打开我们的应用:
 
 ![](../../images/3/1.png)
 
 <!-- In fact, the server works the same way regardless of the latter part of the URL. Also the address <http://localhost:3001/foo/bar> will display the same content. -->
-事实上，无论 URL 的后半部分是什么，服务器的工作方式都是相同的。 地址http://localhost:3001/foo/bar也会显示相同的内容。
+事实上，无论 URL 的后半部分是什么，服务器的工作方式都是相同的。 地址http://localhost:3001/foo/bar 也会显示相同的内容。
 
 <!-- **NB** if the port 3001 is already in use by some other application, then starting the server will result in the following error message: -->
 
@@ -619,7 +619,7 @@ app.get('/api/notes/:id', (request, response) => {
 ```
 
 <!-- When we visit <http://localhost:3001/api/notes/1> again in the browser, the console which is the terminal in this case, will display the following: -->
-当我们在浏览器中再次访问 http://localhost:3001/api/notes/1时，终端控制台将显示如下内容:
+当我们在浏览器中再次访问 http://localhost:3001/api/notes/1 时，终端控制台将显示如下内容:
 
 ![](../../images/3/8.png)
 

--- a/src/content/3/zh/part3b.md
+++ b/src/content/3/zh/part3b.md
@@ -95,7 +95,7 @@ app.use(cors())
 ### Application to the Internet
 【将应用部署到网上】
 <!-- Now that the whole stack is ready, let's move our application to the internet. We'll use good old [Heroku](https://www.heroku.com) for this. -->
-现在整个栈已经准备就绪，让我们将应用迁移到互联网上。 我们将使用古老的 Heroku  https://www.Heroku.com。
+现在整个栈已经准备就绪，让我们将应用迁移到互联网上。 我们将使用古老的 Heroku  https://www.Heroku.com 。
 
 ><!--If you have never used Heroku before, you can find instructions from [Heroku documentation](https://devcenter.heroku.com/articles/getting-started-with-nodejs) or by Googling.-->
 如果您以前从未使用过 Heroku，您可以从[Heroku 文档](Heroku  https://devcenter.Heroku.com/articles/getting-started-with-nodejs 文档)或通过谷歌搜索找到指令。
@@ -229,7 +229,7 @@ const getAll = () => {
 更改之后，我们必须创建一个新的生产构建，并将其复制到后端存储库的根。
 
 <!-- The application can now be used from the <i>backend</i> address <http://localhost:3001>: -->
-该应用现在可以从<i>后端</i> 地址 http://localhost:3001中使用:
+该应用现在可以从<i>后端</i> 地址 http://localhost:3001 中使用:
 
 ![](../../images/3/28e.png)
 
@@ -237,7 +237,7 @@ const getAll = () => {
 我们的应用现在的工作方式与我们在第0章节中研究的[单页应用](/zh/part0/web_应用的基础设施#single-page-app) 示例应用完全一样。
 
 <!-- When we use a browser to go to the address <http://localhost:3001>, the server returns the <i>index.html</i> file from the <i>build</i> repository. Summarized contents of the file are as follows:  -->
-当我们使用浏览器访问地址 http://localhost:3001时，服务器从<i>build</i> 仓库返回<i>index. html</i> 文件。 档案的摘要内容如下:
+当我们使用浏览器访问地址 http://localhost:3001 时，服务器从<i>build</i> 仓库返回<i>index. html</i> 文件。 档案的摘要内容如下:
 
 ```html
 <head>

--- a/src/content/3/zh/part3c.md
+++ b/src/content/3/zh/part3c.md
@@ -767,7 +767,7 @@ app.get('/api/notes/:id', (request, response) => {
 ### Error handling
 【错误处理】
 <!-- If we try to visit the URL of a note with an id that does not actually exist e.g. <http://localhost:3001/api/notes/5c41c90e84d891c15dfa3431> where <i>5a3b80015b6ec6f1bdf68d</i> is not an id stored in the database, then the browser will simply get "stuck" since the server never responds to the request. -->
-如果我们试图向数据库访问一个实际上并不存在的 id 的便笺的 URL，比如 http://localhost:3001/api/notes/5c41c90e84d891c15dfa3431，其中<i>5c41c90e84d891c15dfa3431</i> 不是一个存储在数据库中的 id，那么浏览器将简单地“卡住” ，因为服务器无法响应请求。
+如果我们试图向数据库访问一个实际上并不存在的 id 的便笺的 URL，比如 http://localhost:3001/api/notes/5c41c90e84d891c15dfa3431 ，其中<i>5c41c90e84d891c15dfa3431</i> 不是一个存储在数据库中的 id，那么浏览器将简单地“卡住” ，因为服务器无法响应请求。
 
 <!-- We can see the following error message appear in the logs for the backend: -->
 我们可以在后端的日志中看到如下错误消息:

--- a/src/content/3/zh/part3d.md
+++ b/src/content/3/zh/part3d.md
@@ -260,7 +260,7 @@ personService
 #### 3.21  Deploying the database backend to production
 【将数据库后端部署到生产环境】
 <!-- Generate a new "full stack" version of the application by creating a new production build of the frontend, and copy it to the backend repository. Verify that everything works locally by using the entire application from the address <https://localhost:3001>. -->
-通过创建前端的新生产版本，生成应用的新“完整栈”版本，并将其复制到后端存储库。 通过使用地址 https://localhost:3001的整个应用来验证所有的东西都能在本地工作。
+通过创建前端的新生产版本，生成应用的新“完整栈”版本，并将其复制到后端存储库。 通过使用地址 https://localhost:3001 的整个应用来验证所有的东西都能在本地工作。
 
 <!-- Push the latest version to Heroku and verify that everything works there as well. -->
 将最新版本推送到 Heroku，并验证那里的工作一切正常。


### PR DESCRIPTION
I tried to fix some link errors caused by Chinese typography errors, also, I recommend Chinese markdown Typesetting rules reference https://github.com/sparanoid/chinese -copywriting-guidelines, which can reduce the occurrence of such errors.