### PR TITLE
Part 2c: Another way to secure API key

### DIFF
--- a/src/content/2/fi/osa2c.md
+++ b/src/content/2/fi/osa2c.md
@@ -646,4 +646,14 @@ const api_key = process.env.REACT_APP_API_KEY
 // muuttujassa api_key on nyt käynnistyksessä annettu api-avaimen arvo
 ```
 
+Toinen vaihtoehto on määrittää api-avain erillisessä moduulissa esim. lisäämällä projektin juurihakemistoon tiedosto ```config.js``` ja kirjoittamalla tiedostoon seuraava sisältö:
+
+```js
+const weatherAPIKey = "54l41n3n4v41m34rv0";
+
+export default weatherAPIKey;
+```
+
+Voit nyt importata api-avaimen muiden moduulien tapaan. HUOM! Muista lisätä ```config.js``` projektin ```.gitignore```-tiedostoon, niin sitä ei lisätä git-repositorioon.
+
 </div>


### PR DESCRIPTION
It seems that Windows users can have trouble with the environment variables. I tried many different things from StackOverflow, but nothing seemed to work. I think it might be a good idea to add another way of working with the API keys, so that the problems with environment variables do not cause students to avoid the exercise itself. I think saving all sensitive information in a separate config file and not committing that file is a good practice. But I also understand if you feel like environment variables are the way to go.