### PR TITLE
Performance improvements and sticky sidebar

### DIFF
--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -43,6 +43,7 @@ class Accordion extends Component {
       containerClassName,
       list,
       titleStyle,
+      selectedItem,
     } = this.props;
     const { isOpened } = this.state;
 
@@ -73,7 +74,7 @@ class Accordion extends Component {
           {list && (
             <ul>
               {list.map(l => (
-                <li key={l.text}>
+                <li key={l.text} className={selectedItem === l.id ? 'selected' : undefined}>
                   <Link to={l.href}>{l.text}</Link>
                 </li>
               ))}
@@ -94,6 +95,7 @@ Accordion.propTypes = {
   containerClassName: PropTypes.string,
   initiallyOpened: PropTypes.bool,
   titleStyle: PropTypes.object,
+  selectedItem: PropTypes.string
 };
 
 Accordion.defaultProps = {

--- a/src/components/ScrollNavigation/ScrollNavigation.js
+++ b/src/components/ScrollNavigation/ScrollNavigation.js
@@ -15,14 +15,13 @@ class ScrollNavigation extends Component {
     super(props);
 
     this.state = {
-      h1Top: 0,
       headings: [],
+      selectedItem: null
     };
   }
 
   componentDidMount = () => {
     const headingList = Array.from(document.querySelectorAll('h3'));
-    const h1 = document.querySelector('h1');
 
     const headings = headingList.map(i => {
       i.id = kebabCase(i.innerText);
@@ -35,8 +34,37 @@ class ScrollNavigation extends Component {
       };
     });
 
-    this.setState({ headings: headings, h1Top: h1.offsetTop });
+    this.setState({ headings: headings});
+    window.addEventListener('scroll', this.scrollHandler);
   };
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.scrollHandler);
+  }
+
+  scrollHandler = () => {
+    // Below implements 50 ms debounce
+    if (this.scrollTimer) {
+      clearTimeout(this.scrollTimer)
+    }
+
+    this.scrollTimer = setTimeout(() => {
+      const scrollThreshold = window.scrollY
+      let last = this.state.headings[0]
+      for (const heading of this.state.headings) {
+        const elem = document.getElementById(heading.id)
+        if (elem && elem.offsetTop >= scrollThreshold) {
+          break
+        }
+        last = heading
+      }
+      if (this.state.selectedItem !== last.id) {
+        this.setState({
+          selectedItem: last.id
+        })
+      }
+    }, 50)
+  }
 
   loopThroughPartsNode = partsNode => {
     const { headings } = this.state;
@@ -72,8 +100,10 @@ class ScrollNavigation extends Component {
             initiallyOpened
             key={key}
             title={`${letter} ${partsNode[key]}`}
+            selectedItem={this.state.selectedItem}
             list={headings.map(i => {
               return {
+                id: i.id,
                 href: `${currentPath}#${i.id}`,
                 text: i.text,
               };

--- a/src/components/ScrollNavigation/ScrollNavigation.js
+++ b/src/components/ScrollNavigation/ScrollNavigation.js
@@ -89,13 +89,16 @@ class ScrollNavigation extends Component {
     const { part } = this.props;
 
     return (
-      <Element
-        tag="ul"
-        flex
-        dirColumn
-        className={`scroll-navigation ${this.props.className}`}
-      >
-        {this.loopThroughPartsNode(navigation[this.props.lang][part])}
+      <Element className="scroll-navigation-container">
+        <Element className="scroll-navigation-container-inner">
+          <Element
+            tag="ul"
+            dirColumn
+            className={`scroll-navigation ${this.props.className}`}
+          >
+            {this.loopThroughPartsNode(navigation[this.props.lang][part])}
+          </Element>
+        </Element>
       </Element>
     );
   }

--- a/src/components/ScrollNavigation/ScrollNavigation.scss
+++ b/src/components/ScrollNavigation/ScrollNavigation.scss
@@ -1,16 +1,36 @@
 @import '../common.scss';
 
-.scroll-navigation {
+.scroll-navigation-container {
   display: none;
-
   @include from($desktop) {
+    pointer-events: none;
     display: block;
     font-size: 16px;
-    position: absolute;
-    width: 30%;
+    position: sticky;
+    width: 100%;
+    margin-right: -100%;
+
     left: 0;
-    top: 198px;
+    top: -100px;
+    padding-top: 200px;
   }
+}
+
+.scroll-navigation-container-inner {
+  width: 90%;
+  margin: 0 auto;
+  max-width: 1200px;
+}
+
+.scroll-navigation {
+  pointer-events: auto;
+
+  display: flex;
+  width: 30%;
+  max-width: 30% / 0.9;
+  height: 100%;
+  overflow-y: auto;
+  max-height: calc(100vh - 100px);
 
   padding-right: 1rem;
   z-index: 199;

--- a/src/components/ScrollNavigation/ScrollNavigation.scss
+++ b/src/components/ScrollNavigation/ScrollNavigation.scss
@@ -38,7 +38,7 @@
   li {
     list-style-type: none;
 
-    &:hover {
+    &:hover, &.selected {
       cursor: pointer;
 
       a {

--- a/src/templates/ContentTemplate.js
+++ b/src/templates/ContentTemplate.js
@@ -32,7 +32,7 @@ export default class ContentTemplate extends Component {
       h1Top: 0,
       h1Title: '',
       otherTitles: '',
-      top: 0,
+      showArrowUp: false,
     };
   }
 
@@ -77,9 +77,15 @@ export default class ContentTemplate extends Component {
   }
 
   handleScroll = () => {
-    this.setState({
-      top: window.scrollY,
-    });
+    if (window.scrollY > 300 && !this.state.showArrowUp) {
+      this.setState({
+        showArrowUp: true
+      });
+    } else if (window.scrollY <= 300 && this.state.showArrowUp) {
+      this.setState({
+        showArrowUp: false
+      });
+    }
   };
 
   render() {
@@ -155,7 +161,7 @@ export default class ContentTemplate extends Component {
           ]}
         />
 
-        {this.state.top > 300 && (
+        {this.state.showArrowUp && (
           <div
             className="arrow-go-up"
             onClick={() =>

--- a/src/templates/ContentTemplate.js
+++ b/src/templates/ContentTemplate.js
@@ -29,7 +29,6 @@ export default class ContentTemplate extends Component {
     super(props);
 
     this.state = {
-      h1Top: 0,
       h1Title: '',
       otherTitles: '',
       showArrowUp: false,
@@ -64,7 +63,6 @@ export default class ContentTemplate extends Component {
     });
 
     this.setState({
-      h1Top: h1.offsetTop,
       h1Title: h1.innerText,
       otherTitles: [...h3Arr],
     });
@@ -110,35 +108,35 @@ export default class ContentTemplate extends Component {
           return <pre>{domToReact(children, parserOptions)}</pre>;
         } else if (type === 'tag' && attribs.class === 'content') {
           return (
-            <div className="container">
-              <div className="course-content col-6 push-right-3">
+            <Element className="course-content">
+              <Element className="course-content-inner">
                 {domToReact(children, parserOptions)}
-              </div>
-            </div>
+              </Element>
+            </Element>
           );
         } else if (type === 'tag' && attribs.class === 'tasks') {
           return (
             <Banner
               style={{
-                backgroundColor: colorCode,
+                backgroundColor: colorCode
               }}
-              className="spacing spacing--after tasks"
+              className="spacing tasks content-banner"
             >
-              <div className="container">
-                <div
-                  className="course-content col-6 push-right-3"
-                  style={{
-                    borderColor: colorCode,
-                    backgroundColor: 'transparent',
-                  }}
-                >
+              <Element
+                className="course-content"
+                style={{
+                  borderColor: colorCode,
+                  backgroundColor: 'transparent',
+                }}
+              >
+                <Element className="course-content-inner">
                   {children.name === 'pre' ? (
                     <pre>{domToReact(children, parserOptions)}</pre>
                   ) : (
                     domToReact(children, parserOptions)
                   )}
-                </div>
-              </div>
+                </Element>
+              </Element>
             </Banner>
           );
         }
@@ -209,36 +207,37 @@ export default class ContentTemplate extends Component {
           </Banner>
 
           <Element className="course">
-            <Element flex className="container" relative>
-              <ScrollNavigation
-                part={part}
-                letter={letter}
-                lang={lang}
-                currentPartTitle={navigation[lang][part][letter]}
-                currentPath={`/${
-                  lang === 'en' ? 'en/part' : lang === 'zh' ? 'zh/part':'osa'
-                }${part}/${snakeCase(navigation[lang][part][letter])}`}
-                colorCode={colorCode}
-                className="col-2 spacing"
-                style={{ top: this.state.h1Top }}
-              />
+            <ScrollNavigation
+              part={part}
+              letter={letter}
+              lang={lang}
+              currentPartTitle={navigation[lang][part][letter]}
+              currentPath={`/${
+                lang === 'en' ? 'en/part' : lang === 'zh' ? 'zh/part':'osa'
+              }${part}/${snakeCase(navigation[lang][part][letter])}`}
+              colorCode={colorCode}
+            />
 
+            <Element className="course-content-container">
               <Element
-                className="course-content col-6 push-right-3"
+                className="course-content"
                 autoBottomMargin
               >
-                <p className="col-1 letter" style={{ borderColor: colorCode }}>
-                  {letter}
-                </p>
+                <Element className="course-content-inner">
+                  <p className="col-1 letter" style={{ borderColor: colorCode }}>
+                    {letter}
+                  </p>
 
-                <SubHeader
-                  headingLevel="h1"
-                  text={navigation[lang][part][letter]}
-                />
+                  <SubHeader
+                    headingLevel="h1"
+                    text={navigation[lang][part][letter]}
+                  />
+                </Element>
               </Element>
-            </Element>
 
-            {Parser(html, parserOptions)}
+              {Parser(html, parserOptions)}
+
+            </Element>
           </Element>
 
           <EditLink part={part} letter={letter} lang={lang} />

--- a/src/templates/ContentTemplate.scss
+++ b/src/templates/ContentTemplate.scss
@@ -4,6 +4,13 @@
   position: relative;
   width: 100%;
 
+  @include from($desktop) {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
   p {
     font-family: $font-heading;
 
@@ -96,6 +103,10 @@
   }
 }
 
+.course-content-container {
+  width: 100%;
+}
+
 .course-content,
 .tasks {
   a {
@@ -107,7 +118,16 @@
 }
 
 .course-content {
-  max-width: 100%;
+  width: 90%;
+  margin: 0 auto;
+  max-width: 1200px;
+}
+
+.course-content-inner {
+  @include from($desktop) {
+    padding-left: 30%;
+    padding-right: 5%;
+  }
 }
 
 .tasks {


### PR DESCRIPTION
**Is built on #535 so that needs to be merged first**

[Live demo of this branch's contents](http://improvements-demo.s3-website.eu-north-1.amazonaws.com/)

- Most of the page was re-rendered on scroll events. Screenshots below on unscientific continuous scrolling of up and down with mouse wheel. With the changes, the framerate hardly ever dips under 60.
Before:
![Annotation 2020-07-09 150755](https://user-images.githubusercontent.com/88401/87056374-330c5b80-c20e-11ea-984f-1e29e9f953da.png)
After:
![Annotation 2020-07-09 150820](https://user-images.githubusercontent.com/88401/87056402-3bfd2d00-c20e-11ea-854b-9c993c0b7f03.png)

- Pure CSS implemented efficient sticky sidebar to more easily keep track where you are on the page
- Tracking of scrolled location page to highlight currently visible section on the sticky sidebar

![Annotation 2020-07-09 180420](https://user-images.githubusercontent.com/88401/87056696-aa41ef80-c20e-11ea-8342-e791a1ab30ed.png)


