### PR TITLE
Update osa4b.md

### DIFF
--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -65,7 +65,7 @@ ja muuttamalla <i>package.json</i> kaikilla käyttöjärjestelmillä toimivaan m
 
 Nyt sovelluksen toimintaa on mahdollista muokata sen suoritusmoodiin perustuen. Eli voimme määritellä, esim. että testejä suoritettaessa ohjelma käyttää erillistä, testejä varten luotua tietokantaa.
 
-Sovelluksen testikanta voidaan luoda tuotantokäytön ja sovelluskehityksen tapaan Mongo DB Atlasiin. Ratkaisu ei ole optimaalinen erityisesti, jos sovellusta on tekemässä yhtä aikaa useita henkilöitä. Testien suoritus nimittäin yleensä edellyttää, että samaa tietokantainstanssia ei ole yhtä aikaa käyttämässä useampia testiajoja.
+Sovelluksen testikanta voidaan luoda tuotantokäytön ja sovelluskehityksen tapaan Mongo DB Atlasiin. Ratkaisu ei ole optimaalinen erityisesti, jos sovellusta on tekemässä yhtä aikaa useita henkilöitä. Testien suoritus nimittäin yleensä edellyttää, että samaa tietokannan tilaa ei ole yhtä aikaa käyttämässä useampia testiajoja.
 
 Testaukseen kannattaisikin käyttää verkossa olevan jaetun tietokannan sijaan mieluummin sovelluskehittäjän paikallisella koneella olevaa tietokantaa. Optimiratkaisu olisi tietysti se, että jokaista testiajoa varten olisi käytettävissä oma tietokanta, sekin periaatteessa onnistuu "suhteellisen helposti" mm. [keskusmuistissa toimivan Mongon](https://docs.mongodb.com/manual/core/inmemory/) ja [docker](https://www.docker.com)-kontainereiden avulla. Etenemme kuitenkin nyt lyhyemmän kaavan mukaan ja käytetään testikantana normaalia Mongoa.
 


### PR DESCRIPTION
Sanalla "instanssi" ei näytä suomen kielessä olevan tällaista merkitystä, jota tässä tarkoitetaan tietokantainstanssilla. Kielitoimiston sanakirjan mukaan tarkoittaa suomen kielen "instanssi" ainoastaan oikeus- tai hallintoastetta. 
Kuvakaappaus Kielitoimiston sanakirjasta:
![image](https://user-images.githubusercontent.com/36277211/87247139-9db1d700-c45a-11ea-9a0f-6e7dbede4117.png)

Tieteen termipankin mukaan on sanan "instance" käännösvastine tietojenkäsittelytieteen kontekstissa "ilmentymä".
https://tieteentermipankki.fi/wiki/Tietojenk%C3%A4sittelytiede:ilmentym%C3%A4

TEPA:n termipankin mukaan voi käyttää myös fraasia "tietokannan tila", joka sopii minusta vielä paremmin teidän lauseeseenne, mutta ehdotan jompaakumpaa "instanssin" sijaan.
TEPA:n termipankki: https://termipankki.fi/tepa/fi/haku/instance
