### PR TITLE
Add one parenthesis to code example

### DIFF
--- a/src/content/5/fi/osa5b.md
+++ b/src/content/5/fi/osa5b.md
@@ -644,7 +644,7 @@ const Togglable = React.forwardRef((props, ref) => {
 
 Togglable.propTypes = {
   buttonLabel: PropTypes.string.isRequired
-}
+})
 ```
 
 Jos propsia ei määritellä, seurauksena on konsoliin tulostuva virheilmoitus


### PR DESCRIPTION
as the code snippet begins Togglable definition with `React.forwardRef((props, ref) => {`, it should also end with `})` instead of only `}`.