### PR TITLE
added date property to test notes in 4b

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -285,10 +285,12 @@ const initialNotes = [
   {
     content: 'HTML is easy',
     important: false,
+    date: new Date()
   },
   {
     content: 'Browser can execute only Javascript',
     important: true,
+    date: new Date()
   },
 ]
 


### PR DESCRIPTION
In the 'Initializing the database before tests' section,

the test notes lack "date" property and the tests therefore fail.