### PR TITLE
Remove misleading pointer cursor on sidebar items

### DIFF
--- a/src/components/ScrollNavigation/ScrollNavigation.scss
+++ b/src/components/ScrollNavigation/ScrollNavigation.scss
@@ -39,7 +39,6 @@
     list-style-type: none;
 
     &:hover, &.selected {
-      cursor: pointer;
 
       a {
         background-color: $black;


### PR DESCRIPTION
Navigation sidebar on the left side shows up pointer cursor when hovering on items indicating a clickable region. If the mouse pointer isn't located on top of the anchor element inside of the list item, nothing happens when a mouse button is clicked.

This PR removes the misleading indicator for clickable elements on navigation when there are no anchors under cursor.