### PR TITLE
Update part4a.md

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -482,7 +482,7 @@ Let's define the <i>npm script _test_</i> to execute tests with Jest and to repo
     "deploy:full": "npm run build:ui && git add . && git commit -m uibuild && git push && npm run deploy",
     "logs:prod": "heroku logs --tail",
     "lint": "eslint .",
-    "test": "jest --verbose" // highlight-line
+    "test": "jest --verbose || true" // highlight-line
   },
   //...
 }


### PR DESCRIPTION
This will stop jest from printing these (extra) error logs when one of the tests fails. 
```
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! bloglist@1.0.0 test: `jest --verbose`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the bloglist@1.0.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```