### PR TITLE
Fix broken link on part9b.md

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -555,7 +555,7 @@ Let's specify the following configurations in our <i>tsconfig.json</i> file:
 Do not worry too much about the <i>compilerOptions</i>, they will be under closer inspection on part 2.
 
 <!-- The explanations for each of the field can be found from TypeScript documentation or the really handy although beta-stage [tsconfig page](https://www.staging-typescript.org/tsconfig) or in a little worse format in the tsconfig [schema definition](http://json.schemastore.org/tsconfig). -->
-You can find explanations for each of the configurations from the TypeScript documentation, or the really handy [tsconfig page](https://www.typescriptlang.org/tsconfig), or from the tsconfig [schema definition](http://json.schemastore.org/tsconfig), which unfortunately is formatted a little worse than the first two options. 
+You can find explanations for each of the configurations from the TypeScript documentation, or the really handy [tsconfig page](https://www.staging-typescript.org/tsconfig), or from the tsconfig [schema definition](http://json.schemastore.org/tsconfig), which unfortunately is formatted a little worse than the first two options. 
 
 ### Adding express to the mix
 

--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -554,7 +554,7 @@ Let's specify the following configurations in our <i>tsconfig.json</i> file:
 <!-- Do not worry too much about the <i>compilerOptions</i> selected here, they will be under closer inspection on part 2. -->
 Do not worry too much about the <i>compilerOptions</i>, they will be under closer inspection on part 2.
 
-<!-- The explanations for each of the field can be found from TypeScript documentation or the really handy although beta-stage [tsconfig page](https://www.typescriptlang.org/v2/en/tsconfig) or in a little worse format in the tsconfig [schema definition](http://json.schemastore.org/tsconfig). -->
+<!-- The explanations for each of the field can be found from TypeScript documentation or the really handy although beta-stage [tsconfig page](https://www.staging-typescript.org/tsconfig) or in a little worse format in the tsconfig [schema definition](http://json.schemastore.org/tsconfig). -->
 You can find explanations for each of the configurations from the TypeScript documentation, or the really handy [tsconfig page](https://www.typescriptlang.org/tsconfig), or from the tsconfig [schema definition](http://json.schemastore.org/tsconfig), which unfortunately is formatted a little worse than the first two options. 
 
 ### Adding express to the mix


### PR DESCRIPTION
Link '[tsconfig page](https://www.typescriptlang.org/v2/en/tsconfig)' seems to be broken. If the aim is that this link should point to TS v2 TSConfig documentation, then the correct link should be perhaps this instead: 'https://www.staging-typescript.org/tsconfig'. Otherwise, if the link should point to the latest TSConfig documentation, then the link should be this: 'https://www.typescriptlang.org/docs/handbook/tsconfig-json.html.