### PR TITLE
Additional note about and error in part9c.md

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -940,6 +940,8 @@ router.post('/', (req, res) => {
 });
 ```
 
+> **NB**: If you configured TSConfig like instructed above, above used destructuring assignment of request data will cause '<I>Unsafe assigment of an any value.</I>' error. You may ignore it for now. This problem will be tackled in the next section (**Proofing requests**).
+
 corresponding method in <i>diaryService</i> looks like this
 
 ```js


### PR DESCRIPTION
In the section 'Adding a new diary' in part9c.md, when updating router functionality, it would be wise to add proposed additional note (or such) about an error 'Unsafe assigment of an any value.' which will happen due the line where is done destructuring assigment of request data (which has not been typed yet).