### PR TITLE
Note about unhandled ESlint warnings in part9c.md

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -1372,6 +1372,8 @@ If we now try to create a new diary entry with invalid or missing fields we are 
 
 ![](../../images/9/30b.png)
 
+> **NB**: If you configured ESlint for the project like instructed at the beginning of this part, you may still encounter several warnings from the files of the project. Corrections to these issues will be left as a voluntary exercise.
+
 </div>
 
 <div class="tasks">


### PR DESCRIPTION
At the end of part9c.md, it would be wise to add some disclaimer/additional note about unhandled ESlint warnings. In order to avoid any unnecessary doubts 'Why I get these warnings?! Did I miss something...?' from students. ;-)