### PR TITLE
Update osa3d.md

### DIFF
--- a/src/content/3/fi/osa3d.md
+++ b/src/content/3/fi/osa3d.md
@@ -399,10 +399,9 @@ Yksittäisen sääntö on helppo kytkeä [pois päältä](https://eslint.org/doc
       ],
       'arrow-spacing': [
           'error', { 'before': true, 'after': true }
-      ]
+      ],
+      'no-console': 0, // highlight-line
     },
-    'no-console': 0 // highlight-line
-  },
 }
 ```
 


### PR DESCRIPTION
Materiaalissa esitelty _no-console_-sääntö on väärällä rivillä, rules-lohkon ulkopuolella. Siirretty ko. sääntö rivi ylemmäs ja poistettu ylimääräinen aaltosulje.