### PR TITLE
Update part3a.md

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -158,7 +158,7 @@ Error: listen EADDRINUSE :::3001
 ```
 
 
-You have two options. Either shutdown the application using the port 3001 (the json-server in the last part of the material was using the port 3001), or use a different port for this application.
+You have two options. Either shut down the application using the port 3001 (the json-server in the last part of the material was using the port 3001), or use a different port for this application.
 
 Let's take a closer look at the first line of the code:
 


### PR DESCRIPTION
Fix typo. Two words as a verb (shut down), one word as a noun (shutdown). In this case, it is used as a verb - so two words.