### PR TITLE
Changed Object-wrapper names to primitive type

### DIFF
--- a/src/content/1/en/part1b.md
+++ b/src/content/1/en/part1b.md
@@ -508,7 +508,7 @@ const janja = new Person('Janja Garnbret', 22)
 janja.greet()
 ```
 
-When it comes to syntax, the classes and the objects created from them are very reminiscent of Java classes and objects. Their behavior is also quite similar to Java objects. At the core they are still objects based on JavaScript's [prototypal inheritance](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Inheritance). The type of both objects is actually _Object_, since JavaScript essentially only defines the types [Boolean, Null, Undefined, Number, String, Symbol, BigInt, and Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures).
+When it comes to syntax, the classes and the objects created from them are very reminiscent of Java classes and objects. Their behavior is also quite similar to Java objects. At the core they are still objects based on JavaScript's [prototypal inheritance](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Inheritance). The type of both objects is actually _Object_, since JavaScript essentially only defines the types [boolean, null, undefined, number, string, symbol, and object](http://www.ecma-international.org/ecma-262/10.0/index.html#sec-ecmascript-data-types-and-values).
 
 The introduction of the class syntax was a controversial addition. Check out [Not Awesome: ES6 Classes](https://github.com/petsel/not-awesome-es6-classes) or [Is “Class” In ES6 The New “Bad” Part?](https://medium.com/@rajaraodv/is-class-in-es6-the-new-bad-part-6c4e6fe1ee65) for more details.
 


### PR DESCRIPTION
The doc mentioned the Object-wrapper(Object sub-types) as the primitive types which is wrong, The only 7 primitives that the language offers are boolean , number, string, object, symbol, null and undefined. also provided [this link to the specification](http://www.ecma-international.org/ecma-262/10.0/index.html#sec-ecmascript-data-types-and-values) for the reference since the [MDN documentation seems to be mix up object-wrappers with primitives ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures)  as Boolean, Number, String, Object, Symbol, BigInt are the object wrappers for the primitive types and not themselves the primitive types

Here a good reference from [YDKJS - types and grammer](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/types%20%26%20grammar/ch1.md#built-in-types)

