### PR TITLE
Update part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -797,10 +797,10 @@ app.use(errorHandler)
 The json-parser middleware should be among the very first middleware loaded into Express. If the order was the following:
 
 ```js
-app.use(logger) // request.body is empty!
+app.use(logger) // request.body is undefined!
 
 app.post('/api/notes', (request, response) => {
-  // request.body is empty!
+  // request.body is undefined!
   const body = request.body
   // ...
 })
@@ -808,7 +808,7 @@ app.post('/api/notes', (request, response) => {
 app.use(express.json())
 ```
 
-Then the JSON data sent with the HTTP requests would not be available for the logger middleware or the POST route handler, since the _request.body_ would be an empty object at that point.
+Then the JSON data sent with the HTTP requests would not be available for the logger middleware or the POST route handler, since the _request.body_ would be _undefined_ at that point.
 
 It's also important that the middleware for handling unsupported routes is next to the last middleware that is loaded into Express, just before the error handler.
 


### PR DESCRIPTION
If the json-parser middleware would be loaded after the logger middleware and the POST route handler - request.body would not be an empty object. It would be undefined.