### PR TITLE
Update osa3b.md

### DIFF
--- a/src/content/3/fi/osa3b.md
+++ b/src/content/3/fi/osa3b.md
@@ -70,7 +70,7 @@ Kun koko "stäkki" on saatu vihdoin kuntoon, siirretään sovellus internettiin.
 Lisätään backendin projektin juureen tiedosto <i>Procfile</i>, joka kertoo Herokulle, miten sovellus käynnistetään
 
 ```bash
-web: node index.js
+web: npm start
 ```
 
 Muutetaan tiedoston <i>index.js</i> lopussa olevaa sovelluksen käyttämän portin määrittelyä seuraavasti:


### PR DESCRIPTION
This PR changes the Procfile from `web: node index.js` to `npm start` because it's recommended to use the npm scripts in a npm project.