### PR TITLE
Update osa4b.md

### DIFF
--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -997,15 +997,16 @@ const api = supertest(app)
 
 const Note = require('../models/note')
 
-describe('when there is initially some notes saved', () => {
-  beforeEach(async () => {
-    await Note.deleteMany({})
+beforeEach(async () => {
+  await Note.deleteMany({})
 
-    const noteObjects = helper.initialNotes
-      .map(note => new Note(note))
-    const promiseArray = noteObjects.map(note => note.save())
-    await Promise.all(promiseArray)
-  })
+  const noteObjects = helper.initialNotes
+    .map(note => new Note(note))
+  const promiseArray = noteObjects.map(note => note.save())
+  await Promise.all(promiseArray)
+})
+  
+describe('when there is initially some notes saved', () => {
 
   test('notes are returned as json', async () => {
     await api


### PR DESCRIPTION
When beforeEach() was inside the first describe block, some tests failed because test database was not initialized before each test, i.e. number of entries in helper.initialNotes did not match with the test database in some cases.