### PR TITLE
Update part5b (all languages)

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -559,7 +559,7 @@ The form closes when a new blog is created.
 Separate the form for creating a new blog into its own component (if you have not already done so), and 
 move all the states required for creating a new blog to this component. 
 
-The component must work like the <i>NewNote</i> component from the [material](/en/part5/props_children_and_proptypes) of this part.
+The component must work like the <i>NoteForm</i> component from the [material](/en/part5/props_children_and_proptypes) of this part.
 
 #### 5.7* Blog list frontend, step7
 

--- a/src/content/5/fi/osa5b.md
+++ b/src/content/5/fi/osa5b.md
@@ -517,7 +517,7 @@ Lomakkeen tulee sulkeutua kun uusi blogi luodaan.
 
 Eriytä uuden blogin luomisesta huolehtiva lomake omaan komponenttiinsa (jos et jo ole niin tehnyt), ja siirrä kaikki uuden blogin luomiseen liittyvä tila komponentin vastuulle. 
 
-Komponentin tulee siis toimia samaan tapaan kuin tämän osan [materiaalin](https://fullstack-hy2020.github.io/osa5/props_children_ja_proptypet#lomakkeiden-tila) komponentin <i>NewNote</i>.
+Komponentin tulee siis toimia samaan tapaan kuin tämän osan [materiaalin](https://fullstack-hy2020.github.io/osa5/props_children_ja_proptypet#lomakkeiden-tila) komponentin <i>NoteForm</i>.
 
 #### 5.7* blogilistan frontend, step7
 

--- a/src/content/5/zh/part5b.md
+++ b/src/content/5/zh/part5b.md
@@ -611,8 +611,8 @@ const Togglable = () => ...
 <!-- move all the states required for creating a new blog to this component.  -->
 将创建新 blog 的表单分离到它自己的组件中(如果您还没有这样做) ，并将创建新博客所需的所有状态移动到此组件。
 
-<!-- The component must work like the <i>NewNote</i> component from the [material](/osa5/props_children_ja_proptypet#lomakkeiden-tila) of this part. -->
-这个组件必须像[这里](/zh/part5/props_children_与_proptypes)的<i>NewNote</i> 组件那样工作。
+<!-- The component must work like the <i>NoteForm</i> component from the [material](/osa5/props_children_ja_proptypet#lomakkeiden-tila) of this part. -->
+这个组件必须像[这里](/zh/part5/props_children_与_proptypes)的<i>NoteForm</i> 组件那样工作。
 
 #### 5.7* Blog list frontend, 步骤7
 


### PR DESCRIPTION
Exercise 5.6 references the component NewNote, which doesn't exist in the material. Should be NoteForm instead.
However, it does appear that a NewNote component is found in at least part 6. For consistency's sake it might be better to change the NoteForm component to NewNote instead (that could also be more confusing).