### PR TITLE
Update part0b.md

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -328,7 +328,7 @@ document.getElementById('notes').appendChild(ul)
 
 ### Manipulating the document-object from console
 
-The topmost node of the DOM tree of a HTML document is called the <em>document</em> object. We can perform various operations on a web-page using the DOM-API. You can access the <em>document</em> object by typing <em>document</em> into the Console-tab: 
+The topmost node of the DOM tree of an HTML document is called the <em>document</em> object. We can perform various operations on a web-page using the DOM-API. You can access the <em>document</em> object by typing <em>document</em> into the Console-tab: 
 
 ![](../../images/0/15e.png)
 


### PR DESCRIPTION
Fix typo. 

The choice between a and an is determined by the initial sound, and not the initial letter, of the following word.

For example, it is “a hotel” because “hotel” starts with a consonant sound (/**h**oʊˈtel/), but it is “an HTML” because “HTML” starts with a vowel sound (/ˌ**e**ɪtʃ.tiː.emˈel/).