### PR TITLE
Update part1c.md

### DIFF
--- a/src/content/1/en/part1c.md
+++ b/src/content/1/en/part1c.md
@@ -306,7 +306,7 @@ The function passed as the first parameter to the _setTimeout_ function is invok
 When the state modifying function _setCounter_ is called, <i>React re-renders the component</i> which means that the function body of the component function gets re-executed:
 
 ```js
-(props) => {
+() => {
   const [ counter, setCounter ] = useState(0)
 
   setTimeout(


### PR DESCRIPTION
A function defining an _App_ component **doesn't have** a parameter **_props_** (line 254). 
However, when we later (line 309) take a closer look at the _App_ component - it now **has _props_**.
And if we read on (line 335) we see that the _App_ component **doesn't have _props_** again.

I suggest removing _props_ as it's not needed.