### PR TITLE
Name of component must start with uppercase letter

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -412,7 +412,7 @@ const App = () => {
   // ...
   const noteFormRef = useRef() // highlight-line
 
-  const noteForm = () => (
+  const NoteFormParent = () => (
     <Togglable buttonLabel='new note' ref={noteFormRef}>  // highlight-line
       <NoteForm createNote={addNote} />
     </Togglable>


### PR DESCRIPTION
With name noteForm, the component won't even render at all.