### PR TITLE
Update part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -21,7 +21,7 @@ The Visual Studio Code debugger can be useful in some situations. You can launch
 
 Note that the application shouldn't be running in another console, otherwise the port will already be in use.
 
-__NB__ Newer version of Visual Studio Code may have _run_ instead of _debug_. Furthermore, you may have to configure your _launch.json_ file to start debuggning. This can be done by choosing _Add Configuration..._ on drop down menu, which is located next to green play button and above _VARIABLES_ menu, and select _Run "npm start" in a debug terminal_. 
+__NB__ A newer version of Visual Studio Code may have _Run_ instead of _Debug_. Furthermore, you may have to configure your _launch.json_ file to start debugging. This can be done by choosing _Add Configuration..._ on the drop-down menu, which is located next to the green play button and above _VARIABLES_ menu, and select _Run "npm start" in a debug terminal_. For more detailed setup instructions, visit Visual Studio Code's [Debugging documentation](https://code.visualstudio.com/docs/editor/debugging).
 
 Below you can see a screenshot where the code execution has been paused in the middle of saving a new note:
 

--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -21,6 +21,8 @@ The Visual Studio Code debugger can be useful in some situations. You can launch
 
 Note that the application shouldn't be running in another console, otherwise the port will already be in use.
 
+__NB__ Newer version of Visual Studio Code may have _run_ instead of _debug_. Furthermore, you may have to configure your _launch.json_ file to start debuggning. This can be done by choosing _Add Configuration..._ on drop down menu, which is located next to green play button and above _VARIABLES_ menu, and select _Run "npm start" in a debug terminal_. 
+
 Below you can see a screenshot where the code execution has been paused in the middle of saving a new note:
 
 ![](../../images/3/36e.png)


### PR DESCRIPTION
Current instruction on how to use Visual Studio Code debugger is possibly out of date. For example, my VS Code did not have "Debug" option, but it had "Run" instead. Furthermore, directly running the debugger caused chrome tab to open on wrong port. Even after fixing the port via launch.json, debug panel would not let me observe the changes.

Upon tweaking  my VS Code by adding  "npm start" configuration to launch.json, I was able to use my debugger properly. 

Please note that I am proposing above changes based on my personal experience. I've also attached a screenshot of what my working debugger looks like for reference.

![pull_req_part3C_debug](https://user-images.githubusercontent.com/12351886/93710770-e2628a00-fafd-11ea-9ac4-153f9a6d49df.PNG)