### PR TITLE
fix(part 10): prevent application crash

### DIFF
--- a/src/content/10/en/part10b.md
+++ b/src/content/10/en/part10b.md
@@ -577,7 +577,7 @@ import Main from './src/components/Main';
 
 const App = () => {
   return (
-    <NativeRouter>
+    <NativeRouter> // highlight-line
       <Main />
     </NativeRouter> // highlight-line
   );

--- a/src/content/10/en/part10b.md
+++ b/src/content/10/en/part10b.md
@@ -578,8 +578,6 @@ import Main from './src/components/Main';
 const App = () => {
   return (
     <NativeRouter>
-      {' '}
-      // highlight-line
       <Main />
     </NativeRouter> // highlight-line
   );


### PR DESCRIPTION
The empty string is causin the application to crash:
> Error: Text strings must be rendered within a <Text> component.

![image](https://user-images.githubusercontent.com/4258488/93719650-4596ff80-fb84-11ea-9757-2d51b33e36d7.png)

Removing it fixes the issue