### PR TITLE
Update part4b.md

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -241,7 +241,7 @@ const response = await api.get('/api/notes')
 
 // execution gets here only after the HTTP request is complete
 // the result of HTTP request is saved in variable response
-expect(res.body).toHaveLength(2)
+expect(response.body).toHaveLength(2)
 ```
 
 <!-- HTTP-pyyntöjen tiedot konsoliin kirjoittava middleware häiritsee hiukan testien tulostusta. Muutetaan loggeria siten, että testausmoodissa lokiviestit eivät tulostu konsoliin: -->

--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -237,10 +237,10 @@ Both tests store the response of the request to the _response_ variable, and unl
 The benefit of using the async/await syntax is starting to become evident. Normally we would have to use callback functions to access the data returned by promises, but with the new syntax things are a lot more comfortable:
 
 ```js
-const res = await api.get('/api/notes')
+const response = await api.get('/api/notes')
 
 // execution gets here only after the HTTP request is complete
-// the result of HTTP request is saved in variable res
+// the result of HTTP request is saved in variable response
 expect(res.body).toHaveLength(2)
 ```
 


### PR DESCRIPTION
It's actually `response` instead of `res` in the previous codeblock.