### PR TITLE
Updated dependencies for subscriptions

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -240,7 +240,7 @@ The backend code can be found on [Github](https://github.com/fullstack-hy2020/gr
 ### Subscriptions on the client
 
 
-In order to use subscriptions in our React application, we have to do some changes, especially on its [configuration](https://www.apollographql.com/docs/react/v3.0-beta/data/subscriptions/).
+In order to use subscriptions in our React application, we have to do some changes, especially on its [configuration](https://www.apollographql.com/docs/react/data/subscriptions/).
 The configuration in <i>index.js</i> has to be modified like so: 
 
 ```js
@@ -252,7 +252,7 @@ import { setContext } from 'apollo-link-context'
 
 // highlight-start
 import { getMainDefinition } from '@apollo/client/utilities'
-import { WebSocketLink } from '@apollo/link-ws'
+import { WebSocketLink } from '@apollo/client/link/ws'
 // highlight-end
 
 const authLink = setContext((_, { headers }) => {
@@ -306,7 +306,7 @@ ReactDOM.render(
 For this to work, we have to install some dependencies:
 
 ```bash
-npm install @apollo/link-ws subscriptions-transport-ws
+npm install @apollo/client subscriptions-transport-ws
 ```
 
 The new configuration is due to the fact that the application must have an HTTP connection as well as a WebSocket connection to the GraphQL server.


### PR DESCRIPTION
'@apollo/link/ws' is now '@apollo/client/link/ws'
updated configuration link
Signed-off-by: Jayesh Mann <jayeshmann06@gmail.com>