### PR TITLE
Update part1d.md

### DIFF
--- a/src/content/1/en/part1d.md
+++ b/src/content/1/en/part1d.md
@@ -548,7 +548,7 @@ Event handlers must always be a function or a reference to a function. The butto
 If we were to define the event handler as a string:
 
 ```js
-<button onClick='crap...'>button</button>
+<button onClick="crap...">button</button>
 ```
 
 React would warn us about this in the console:

--- a/src/content/1/en/part1d.md
+++ b/src/content/1/en/part1d.md
@@ -548,7 +548,7 @@ Event handlers must always be a function or a reference to a function. The butto
 If we were to define the event handler as a string:
 
 ```js
-<button onClick={'crap...'}>button</button>
+<button onClick='crap...'>button</button>
 ```
 
 React would warn us about this in the console:


### PR DESCRIPTION
When specifying attributes with JSX:
* use quotes for string values
* use curly braces for expressions

But not both in the same attribute.

From React docs:
[Specifying Attributes with JSX](https://reactjs.org/docs/introducing-jsx.html#specifying-attributes-with-jsx)
