### PR TITLE
Subscription Link Updated

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -322,7 +322,7 @@ const httpLink = createHttpLink({
 })
 ```
 
-The subscriptions are done using the [useSubscription](https://www.apollographql.com/docs/react/v3.0-beta/api/react/hooks/#usesubscription) hook function.
+The subscriptions are done using the [useSubscription](https://www.apollographql.com/docs/react/api/react/hooks/#usesubscription) hook function.
 
 Let's modify the code like so:
 


### PR DESCRIPTION
Link should always point to latest apollo version in apollo docs.
 