### PR TITLE
Update osa7d.md

### DIFF
--- a/src/content/7/fi/osa7d.md
+++ b/src/content/7/fi/osa7d.md
@@ -291,7 +291,7 @@ const config = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['@babel/preset-react'],
         },
       },
@@ -309,7 +309,7 @@ Yksittäisen loaderin määrittely on kolmiosainen:
 {
   test: /\.js$/,
   loader: 'babel-loader',
-  query: {
+  options: {
     presets: ['@babel/preset-react']
   }
 }
@@ -372,7 +372,7 @@ Tällä hetkellä sovelluksemme transpiloinnissa käytetään presetiä [@babel/
 {
   test: /\.js$/,
   loader: 'babel-loader',
-  query: {
+  options: {
     presets: ['@babel/preset-react'] // highlight-line
   }
 }


### PR DESCRIPTION
webpack.config.js has 'Rule.query', which is deprecated already in webpack 4 and not working in webpack 5. 'Rule.options' works instead