### PR TITLE
Update osa7d.md Rule.loaders -> Rule.use

### DIFF
--- a/src/content/7/fi/osa7d.md
+++ b/src/content/7/fi/osa7d.md
@@ -454,7 +454,7 @@ CSS:ää varten onkin otettava käyttöön [css](https://webpack.js.org/loaders/
     // highlight-start
     {
       test: /\.css$/,
-      loaders: ['style-loader', 'css-loader'],
+      use: ['style-loader', 'css-loader'],
     },
     // highlight-end
   ];


### PR DESCRIPTION
Rule.loaders is deprecated and does not work in webpack5. Changed it to Rule.use as instructed in https://webpack.js.org/configuration/module/#ruleloaders
This will also work, if it would be educationally better:
use: [
          {loader: 'style-loader'}, 
          {loader: 'css-loader'}
        ],