### PR TITLE
Update osa7d.md webpack-cli version

### DIFF
--- a/src/content/7/fi/osa7d.md
+++ b/src/content/7/fi/osa7d.md
@@ -89,7 +89,7 @@ Tiedoston <i>package.json</i> sisältö voi olla esim. seuraava:
 Asennetaan webpack komennolla
 
 ```js
-npm install --save-dev webpack webpack-cli
+npm install --save-dev webpack webpack-cli@3.3.12
 ```
 
 Webpackin toiminta konfiguroidaan tiedostoon <i>webpack.config.js</i>, laitetaan sen alustavaksi sisällöksi seuraava


### PR DESCRIPTION
Fixed the webpack-cli version to 3.3.12, as webpack-cli is now by default at version 4.0 and that does not work with webpack-dev-server. Easiest way around seems to be to install the latest v3 package. Otherwise webpack-dev-server needs to be changed to webpack serve. And that will need more changes to material.