### PR TITLE
Update part2c.md

### DIFF
--- a/src/content/2/en/part2c.md
+++ b/src/content/2/en/part2c.md
@@ -110,7 +110,7 @@ When an asynchronous operation is completed, or more specifically, at some point
 
 Currently, JavaScript engines are <i>single-threaded</i>, which means that they cannot execute code in parallel. As a result, it is a requirement in practise to use a non-blocking model for executing IO operations. Otherwise, the browser would "freeze" during, for instance, the fetching of data from a server.
 
-Another consequence of this single threaded nature of JavaScript engines is that if some code execution takes up a lot of time, the browser will get stuck for the duration of the execution. If we added the following code at the top of our application:
+Another consequence of this single-threaded nature of JavaScript engines is that if some code execution takes up a lot of time, the browser will get stuck for the duration of the execution. If we added the following code at the top of our application:
 
 ```js
 setTimeout(() => {


### PR DESCRIPTION
Fix typo.
A hyphen is used to create compound words.
The two words joined by the hyphen act as an adjective (single-threaded) that describes a noun (nature) in the sentence.