### PR TITLE
Update part4b.md

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -798,7 +798,7 @@ npm install express-async-errors
 <!-- Kirjaston käyttö on <i>todella</i> helppoa.
  Kirjaston koodi otetaan käyttöön tiedostossa <i>src/app.js</i>: -->
 Using the library is <i>very</i> easy. 
-You introduce the library in <i>src/app.js</i>:
+You introduce the library in <i>app.js</i>:
 
 ```js
 const config = require('./utils/config')


### PR DESCRIPTION
```express-async-errors``` library should be imported to ```app.js``` rather than ```src/app.js```.

This is under "Eliminating the try-catch" section. Modified line 801 of ```part4b.md```.

I have also double checked and noticed that the branch containing completed result of above section does not have ```src``` directory.
Source: https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-5