### PR TITLE
Material correction

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -1241,7 +1241,7 @@ The question is, how can we validate that the string is of a specific form?
 One possible way to write the type guard would be this:
 
 ```js
-const isWeather = (str: any): str is Weather => {
+const isWeather = (str: string): str is Weather => {
   return ['sunny', 'rainy', 'cloudy', 'stormy' ].includes(str);
 };
 ```


### PR DESCRIPTION
str: string is refactored to param: any , in the later material.
See L#1278 describing the same.