### PR TITLE
Update part4c.md

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -430,6 +430,17 @@ usersRouter.get('/', async (request, response) => {
 })
 ```
 
+For making new user in production or development environemnt, you may send POST request to ```/api/users/``` via Postman or REST Client in following format:
+```js
+{
+    "notes": [],
+    "username": "root",
+    "name": "Superuser",
+    "password": "salainen"
+}
+
+```
+
 The list looks like this:
 
 ![](../../images/4/9.png)


### PR DESCRIPTION
Added more steps for "creating users" so that it is easier to follow.

POST request implementations for ```users``` were mentioned and tested, but it did not mention how to send POST request to server via Postman or VS code's REST Client.

Following is what I did (and worked) to send the user information:
![fs4c-how_to_make_POST_for_userInfo](https://user-images.githubusercontent.com/12351886/96954991-7206aa00-14a9-11eb-9d0e-e97856ba1828.PNG)

Reason why I made this pull request is because it felt like there was a missing step between implementing ```GET``` request and actually displaying the contents of DB on ```localhost:3001/api/users```. I understand that readers should know how to make request via Postman/Rest Client/etc by now, and hence you do not have to make this addition if you feel like this addition is redundant.