### PR TITLE
Fix padding inconsistency in example menu

### DIFF
--- a/src/content/7/en/part7c.md
+++ b/src/content/7/en/part7c.md
@@ -212,8 +212,8 @@ Lastly, let's alter the application's navigation menu to use Bootstrap's [Navbar
       </Nav.Link>
       <Nav.Link href="#" as="span">
         {user
-          ? <em>{user} logged in</em>
-          : <Link to="/login">login</Link>
+          ? <em style={padding}>{user} logged in</em>
+          : <Link style={padding} to="/login">login</Link>
         }
     </Nav.Link>
     </Nav>


### PR DESCRIPTION
The example Bootstrap hamburger menu in Part 7c contains padding for every item except for the user item, so it was slightly to the left of the other menu elements. Applying the same padding to it as everything else fixes the issue.

Before:
![image](https://user-images.githubusercontent.com/64725469/97512458-ea64e380-195f-11eb-941f-f0446976f55f.png)

After:
![image](https://user-images.githubusercontent.com/64725469/97512394-c903f780-195f-11eb-8a6a-3a979eeac266.png)
