### PR TITLE
fix faq broken links

### DIFF
--- a/src/content/0/zh/part0a.md
+++ b/src/content/0/zh/part0a.md
@@ -213,21 +213,21 @@ React Native 章节的学分
 
 即使你没有因为考试而注册公开大学，只要你完成了结业所需的足够的练习数量，你就可以从 [提交系统](https://studies.cs.helsinki.fi/stats/courses/fullstackopen) 中下载课程的结业证书。如果只想要获得结业证书，你不需要提供芬兰社保账号。
 
-### Expanding a previously completed course 
+### Expanding on a previously completed course 
 【拓展之前完成的课程】
 
 <!-- If you have already taken the course either as a MOOC or as a University Course, you can now expand your course. -->
 
 如果你已经参与过这门课程，无论是在大学课程还是公开课，你都可以基于之前的课来进行拓展。
 
-#### Expanding Full stack open 2019 
+#### Expanding on Full stack open 2019 
 【拓展全栈公开课 2019】
 
 <!-- You can just pick up where you left! If you wish to resubmit a whole part, please contact the course personel. -->
 
 你可以续接你上次学习的进度！ 如果您希望重新提交整个章节的内容，请与课程负责人联系。
 
-#### Expanding other course instance
+#### Expanding on other instances of this course
 【拓展其他课程】
 
 <!-- You can substitute <i>parts</i> of this course with parts you have previously submitted. For example, if you have previously completed the 3-credit course, you can substitute parts 0-3 of this course with the parts you have previously completed. You can only substitute parts in sequence, so you cannot for example substitute parts 0 and 2 but now complete part 1. -->

--- a/src/content/pages/faq.json
+++ b/src/content/pages/faq.json
@@ -1,11 +1,11 @@
 {
-  "fi": [   
+  "fi": [
     {
       "title": "Ilmestyykö kurssista uusi versio 2021?",
       "text": [
         "Kyllä, uusi versio ilmestyy 15.3.2021.<br><br>Uusi versio ei tule poikkeamaan radikaalisti nykyisestä. <br><br>Vuoden 2020 versiota voi laajentaa 2021 versiossa <a href='/osa0/yleista#aiemmin-suoritetun-kurssin-taydentaminen'>tämän</a> ohjeen mukaisesti."
       ]
-    },    
+    },
     {
       "title": "Miten kurssille ilmoittaudutaan?",
       "text": [
@@ -17,7 +17,7 @@
       "text": [
         "Kurssin laajuus on <a href='/osa0/yleista#arvosteluperusteet'>riippuen tekemiesi tehtävien määrästä</a> 3-9 opintopistettä. Suoritettuasi kurssin voit jatkaa aihepiiriin syventymistä 1-10 opintopisteen laajuisen <a href='/osa0/yleista#full-stack-harjoitustyo'>Full stack -harjoitustyön</a> parissa."
       ]
-    },    
+    },
     {
       "title": "Milloin on tehtävien ja kokeen deadline?",
       "text": [
@@ -29,7 +29,7 @@
       "text": [
         "Tehtävät palautetaan GitHubin kautta ja merkitsemällä tehdyt tehtävät palautussovellukseen, lue lisää <a href='/osa0/yleista#tehtavien-palauttaminen'>täältä</a>."
       ]
-    },    
+    },
     {
       "title": "Pitääkö jokainen osa palauttaa omaan repositorioon?",
       "text": [
@@ -47,13 +47,13 @@
       "text": [
         "Saat suoritusmerkinnän sen jälkeen kun olet tehnyt hyväksyttävään suoritukseen oikeuttavan määrän tehtäviä, suorittanut kokeen hyväksytysti ja ilmoittanut palautussovelluksessa olevasi valmis kurssin suorituksen kanssa. Viimeinen mahdollinen suorituspäivä on 10.1.2021. Lue lisää <a href='/osa0/yleista#arvosteluperusteet'>täältä</a>."
       ]
-    },  
+    },
     {
       "title": "Mikä kurssilla on muuttunut edellisestä vuodesta?",
       "text": [
         "Osiossa 0-4 on ainoastaan vähäisiä muutoksia. Osa 5d eli Cypress.io-kirjastolla tapahtuva <i>end to end -testaus</i> on suurelta osin uusi. Custom hookien käsittely on siirretty osasta 5 hieman laajennettuna osaan 7. <br><br>Reduxia käsittelevä osa 6 keskittyy ensisijaisesti reduxin uuteen hook-perustaiseen apiin. Myös osassa 7 käsiteltävä react-router on uudistunut käyttämään hook-apia. Vähäiselle ylläpidolle jäänyt Semantic UI React -kirjasto on korvattu MaterialUI-kirjastolla. <br><br>GraphQL:ää käsittelevä osa 8 on kokenut paljon päivityksiä erityisesti Apollo Clientin osalta, jonka hook-perustaiset apit ovat vihdoin stabiloituneet. TypeScriptiin keskittyvä osa 9 on kokonaan uusi. <br><br> Viime vuoden kurssimateriaali on nähtävissä osoitteessa <a href='https://fullstackopen-2019.github.io/'>https://fullstackopen-2019.github.io/</a>"
       ]
-    },        
+    },
     {
       "title": "Voinko laajentaa aiempaa kurssisuoritustani?",
       "text": [
@@ -71,9 +71,9 @@
     {
       "title": "Will there be a new course 2021?",
       "text": [
-        "Yes, the new version of the course will start 15.3.2021.<br><br>There won't be major changes in the course content.<br><br> The 2020 version can be expanded in the 2021 version, see more <a href='/part0/general_info#expanding-a-previously-completed-course'>here</a>. "
+        "Yes, the new version of the course will start 15.3.2021.<br><br>There won't be major changes in the course content.<br><br> The 2020 version can be expanded in the 2021 version, see more <a href='/en/part0/general_info#expanding-on-a-previously-completed-course'>here</a>. "
       ]
-    },    
+    },
     {
       "title": "How do I sign up for the course?",
       "text": [
@@ -121,7 +121,7 @@
       "text": [
         "Yes, certificate is available to all who pass the course by 10th January 2021. You can download the certificate after completing the course from the exercise submission system. For the course certificate signup to Open university and Finnish social security number are not needed."
       ]
-    },    
+    },
     {
       "title": "Do I need a Finnish social security number to get the course certificate?",
       "text": [
@@ -139,13 +139,13 @@
       "text": [
         "There are only minor changes to parts 0-4. Part 5d, <i>end to end -testing</i> using the Cypress.io- library is almost completely new material.  Using custom hooks has been moved from part 5 to part 7 with some new content. <br><br> Part 6, which is about Redux, concentrates on the new, hook-based, redux api. The material on react-router in part 7 has also been updated to use the hook-api. Semantic UI React has been replaced with the MaterialUI library due to lack of maintenance. <br><br> Part 8 on GraphQL has major updates especially on Apollo Client, which finally has stable hook based apis. Part 9 on TypeScript is completely new. <br><br> Last year's course material can be found from <a href='https://fullstackopen-2019.github.io/'>https://fullstackopen-2019.github.io/</a>."
       ]
-    },        
+    },
     {
       "title": "I started the course last year, how should I continue?",
       "text": [
-        "Read more from <a href='/en/part0/general_info#expanding-a-previously-completed-course'>here</a>"
+        "Read more from <a href='/en/part0/general_info#expanding-on-a-previously-completed-course'>here</a>"
       ]
-    },    
+    },
     {
       "title": "I heard that I could get a job interview by completing the course.",
       "text": [
@@ -157,9 +157,9 @@
     {
       "title": "2021 年会有新的课程吗?",
       "text": [
-        "是的，新版本的课程会在2021年3月15号开始。<br><br>课程的主体内容不会有太大的改变。<br><br> 2021年版本的内容会在2020年的基础上做进一步的延伸，可以参考 <a href='/zh/part0/general_info#expanding-a-previously-completed-course'>这里</a>. "
+        "是的，新版本的课程会在2021年3月15号开始。<br><br>课程的主体内容不会有太大的改变。<br><br> 2021年版本的内容会在2020年的基础上做进一步的延伸，可以参考 <a href='/zh/part0/%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86#expanding-on-a-previously-completed-course'>这一章节</a>的内容'>这里</a>. "
       ]
-    },  
+    },
     {
       "title": "我如何报名这门课程呢？",
       "text": [
@@ -207,7 +207,7 @@
       "text": [
         "是的，所有在2021年1月10日之前通过课程的人都可获得证书。您可以从练习提交系统中完成课程后下载证书。 对于课程证书，不需要注册公开大学和芬兰的社保号码。"
       ]
-    },    
+    },
     {
       "title": "为了获得课程的结业证书，我需要芬兰的社保号码吗？",
       "text": [
@@ -229,7 +229,7 @@
     {
       "title": "我是从去年的课程开始学习的，我应该怎么续接今年的课程呢？",
       "text": [
-        "阅读更多 <a href='/zh/part0/general_info#expanding-a-previously-completed-course'>这一章节</a>的内容。"
+        "阅读更多 <a href='/zh/part0/%E5%9F%BA%E7%A1%80%E7%9F%A5%E8%AF%86#expanding-on-a-previously-completed-course'>这一章节</a>的内容。"
       ]
     }
   ]


### PR DESCRIPTION
Mainly due to this [commit](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/commit/b8ac9d97c8b9907c5f1e06309434b274ddd24b15) links from FAQ sections on expanding on a previous course are now leading to 404 (or anchor is not working). This commit fixes the URLs and also syncs the typo changes between ZH and EN parts. Also, my IDE seems to have removed some extra spaces.