### PR TITLE
Update osa0a.md

### DIFF
--- a/src/content/0/fi/osa0a.md
+++ b/src/content/0/fi/osa0a.md
@@ -139,7 +139,7 @@ email matti.luukkainen@helsinki.fi tai Telegram @mluukkai. Kerro github-tunnukse
 
 #### Vuoden 2020 kurssin jatkaminen vuoden 2021 versiossa
 
-Vuoden 2020 versio päättyy 10.1.2021. Jos kurssi jää kesken, voit jatkaa sitä taas 15.3.2021 uudem version alkaessa!
+Vuoden 2020 versio päättyy 10.1.2021. Jos kurssi jää kesken, voit jatkaa sitä taas 15.3.2021 uuden version alkaessa!
 
 #### Kurssin jonkin muun version täydentäminen
 


### PR DESCRIPTION
typo in section "Vuoden 2020 kurssin jatkaminen vuoden 2021 versiossa".
Changed "...uudem version alkaessa" to "...uuden version alkaessa".