### PR TITLE
Update part5c.md: Make getByText as a method of component

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -300,7 +300,7 @@ const mockHandler = jest.fn()
 The test finds the button <i>based on the text</i> from the rendered component and clicks the element:
 
 ```js
-const button = getByText('make not important')
+const button = component.getByText('make not important')
 fireEvent.click(button)
 ```
 


### PR DESCRIPTION
I think it's need to mention that getByText is a method of component.
So, let's add 'component' before.