### PR TITLE
Fix multiple e.g. and i.e. usage

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -272,7 +272,7 @@ If the project was created with create-react-app, this problem is easy to solve.
 }
 ```
 
-After a restart, the React development environment will work as a [proxy](https://create-react-app.dev/docs/proxying-api-requests-in-development/). If the React code does an HTTP request to a server address at <i>http://localhost:3000</i> not managed by the React application itself (i.e when requests are not about fetching the CSS or JavaScript of the application), the request will be redirected to the server at <i>http://localhost:3001</i>. 
+After a restart, the React development environment will work as a [proxy](https://create-react-app.dev/docs/proxying-api-requests-in-development/). If the React code does an HTTP request to a server address at <i>http://localhost:3000</i> not managed by the React application itself (i.e. when requests are not about fetching the CSS or JavaScript of the application), the request will be redirected to the server at <i>http://localhost:3001</i>. 
 
 Now the frontend is also fine, working with the server both in development- and production mode. 
 

--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -558,7 +558,7 @@ CI=true npm test -- --coverage
 
 <!-- Melko primitiivinen HTML-muotoinen raportti generoituu hakemistoon <i>coverage/lcov-report</i>. HTML-muotoinen raportti kertoo mm. yksittäisen komponenttien testaamattomat koodirivit: -->
 A quite primitive HTML report will be generated to the <i>coverage/lcov-report</i> directory. 
-The report will tell us i.e the lines of untested code in each component:
+The report will tell us the lines of untested code in each component:
 
 ![](../../images/5/19ea.png)
 

--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -567,7 +567,7 @@ const numbers = [1, 2, 3]
 ```
 
 
-<code>...numbers</code> breaks the array up into individual elements, which can place i.e to another array. 
+<code>...numbers</code> breaks the array up into individual elements, which can be placed in another array.
 
 ```js
 [...numbers, 4, 5]

--- a/src/content/7/en/part7e.md
+++ b/src/content/7/en/part7e.md
@@ -275,7 +275,7 @@ However, MVC-architecture is not usually mentioned when talking about React-appl
 
 Because both React and [Flux](https://facebook.github.io/flux/docs/in-depth-overview) were created at Facebook one could say that using React only as a UI library is the intended use case. Following the Flux-architecture adds some overhead to the application, and if we're talking about a small application or prototype it might be a good idea to use React "wrong", since [over-engineering](https://en.wikipedia.org/wiki/Overengineering) rarely yields an optimal result.
 
-As I mentioned at the end of [part 6](/en/part6/connect#redux-and-the-component-state), the React [Context-api](https://reactjs.org/docs/context.html) offers one alternative solution for centralized state management without the need for third party libraries such as redux. You can read more about this i.e [here](https://www.simplethread.com/cant-replace-redux-with-hooks/) and [here](https://hswolff.com/blog/how-to-usecontext-with-usereducer/).
+As I mentioned at the end of [part 6](/en/part6/connect#redux-and-the-component-state), the React [Context-api](https://reactjs.org/docs/context.html) offers one alternative solution for centralized state management without the need for third party libraries such as redux. You can read more about this [here](https://www.simplethread.com/cant-replace-redux-with-hooks/) and [here](https://hswolff.com/blog/how-to-usecontext-with-usereducer/).
 
 ### React/node-application security
 

--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -20,7 +20,7 @@ The GraphQL philosophy is very different from REST. REST is <i>resource based</i
 The resource basedness of REST works well in most situations. However, it can be a bit awkward sometimes. 
 
 
-Let's assume our bloglist application contains social media like functionality, and we would i.e. want to show a list of all the blogs the users who have commented on the blogs we follow have added. 
+Let's assume our bloglist application contains social media like functionality, and we would e.g. want to show a list of all the blogs the users who have commented on the blogs we follow have added. 
 
 
 If the server implemented a REST API, we would probably have to do multiple HTTP-requests from the browser before we had all the data we wanted. The requests would also return a lot of unnecessary data, and the code on the browser would probably be quite complicated. 

--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -233,7 +233,7 @@ module.exports = mongoose.model('User', schema)
 ```
 
 
-Every user is connected to a bunch of other persons in the system through the _friends_ field. The idea is that when a user, i.e <i>mluukkai</i>, adds a person, i.e <i>Arto Hellas</i>, to the list, the person is added to their _friends_ list. This way logged in users can have their own, personalized, view in the application. 
+Every user is connected to a bunch of other persons in the system through the _friends_ field. The idea is that when a user, e.g. <i>mluukkai</i>, adds a person, e.g. <i>Arto Hellas</i>, to the list, the person is added to their _friends_ list. This way logged in users can have their own, personalized, view in the application. 
 
 
 Logging in and identifying the user are handled the same way we used in [part 4](/en/part4/token_authentication) when we used REST, by using tokens. 
@@ -350,7 +350,7 @@ The object returned by context is given to all resolvers as their <i>third param
 So our code sets the object corresponding to the user who made the request to the _currentUser_ field of the context. If there is no user connected to the request, the value of the field is undefined. 
 
 
-The resolver of the _me_ query is very simple, it just returns the logged in user it receives in the _currentUser_ field of the third parameter of the resolver, _context_. It's worth noting that if there is no logged in user, i.e there is no valid token in the header attached to the request, the query returns <i>null</i>:
+The resolver of the _me_ query is very simple, it just returns the logged in user it receives in the _currentUser_ field of the third parameter of the resolver, _context_. It's worth noting that if there is no logged in user, i.e. there is no valid token in the header attached to the request, the query returns <i>null</i>:
 
 ```js
 Query: {

--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -42,7 +42,7 @@ one using pure JavaScript. The only differences are, that the <i>.js</i> and <i>
 <!-- Now, let's take a look at the <i>tsconfig.json</i> file that has been created for us. Everything should be more or less fine within the file, except for that at the moment the configuration also allows JavaScript files to be compiled, because <i>allowJs</i> is set to <i>true</i>. That would be fine if you need to mix TypeScript and JavaScript (e.g. if you are in the middle of transforming a JavaScript project into TypeScript or some other reason), but we want our app to be purely TypeScript, so let's change that setting to <i>false</i>. -->
 Now, let's take a look at the <i>tsconfig.json</i> file that has been created for us.
 Everything in it should be more or less fine, except at the moment the configuration allows compiling JavaScript files, because <i>allowJs</i> is set to <i>true</i>.
-That would be fine if you need to mix TypeScript and JavaScript (e.g if you are in the process of transforming a JavaScript project into TypeScript or something like that), but we want to create a pure TypeScript app, so let's change that configuration to  <i>false</i>.
+That would be fine if you need to mix TypeScript and JavaScript (e.g. if you are in the process of transforming a JavaScript project into TypeScript or something like that), but we want to create a pure TypeScript app, so let's change that configuration to  <i>false</i>.
 
 <!-- Earlier we added eslint to help us enforce coding style in backend, so let's do the same with this app. We do not need to install any dependencies since create-react-app has taken care of that already. -->
 In our previous project we used eslint to help us enforce coding style, and we'll do the same with this app. We do not need to install any dependencies, since create-react-app has taken care of that already.
@@ -587,7 +587,7 @@ It is always a good idea to start the application and click around to verify you
 You can also browse the folder structure to get insight into the application's functionality and/or the architecture used.
 These are not always clear, and the developers might have chosen a way to organize code that is not familiar to you.
 The [sample project](https://github.com/fullstack-hy2020/patientor) used in the rest of this part is organized featurewise.
-You can see what pages the application has, and some general components e.g modals and state.
+You can see what pages the application has, and some general components, e.g. modals and state.
 Keep in mind that the features may have
 different scopes. For example modals are visible UI level components whereas the state is comparable to business logic
 and keeps the data organized under the hood for the rest of the app to use. 
@@ -957,7 +957,7 @@ Response should look as follows:
 Create a page for showing a patient's full information in the frontend. 
 
 <!-- Patient information should be accessible when clicking e.g. the patients name. -->
-User should be able to access a patient's information e.g by clicking the patient's name.
+User should be able to access a patient's information e.g. by clicking the patient's name.
 
 Fetch the data from the enpoint created in the previous exercise. After fetching the patient information from the backend, add the fetched information to the application's state. Do not fetch the information if it already is in the app state, i.e. if the user is visiting the same patient's information many times. 
 


### PR DESCRIPTION
### Fix possible misuse of e.g. and i.e. in English version.

i.e. should mean "that is".

e.g. should mean "for example".