### PR TITLE
Resolved bug in part 6a exercise 6.8 expected code

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -1281,8 +1281,8 @@ const App = () => {
   return (
     <div>
       <h2>Anecdotes</h2>
+      <AnecdoteList />
       <AnecdoteForm />
-      <AnecdoteList  />
     </div>
   )
 }


### PR DESCRIPTION
This may be a little minor and resolved in this PR:

The order of  `<AnecdoteForm />` and `<AnecdoteList  />`  in part 6a exercise 6.8's expected code should be flipped else it will not match the expected image of how the application should look like as shown below:

**The excerpt**

> After completing these exercises, your application should look like this: 
![](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/blob/source/src/content/images/6/3.png?raw=true)

Thank you