### PR TITLE
Add eslint exception for eslintrc.js

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -743,6 +743,7 @@ npm install --save-dev eslint-plugin-jest
 Let's create a <i>.eslintrc.js</i> file with the following contents:
 
 ```js
+/* eslint-env node */
 module.exports = {
   "env": {
       "browser": true,


### PR DESCRIPTION
`module.exports` is marked as error, because this file uses a node env, not es6