### PR TITLE
part3d: improve clarity around toJSON

### DIFF
--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -100,7 +100,7 @@ When validating an object fails, we return the following default error message f
 
 ### Promise chaining
 
-Many of the route handlers changed the response data into the right format by calling the _toJSON_ method. When we created a new note, the _toJSON_ method was called for the object passed as a parameter to _then_:
+Many of the route handlers changed the response data into the right format by implicitly calling the _toJSON_ method from _response.json_. For the sake of an example, we can also perform this operation explicitly by calling the _toJSON_ method on the object passed as a parameter to _then_:
 
 ```js
 app.post('/api/notes', (request, response, next) => {


### PR DESCRIPTION
When introducing the toJSON override in _3c Backend connected to a database_, it is (correctly) said that:

> When the response is sent in the JSON format, the toJSON method of each object in the array is called automatically by the JSON.stringify method.

But then _3d Promise chaining_ gives example of supposedly the same code it shows explicit of use of toJSON. This made me question whether I had read and implemented the previous part correctly. In my proposed changes, I wanted to hint to the reader that code shown in 3d is not the same as in 3c.
