### PR TITLE
Update part7f.md

### DIFF
--- a/src/content/7/en/part7f.md
+++ b/src/content/7/en/part7f.md
@@ -94,7 +94,7 @@ Users should be able to access the view by clicking the name of the blog post in
 
 ![](../../images/7/46.png)
 
-After you're done with this exercise, the functionality that was implemented in exercise 5.6 is no longer necessary. Clicking a blog post no longer needs to expand the item in the list and display the details of the blog post.
+After you're done with this exercise, the functionality that was implemented in exercise 5.7 is no longer necessary. Clicking a blog post no longer needs to expand the item in the list and display the details of the blog post.
 
 #### 7.16: Navigation
 


### PR DESCRIPTION
Fix reference to a past Exercise, Clicking to expand a blog post was implemented in Exercise 5.7 not 5.6