### PR TITLE
Update part4c.md

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -156,7 +156,7 @@ const mongoose = require('mongoose')
 const userSchema = new mongoose.Schema({
   username: String,
   name: String,
-  passwordHash: String,
+  password: String,
   notes: [
     {
       type: mongoose.Schema.Types.ObjectId,
@@ -261,7 +261,7 @@ usersRouter.post('/', async (request, response) => {
   const user = new User({
     username: body.username,
     name: body.name,
-    passwordHash,
+    password:passwordHash,
   })
 
   const savedUser = await user.save()


### PR DESCRIPTION
on line 259  we reference  ``` body.password  ```  yet in the user schema there's an attribute of passwordHash instead. For better clarity, I see it much better to instead name the property passwordHash defined in the user schema to password since in the tests created later on for example on line 315 and 367  a new user is created with a property of password and not passwordHash.
on line 264   we directly place the passwordHash created in a new User object without assigning it to the appropriate user property.