### PR TITLE
remove double "and" in setup section of exercises

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -435,7 +435,7 @@ Exercises 9.1.-9.7. will be all made to the same node project. Create the projec
 }
 ```
 
-The <i>tsconfig.json</i> file is used to define how the TypeScript compiler should interpret the code, how strictly the compiler should work, which files to watch or ignore, and and [much much more](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
+The <i>tsconfig.json</i> file is used to define how the TypeScript compiler should interpret the code, how strictly the compiler should work, which files to watch or ignore, and [much much more](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 For now we will only use the compiler option [noImplicitAny](https://www.typescriptlang.org/tsconfig#noImplicitAny), that makes it mandatory to have types for all variables used.
 
 #### 9.1 Body mass index


### PR DESCRIPTION
In the setup section of the exercises, before exercise 1 there are two "and".
Proposal to remove the second "and".