### PR TITLE
Browsers actually know how to load modules

### DIFF
--- a/src/content/7/en/part7d.md
+++ b/src/content/7/en/part7d.md
@@ -16,7 +16,7 @@ We can not rely on the black magic of create-react-app forever and it's time for
 ### Bundling
 
 
-We have implemented our applications by dividing our code into separate modules that have been <i>imported</i> to places that require them. Even though ES6 modules are defined in the ECMAScript standard, no browser actually knows how to handle code that is divided into modules.
+We have implemented our applications by dividing our code into separate modules that have been <i>imported</i> to places that require them. Even though ES6 modules are defined in the ECMAScript standard, only modern browser actually know how to handle code that is divided into modules.
 
 
 For this reason, code that is divided into modules must be <i>bundled</i> for browsers, meaning that all of the source code files are transformed into a single file that contains all of the application code. When we deployed our React frontend to production in [part 3](/en/part3/deploying_app_to_internet), we performed the bundling of our application with the _npm run build_ command. Under the hood, the npm script bundles the source code using webpack which produces the following collection of files in the <i>build</i> directory:


### PR DESCRIPTION
As proof, I developed an Aalto project that only uses ES6 modules, and I divided the code into multiple files, of which I only load the entry point: https://fcole90.github.io/interactive_bayesian_optimization/study.html

You can see at the bottom
```html
<script type="module">
  import {ui} from "./static/libs/ui.js";
  let app = new ui.Application();
  app.exec();
</script>
```

JS modules: https://github.com/fcole90/interactive_bayesian_optimization/tree/master/interactive_bayesian_optimisation/static/libs

