### PR TITLE
Fix parenthesis in 5b code example

### DIFF
--- a/src/content/5/fi/osa5b.md
+++ b/src/content/5/fi/osa5b.md
@@ -640,11 +640,11 @@ import PropTypes from 'prop-types'
 
 const Togglable = React.forwardRef((props, ref) => {
   // ..
-}
+})
 
 Togglable.propTypes = {
   buttonLabel: PropTypes.string.isRequired
-})
+}
 ```
 
 Jos propsia ei määritellä, seurauksena on konsoliin tulostuva virheilmoitus


### PR DESCRIPTION
The closing parenthesis for forwardRef was misplaced in the Finnish version, so Togglable's PropTypes were defined in the wrong place.