### PR TITLE
Update: Part 2a > React Import and JSX

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -432,9 +432,13 @@ const Note = ({ note }) => {
 export default Note
 ```
 
-Because this is a React-component, we must import React. 
+We import React on the first line of the module.
 
 The last line of the module [exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) the declared module, the variable <i>Note</i>.
+
+Please note that on recent versions of React it is no longer necessary to import React to use JSX syntax, however it is still important to learn as there are billions of lines of old React code that still need the React import. The same applies to documentation and examples of React that you may stumble across on the internet.
+
+We would still need to import React in order to use Hooks or other exports that React provides. Read more about this [here](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
 Now the file that is using the component - <i>index.js</i> - can [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) the module: 
 

--- a/src/content/2/es/part2a.md
+++ b/src/content/2/es/part2a.md
@@ -429,9 +429,13 @@ const Note = ({ note }) => {
 export default Note
 ```
 
-Debido a que este es un componente de React, debemos importar React. 
+Importamos React en la primera línea del módulo.
 
 La última línea del módulo [exporta](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) el módulo declarado, la variable <i>Note</i>.
+
+Toma en cuenta que en versiones recientes de React ya no es necesario importar React para usar sintaxis JSX, sin embargo sigue siendo importante conocer su uso, ya que hay miles de millones de líneas de código antiguo de React que aún necesitan importar React. Lo mismo se aplica a la documentación y los ejemplos de React con los que puede tropezar en Internet.
+
+Si necesitamos importar React para usar Hooks y otras funciones exportadas que React provee. Lea más sobre esto [aquí](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
 Ahora el archivo que está usando el componente - <i>index.js</i> - puede [importar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import ) el módulo:
 


### PR DESCRIPTION
Update en/part2a.md and es/part2a.md to add note about React import
as new JSX transform no longer needs the import
More info: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

Related to #1113