### PR TITLE
avoid import error

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -549,7 +549,8 @@ Let's specify the following configurations in our <i>tsconfig.json</i> file:
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "moduleResolution": "node"
   }
 }
 ```


### PR DESCRIPTION
Avoids import error saying: `Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?`