### PR TITLE
Remove the suggestion to install extension.

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -14,7 +14,7 @@ In addition to language features we will also have a strong emphasis in tooling.
 
 ### Setting things up
 
-Install TypeScript support to your editor of choice. For [Visual Studio Code](https://code.visualstudio.com/) you need the [typescript hero](https://marketplace.visualstudio.com/items?itemName=rbbit.typescript-hero) extension. 
+Install TypeScript support to your editor of choice. [Visual Studio Code](https://code.visualstudio.com/) works natively with TypeScript. 
 
 <!-- As mentioned before, TypeScript code is not runnable by itself, but it first needs to be compiled into runnable JavaScript code. When TypeScript is compiled into JavaScript, the code becomes subject for type erasure. This means that type annotations, interfaces, type aliases, and other type system constructs are removed from the code and the result is pure ready-to-run JavaScript. -->
 As mentioned earlier, TypeScript code is not executable by itself but it has to be first compiled into executable JavaScript. 


### PR DESCRIPTION
Remove the suggestion to install TypeScript Hero extension since it has not been updated in 3 years, it's repository has disappeared and Visual Studio Code has full TypeScript support out of the box.