### PR TITLE
Remove NoteForm highlight (and className?) in 5c

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -484,7 +484,7 @@ const NoteForm = ({ createNote }) => {
   }
 
   return (
-    <div className="formDiv"> // highlight-line
+    <div className="formDiv">
       <h2>Create a new note</h2>
 
       <form onSubmit={addNote}>


### PR DESCRIPTION
The NoteForm code adds a "formDiv" class to the div surrounding the form, and that change is highlighted, but this class isn't actually necessary for the NoteForm test. The test grabs the form itself and the input field. 

I don't think the change is significant enough to be highlighted, since it's not relevant to test, and maybe adding the class isn't necessary as well.