### PR TITLE
Changing the way to get a random integer

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -736,7 +736,7 @@ Let's add the functionality for adding new notes and changing their importance:
 
 ```js
 const generateId = () =>
-  Number((Math.random() * 1000000).toFixed(0))
+  Math.floor(Math.random() * 1000000)
 
 const App = () => {
   const addNote = (event) => {


### PR DESCRIPTION
transforming a random number into a string without the decimal part and then parsing it as a number seems like a roundabout and counter intuitive way of doing things, it's probably better to just use math.floor()