### PR TITLE
Add support for using `cra` as an alias.

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -20,6 +20,18 @@ $ cd part1
 
 Every command, here and in the future, starting with the character <em>$</em> is typed into a terminal prompt, aka the command-line. The character <em>$</em> is not to be typed out because it represents the prompt.
 
+Since, `npx create-react-app my-app-name` is a little tedious to write in terminal everytime you need to create a react app, you can alias `npx create-react-app` to `cra` in your `~/.bashrc` file with below command. Windows users need to use `git-bash` terminal for this(generally installed with `git`).
+
+```bash
+$ echo "alias cra='npx create-react-app'" >> ~/.bashrc && source ~/.bashrc
+```
+
+Now, creating the creating react app reduces to 
+
+```bash
+$ cra my-app-name
+```
+
 The application is run as follows
 
 ```bash

--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -26,10 +26,11 @@ Since, `npx create-react-app my-app-name` is a little tedious to write in termin
 $ echo "alias cra='npx create-react-app'" >> ~/.bashrc && source ~/.bashrc
 ```
 
-Now, creating the creating react app reduces to 
+Now, creating a react app reduces to below command
 
 ```bash
 $ cra my-app-name
+$ cd my-app-name
 ```
 
 The application is run as follows


### PR DESCRIPTION
Using cra alias would allow users to create cra apps really handy instead of writing whole lot of text while creating simple react apps.