### PR TITLE
Update osa4b.md

### DIFF
--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -847,7 +847,7 @@ beforeEach(async () => {
 })
 ```
 
-Funktio tallettaa tietokantaan taulukon _helper.initialNotes_ nollannen ja ensimmäisen alkion, kummankin erikseen taulukon alkioita indeksöiden. Ratkaisu on ok, mutta jos haluaisimme tallettaa alustuksen yhteydessä kantaan useampia alkioita, olisi toisto parempi ratkaisu:
+Funktio tallettaa tietokantaan taulukon _helper.initialNotes_ nollannen ja ensimmäisen alkion, kummankin erikseen taulukon alkioita indeksoiden. Ratkaisu on ok, mutta jos haluaisimme tallettaa alustuksen yhteydessä kantaan useampia alkioita, olisi toisto parempi ratkaisu:
 
 ```js
 beforeEach(async () => {


### PR DESCRIPTION
"Indeksoida" on Kielitoimiston sanakirjassa, mutta "indeksöidä" ei ole.
![image](https://user-images.githubusercontent.com/36277211/110691755-35381700-81ee-11eb-8fed-167ce989dfc6.png)
