### PR TITLE
Change in one of the headings

### DIFF
--- a/src/content/1/fi/osa1c.md
+++ b/src/content/1/fi/osa1c.md
@@ -531,7 +531,7 @@ Tälläkin kertaa tapahtumankäsittelijät on määritelty oikein, sillä <i>onC
 </button>
 ```
 
-### Tilan vieminen alikomponenttiin
+### Vie tila alakomponenttiin
 
 Reactissa suositaan pieniä komponentteja, joita on mahdollista uusiokäyttää monessa osissa sovellusta ja jopa useissa eri sovelluksissa. Refaktoroidaan koodiamme vielä siten, että yhden komponentin sijaan koostamme laskurin näytöstä ja kahdesta painikkeesta.
 


### PR DESCRIPTION
Updated " Tilan vieminen alikomponenttiin " to " Vie tila alakomponenttiin ". This is because " Tilan vieminen alikomponenttiin " translates as "Exporting space to subcomponents" in English while " Vie tila alakomponenttiin " translates as "exporting state to subcomponents". I feel like it should be state, not space