### PR TITLE
Typo in the interface definiton

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -431,7 +431,7 @@ interface CoursePartBase {
 }
 
 interface CourseNormalPart extends CoursePartBase {
-  type: "described";
+  type: "normal";
   description: string;
 }
 interface CourseProjectPart extends CoursePartBase {


### PR DESCRIPTION
At the exercise 9.15  there is a typo in a definition of the CourseNormalPart interface, the current type is "described", for some reason, should be changed to "normal". Otherwise it causes compilation error since type "described" is not mentioned anywhere, and type "normal" is used in the courseParts array