### PR TITLE
remove dash from "end to end -testing"

### DIFF
--- a/src/content/0/zh/part0a.md
+++ b/src/content/0/zh/part0a.md
@@ -266,7 +266,7 @@ React Native 章节的学分
 
 <!-- ### Changed since the last year -->
 <!-- 【与去年相比课程的改变】 -->
-<!-- There is only minor changes to parts 0-4. Part 5d, <i>end to end -testing</i> using the Cypress.io- library is almost completely new material.  Using custom hooks has been moved from part 5 to part 7 with some new content. -->
+<!-- There is only minor changes to parts 0-4. Part 5d, <i>end to end testing</i> using the Cypress.io- library is almost completely new material.  Using custom hooks has been moved from part 5 to part 7 with some new content. -->
 <!-- * 对于0~4章节，只有一些很小的改动。 -->
 <!-- * 第5d章节，<i>端到端测试</i> 利用了[Cypress.io](https://www.cypress.io) 这个库，这几乎是全新的内容。使用自定义钩子（custom hook）的内容已经从第5章节转移到了第7章节，并添加了一些新的内容。 -->
 

--- a/src/content/11/en/part11b.md
+++ b/src/content/11/en/part11b.md
@@ -322,7 +322,7 @@ Once you have fixed all the issues and the Pokedex is bug-free, the workflow run
 
 The current set of tests use [jest](https://jestjs.io/) to ensure that the React components work as intended. This is exactly the same thing that is done in section [Testing React apps](/en/part5/testing_react_apps) of part 5. 
 
-Testing components in isolation is quite useful but that still does not ensure that the system as a whole works as we wish. To have more confidence about this, let us write a couple of really simple end to end -tests with the [Cypress](https://www.cypress.io/) library simillarly what we do in section [End to end -testing](/en/part5/end_to_end_testing) of part 5. 
+Testing components in isolation is quite useful but that still does not ensure that the system as a whole works as we wish. To have more confidence about this, let us write a couple of really simple end to end -tests with the [Cypress](https://www.cypress.io/) library simillarly what we do in section [End to end testing](/en/part5/end_to_end_testing) of part 5. 
 
 So, setup cypress (you'll find [here](/en/part5/end_to_end_testing/) all info you need) and use this test at first:
 

--- a/src/content/11/zh/part11b.md
+++ b/src/content/11/zh/part11b.md
@@ -456,7 +456,7 @@ push您的代码并导航到“Actions”标签，然后点击左侧新创建的
 <!-- The current set of tests use [jest](https://jestjs.io/) to ensure that the React components work as intended. This is exactly the same thing that is done in section [Testing React apps](/en/part5/testing_react_apps) of part 5.  -->
 当前的测试集使用 [jest](https://jestjs.io/) 来确保 React 组件按预期的方式工作。这和第5章[测试 React 应用](/zh/part5/testing_react_apps)一模一样。
 
-<!-- Testing components in isolation is quite useful but that still does not ensure that the system as a whole works as we wish. To have more confidence about this, let us write a couple of really simple end to end -tests with the [Cypress](https://www.cypress.io/) library simillarly what we do in section [End to end -testing](/en/part5/end_to_end_testing) of part 5.  -->
+<!-- Testing components in isolation is quite useful but that still does not ensure that the system as a whole works as we wish. To have more confidence about this, let us write a couple of really simple end to end -tests with the [Cypress](https://www.cypress.io/) library simillarly what we do in section [End to end testing](/en/part5/end_to_end_testing) of part 5.  -->
 隔离测试组件是非常有用的，但是这仍然不能确保系统作为一个整体按照我们希望的那样工作。为了对此有更多的信心，让我们用 [Cypress](https://www.cypress.io/) 库简单地编写几个非常简单的端到端测试，就像我们在第5部分的 [End-To-End 测试](/zh/part5/end_to_end_testing)一样。
 
 

--- a/src/content/partnavigation/partnavigation.js
+++ b/src/content/partnavigation/partnavigation.js
@@ -94,7 +94,7 @@ module.exports = {
       a: 'Login in frontend',
       b: 'props.children and proptypes',
       c: 'Testing React apps',
-      d: 'End to end -testing',
+      d: 'End to end testing',
     },
     '6': {
       a: 'Flux-architecture and Redux',


### PR DESCRIPTION
In the english version of the site "end to end -testing" is used.

It isn't clear to me why there is a `-` before testing and I've never seen that style used anywhere before.

I'm assuming it's a typo and removing it. But if it isn't a typo I'm curious to learn more about why that style was used.

Cheers