### PR TITLE
typo in description of parseComment function

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -1084,7 +1084,7 @@ const parseComment = (comment: unknown): string => {
 }
 ```
 
-The function gets a parameter of type <i>any</i> and returns it as type <i>string</i> if it exists and is of the right type.
+The function gets a parameter of type <i>unknown</i> and returns it as type <i>string</i> if it exists and is of the right type.
 
 The string validation function looks like this
 


### PR DESCRIPTION
parseComment function receives a param 'comment' of type 'unknown'. However, the description of function given below the code describe it as type 'any'.
This typo is fixed.