### PR TITLE
Specify install of CORS is to backend repo

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -51,7 +51,7 @@ Keep in mind, that [same origin policy](https://developer.mozilla.org/en-US/docs
 
 We can allow requests from other <i>origins</i> by using Node's [cors](https://github.com/expressjs/cors) middleware.
 
-Install <i>cors</i> with the command
+In your backend repository, install <i>cors</i> with the command
 
 ```bash
 npm install cors


### PR DESCRIPTION
Clarify that user to be installing the `cors` middleware to backend repo.  There is a lot of back and forth between frontend and backend in this chapter and this part is particularly confusing since changing something in the backend fixes a problem in the frontend.  This edit will help make things less confusing.