### PR TITLE
Update part5b.md

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -401,7 +401,7 @@ There are many ways to implement closing the form from the parent component, but
 Let's make the following changes to the <i>App</i> component:
 
 ```js
-import React, { useState, useRef } from 'react' // highlight-line
+import React, { useState, useEffect, useRef } from 'react' // highlight-line
 
 const App = () => {
   // ...


### PR DESCRIPTION
Line 404 suggests to use only < import React, { useState, useRef } from 'react' >, without any mention to useEffect. It does imply substituting 
the whole line, what is not expected. The proposed change reinstate useEffect import.