### PR TITLE
Mentioning what void type is

### DIFF
--- a/src/content/9/en/part9a.md
+++ b/src/content/9/en/part9a.md
@@ -92,7 +92,7 @@ func((result) => {
 ```
 
 First we have a declaration of a [type alias](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-aliases) called <i>CallsFunction</i>.
-CallsFunction is a function type with one parameter <i>callback</i>. The parameter <i>callback</i> is of type function which takes a string parameter and returns [any](http://www.typescriptlang.org/docs/handbook/basic-types.html#any) value.  As we will learn later in this part <i>any</i> is a kind of "wildcard" type that can represent any type.
+CallsFunction is a function type with one parameter <i>callback</i>. The parameter <i>callback</i> is of type function which takes a string parameter and returns [any](http://www.typescriptlang.org/docs/handbook/basic-types.html#any) value.  As we will learn later in this part <i>any</i> is a kind of "wildcard" type that can represent any type. Also CallsFunction returns [void](https://www.typescriptlang.org/docs/handbook/basic-types.html#void) type.
 
 Next we define the function <i>func</i> of  type <i>CallsFunction</i>. From the function's type we can infer that its parameter function cb will only accept a string argument. To demonstrate this, there is also an example where the parameter function is called with a numeric value, which will cause an error in TypeScript. 
 


### PR DESCRIPTION
There was no mention of what void type is, so there should be something. So I added a short mention and provided link with official typescript docs