### PR TITLE
Updated deprecated link

### DIFF
--- a/src/content/9/en/part9a.md
+++ b/src/content/9/en/part9a.md
@@ -92,7 +92,7 @@ func((result) => {
 ```
 
 First we have a declaration of a [type alias](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-aliases) called <i>CallsFunction</i>.
-CallsFunction is a function type with one parameter <i>callback</i>. The parameter <i>callback</i> is of type function which takes a string parameter and returns [any](http://www.typescriptlang.org/docs/handbook/basic-types.html#any) value.  As we will learn later in this part <i>any</i> is a kind of "wildcard" type that can represent any type.
+CallsFunction is a function type with one parameter <i>callback</i>. The parameter <i>callback</i> is of type function which takes a string parameter and returns [any](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any) value.  As we will learn later in this part <i>any</i> is a kind of "wildcard" type that can represent any type.
 
 Next we define the function <i>func</i> of  type <i>CallsFunction</i>. From the function's type we can infer that its parameter function cb will only accept a string argument. To demonstrate this, there is also an example where the parameter function is called with a numeric value, which will cause an error in TypeScript. 
 


### PR DESCRIPTION
When the link for type any (https://www.typescriptlang.org/docs/handbook/basic-types.html#any) is visited\,
The message is shown on the page as:
```
This page has been deprecated

This handbook page has been replaced, go to the new page
```
So the link has been updated with new handbook (2) documentation.