### PR TITLE
updated broken link about Redux reducer rules

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -352,7 +352,7 @@ const noteReducer = (state = [], action) => {
 The state is now an Array. <i>NEW\_NOTE</i>- type actions cause a new note to be added to the state with the [push](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) method. 
 
 
-The application seems to be working, but the reducer we have declared is bad. It breaks the [basic assumption](https://github.com/reactjs/redux/blob/master/docs/basics/Reducers.md#handling-actions) of Redux reducer that reducers must be [pure functions](https://en.wikipedia.org/wiki/Pure_function).
+The application seems to be working, but the reducer we have declared is bad. It breaks the [basic assumption](https://redux.js.org/tutorials/fundamentals/part-3-state-actions-reducers#rules-of-reducers) of Redux reducer that reducers must be [pure functions](https://en.wikipedia.org/wiki/Pure_function).
 
 
 Pure functions are such, that they <i>do not cause any side effects</i> and they must always return the same response when called with the same parameters. 


### PR DESCRIPTION
The link https://github.com/reduxjs/redux/blob/master/docs/basics/Reducers.md#handling-actions returns 404 not found.
Redux Github repo changed their `Reducers.md` to https://github.com/reduxjs/redux/blob/master/docs/faq/Reducers.md
However there is no longer a subsection titled `#handling-actions` there. There are some passing references to "basic rules of reducers" but they are listed under different subheadings.

I found this link that does a really good job of outlining the rules of reducers point by point, and give a clear definition of pure functions at the same time:
https://redux.js.org/tutorials/fundamentals/part-3-state-actions-reducers#rules-of-reducers