### PR TITLE
matching the store code in Redux DevTools with 6-2 branch

### DIFF
--- a/src/content/6/en/part6b.md
+++ b/src/content/6/en/part6b.md
@@ -422,13 +422,14 @@ When debugging, in addition to the browser extension we also have the software l
 npm install --save-dev redux-devtools-extension
 ```
 
-We'll have to slightly change the definition of the store to get the library up and running:
+We'll have to slightly change the definition of the store in `index.js` to get the library up and running:
 
 ```js
 // ...
 import { createStore, combineReducers } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension' // highlight-line
 
+// ...
 import noteReducer from './reducers/noteReducer'
 import filterReducer from './reducers/filterReducer'
 
@@ -443,8 +444,8 @@ const store = createStore(
   composeWithDevTools()
   // highlight-end
 )
-
-export default store
+      
+// ...
 ```
 
 Now when you open the console, the <i>redux</i> tab looks like this:


### PR DESCRIPTION
There is `export default store` at the end of the code snippet, but we have not refactored the store into its own `store.js` file at this point yet. The store definition is still in `index.js` in the [6-2 branch](https://github.com/FullStack-HY/redux-notes/blob/part6-2/src/index.js) (which is mentioned shortly after the snippet.)

On that note, is Exercise 6.9 a bit too early? Creating `store.js` is done in the next section Part6c. I'm fine with doing it before the lesson does it, it's simple enough.