### PR TITLE
Update osa8d.md

### DIFF
--- a/src/content/8/fi/osa8d.md
+++ b/src/content/8/fi/osa8d.md
@@ -312,7 +312,7 @@ Tee sovellukseen näkymä, joka näyttää kirjautuneelle käyttäjälle käytt�
 
 #### 8.21 Genren kirjat GraphQL:llä
 
-Tietyn genren kirjoihin rajoittamisen voi tehdä kokonaan React-sovelluksen puolella. Voit merkitä tämän tehtävän, jos rajaat näytettävät kirjat tehtävässä 8.5 palvelimelle toteutetun suoran GraphQL-kyselyn avulla. 
+Tietyn genren kirjoihin rajoittamisen voi tehdä kokonaan React-sovelluksen puolella. Voit merkitä tämän tehtävän, jos rajaat lempigenren kirjojen näkymässä näytettävät kirjat tehtävässä 8.5 palvelimelle toteutetun suoran GraphQL-kyselyn avulla. 
 
 Tämä **tehtävä on haastava** ja niin kurssin tässä vaiheessa jo kuuluukin olla. Muutama vihje
 


### PR DESCRIPTION
Tämän osan tehtävän 8.21 suomenkielisestä tehtävänannosta ei alkuperäisessä muodossa ilmennyt selkeästi, että missä näkymässä kirjojen rajaaminen tulisi tehdä graphQL-kyselyllä; books vai recommendations-näkymässä. 

Englanninkielinen materiaali sen sijaan mainitsee asian selkeästi: "To complete this exercise, you should filter the books in the **recommendations page** using a GraphQL query to the server."