### PR TITLE
Remove unnecessary lines of part8e.md

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -248,7 +248,7 @@ import {
   ApolloClient, ApolloProvider, HttpLink, InMemoryCache, 
   split  // highlight-line
 } from '@apollo/client'
-import { setContext } from 'apollo-link-context'
+import { setContext } from '@apollo/client/link/context'
 
 // highlight-start
 import { getMainDefinition } from '@apollo/client/utilities'

--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -305,12 +305,6 @@ ReactDOM.render(
 )
 ```
 
-For this to work, we have to install some dependencies:
-
-```bash
-npm install @apollo/client subscriptions-transport-ws
-```
-
 The new configuration is due to the fact that the application must have an HTTP connection as well as a WebSocket connection to the GraphQL server.
 
 ```js

--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -313,7 +313,7 @@ const wsLink = new WebSocketLink({
   options: { reconnect: true }
 })
 
-const httpLink = createHttpLink({
+const httpLink = new HttpLink({
   uri: 'http://localhost:4000',
 })
 ```


### PR DESCRIPTION
Use @apollo/client/link/context for setContext instead of apollo-link-context.

Remove unused dependency subscriptions-transport-ws since we use the WebSocketLink from apollo-client.