### PR TITLE
Update link for type guard page

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -1094,7 +1094,7 @@ const isString = (text: unknown): text is string => {
 };
 ```
 
-The function is a so called [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards). That means it is a function which returns a boolean <i>and</i> which has a <i>type predicate</i> as the return type. In our case the type predicate is
+The function is a so called [type guard](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates). That means it is a function which returns a boolean <i>and</i> which has a <i>type predicate</i> as the return type. In our case the type predicate is
 
 ```js
 text is string

--- a/src/content/9/es/part9c.md
+++ b/src/content/9/es/part9c.md
@@ -1027,7 +1027,7 @@ const isString = (text: any): text is string => {
 };
 ```
 
-La función es un [tipo de protección](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards). Eso significa que es una función que devuelve un booleano <i>y</i> que tiene un <i>predicado</i> de tipo como tipo de retorno. En nuestro caso, el tipo de predicado es
+La función es un [tipo de protección](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates). Eso significa que es una función que devuelve un booleano <i>y</i> que tiene un <i>predicado</i> de tipo como tipo de retorno. En nuestro caso, el tipo de predicado es
 
 
 ```js

--- a/src/content/9/zh/part9c.md
+++ b/src/content/9/zh/part9c.md
@@ -1451,8 +1451,8 @@ const isString = (text: unknown): text is string => {
 
 
 
-<!-- The function is a so called [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards). That means it is a function which returns a boolean <i>and</i> which has a <i>type predicate</i> as the return type. In our case the type predicate is -->
-这个函数是一个所谓的[类型保护](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards)。 这意味着它是一个返回布尔型的函数，它的返回类型是<i>类型谓词</i>。 在我们的示例中，类型谓词是
+<!-- The function is a so called [type guard](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates). That means it is a function which returns a boolean <i>and</i> which has a <i>type predicate</i> as the return type. In our case the type predicate is -->
+这个函数是一个所谓的[类型保护](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates)。 这意味着它是一个返回布尔型的函数，它的返回类型是<i>类型谓词</i>。 在我们的示例中，类型谓词是
 
 ```js
 text is string


### PR DESCRIPTION
The existing link to the type guard page displays a deprecation notice with a link to the updated page. This redirects users to the new link directly.