### PR TITLE
 babel-eslint is now @babel/eslint-parser. 

### DIFF
--- a/src/content/10/en/part10a.md
+++ b/src/content/10/en/part10a.md
@@ -127,7 +127,7 @@ Now that the repository is created, run <em>git init</em> within your applicatio
 Now that we are somewhat familiar with the development environment let's enhance our development experience even further by configuring a linter. We will be using [ESLint](https://eslint.org/) which is already familiar to us from the previous parts. Let's get started by installing the dependencies:
 
 ```shell
-npm install --save-dev eslint babel-eslint eslint-plugin-react
+npm install --save-dev eslint @babel/eslint-parser eslint-plugin-react
 ```
 
 Next, let's add the ESLint configuration into a <i>.eslintrc</i> file into the <i>rate-repository-app</i> directory with the following content:
@@ -141,7 +141,7 @@ Next, let's add the ESLint configuration into a <i>.eslintrc</i> file into the <
     }
   },
   "extends": ["eslint:recommended", "plugin:react/recommended"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "env": {
     "browser": true
   },

--- a/src/content/10/en/part10d.md
+++ b/src/content/10/en/part10d.md
@@ -49,7 +49,7 @@ To use the eslint-plugin-jest plugin in ESLint, we need to include it in the plu
 {
   "plugins": ["react", "jest"],
   "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jest/recommended"], // highlight-line
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "env": {
     "browser": true
   },


### PR DESCRIPTION
babel-eslint is deprecated and is now @babel/eslint-parser. This package will no longer receive updates.
npm: https://www.npmjs.com/package/babel-eslint
babel: https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint