### PR TITLE
Small fix to REST client in part3.md

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -710,7 +710,22 @@ Because the notes in the application are only saved to memory, the list of notes
 
 If you use Visual Studio Code, you can use the VS Code [REST client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) plugin instead of Postman.
 
-Once the plugin is installed, using it is very simple. We make a directory at the root of application named <i>requests</i>. We save all the REST client requests in the directory as files that end with the <i>.rest</i> extension.
+Once the plugin is installed, we have to make a small change to our index.js definition in order for it to work:
+  
+```js
+const express = require('express')
+const app = express()
+
+//...
+
+const PORT = 3001
+app.listen(PORT,'localhost')  // highlight-line
+
+//...
+
+```
+  
+Using REST Client it is very simple. We make a directory at the root of application named <i>requests</i>. We save all the REST client requests in the directory as files that end with the <i>.rest</i> extension.
 
 Let's create a new <i>get\_all\_notes.rest</i> file and define the request that fetches all notes.
 


### PR DESCRIPTION
I had an issue when using REST client as indicated in the course: the requests were being sent to 127.0.0.1 instead of localhost:3001. Searching the web I found a closed issue on the plugin's Github page, where the following response solved the problem for me: https://github.com/Huachao/vscode-restclient/issues/122#issuecomment-673163671.
I added the fix in the shortest way I could! Hope this helps somebody