### PR TITLE
webpack devServer 'contentBase' changed to 'static'

### DIFF
--- a/src/content/7/fi/osa7d.md
+++ b/src/content/7/fi/osa7d.md
@@ -508,7 +508,7 @@ const config = {
   },
   // highlight-start
   devServer: {
-    contentBase: path.resolve(__dirname, 'build'),
+    static: path.resolve(__dirname, 'build'),
     compress: true,
     port: 3000,
   },


### PR DESCRIPTION
Ran into an error while doing this part.

![Screenshot from 2021-08-24 07-20-33](https://user-images.githubusercontent.com/57188012/130555268-2031c5f0-b125-490e-8589-32e16efe8a12.png)

By looking at some [discussions](https://github.com/webpack/webpack-dev-server/issues/2958#issuecomment-757141969), I think contentBase isn't valid anymore. 
Doesn't seem to be in the devServer [docs](https://webpack.js.org/configuration/dev-server/) either