### PR TITLE
remove: unnecessary material about act function

### DIFF
--- a/src/content/10/en/part10d.md
+++ b/src/content/10/en/part10d.md
@@ -376,15 +376,6 @@ describe('SignIn', () => {
   });
 });
 ```
-
-You might face the following warning messages: <em>Warning: An update to Formik inside a test was not wrapped in act(...)</em>. This happens because <em>fireEvent</em> method calls cause asynchronous calls in Formik's internal logic. You can get rid of these messages by wrapping each of the <em>fireEvent</em> method calls with the [act](https://www.native-testing-library.com/docs/next/api-main#act) function like this:
-
-```javascript
-await act(async () => {
-  // call the fireEvent method here
-});
-```
-
 </div>
 
 <div class="content">


### PR DESCRIPTION
act function is by default wrapped around fireEvent and a couple other methods, so there is no need for it to be in the material. I tested without the act function and it worked fine, without any errors.
Link to act docs:
https://callstack.github.io/react-native-testing-library/docs/api/#act