### PR TITLE
Update Heroku CLI npm package links in Part 3b

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -321,7 +321,7 @@ You will probably have to do some small changes to the frontend, at least to the
 
 Deploy the backend to the internet, for example to Heroku. 
 
-**NB** the command _heroku_ works on the department's computers and the freshman laptops. If for some reason you cannot [install](https://devcenter.heroku.com/articles/heroku-cli) Heroku to your computer, you can use the command [npx heroku-cli](https://www.npmjs.com/package/heroku-cli).
+**NB** the command _heroku_ works on the department's computers and the freshman laptops. If for some reason you cannot [install](https://devcenter.heroku.com/articles/heroku-cli) Heroku to your computer, you can use the command [npx heroku](https://www.npmjs.com/package/heroku).
 
 Test the deployed backend with a browser and Postman or VS Code REST client to ensure it works. 
 

--- a/src/content/3/fi/osa3b.md
+++ b/src/content/3/fi/osa3b.md
@@ -300,7 +300,7 @@ Joudut todennäköisesti tekemään frontendiin erinäisiä pieniä muutoksia ai
 
 Vie sovelluksen backend Internetiin, esim. Herokuun. 
 
-**Huom.** komento _heroku_ toimii laitoksen koneilla ja fuksikannettavilla. Jos et jostain syystä saa [asennettua](https://devcenter.heroku.com/articles/heroku-cli) herokua koneellesi, voit käyttää komentoa [npx heroku-cli](https://www.npmjs.com/package/heroku-cli).
+**Huom.** komento _heroku_ toimii laitoksen koneilla ja fuksikannettavilla. Jos et jostain syystä saa [asennettua](https://devcenter.heroku.com/articles/heroku-cli) herokua koneellesi, voit käyttää komentoa [npx heroku](https://www.npmjs.com/package/heroku).
 
 Testaa selaimen ja Postmanin tai VS Coden REST-clientin avulla, että Internetissä oleva backend toimii.
 

--- a/src/content/3/zh/part3b.md
+++ b/src/content/3/zh/part3b.md
@@ -416,8 +416,8 @@ const baseUrl = '/api/notes'
 <!-- Deploy the backend to the internet, for example to Heroku.  -->
 将后端部署到互联网，例如 Heroku。
 
-<!-- **NB** the command _heroku_ works on the department's computers and the freshman laptops. If for some reason you cannot [install](https://devcenter.heroku.com/articles/heroku-cli) Heroku to your computer, you can use the command [npx heroku-cli](https://www.npmjs.com/package/heroku-cli). -->
-注意：命令 heroku 在部门的电脑和新生的笔记本电脑上可以工作。 如果由于某种原因不能[安装](https://devcenter.Heroku.com/articles/Heroku-cli) Heroku 到你的计算机，你可以使用命令[npx heroku-cli](https://www.npmjs.com/package/heroku-cli)。
+<!-- **NB** the command _heroku_ works on the department's computers and the freshman laptops. If for some reason you cannot [install](https://devcenter.heroku.com/articles/heroku-cli) Heroku to your computer, you can use the command [npx heroku](https://www.npmjs.com/package/heroku). -->
+注意：命令 heroku 在部门的电脑和新生的笔记本电脑上可以工作。 如果由于某种原因不能[安装](https://devcenter.Heroku.com/articles/Heroku-cli) Heroku 到你的计算机，你可以使用命令[npx heroku](https://www.npmjs.com/package/heroku)。
 
 <!-- Test the deployed backend with a browser and Postman or VS Code REST client to ensure it works.  -->
 使用浏览器和Postman或 VS Code REST 客户端测试已部署的后端，以确保其工作正常。


### PR DESCRIPTION
In Part 3b: Updated Heroku CLI's npm package links ('heroku-cli' has been renamed 'heroku'). 
Old link (deprecated): [https://www.npmjs.com/package/heroku-cli](https://www.npmjs.com/package/heroku-cli)
Updated link: [https://www.npmjs.com/package/heroku](https://www.npmjs.com/package/heroku)
