### PR TITLE
Remove mongoose.connect() options parameter for

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -149,7 +149,7 @@ const password = process.argv[2]
 const url =
   `mongodb+srv://fullstack:${password}@cluster0-ostce.mongodb.net/test?retryWrites=true`
 
-mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false, useCreateIndex: true })
+mongoose.connect(url)
 
 const noteSchema = new mongoose.Schema({
   content: String,
@@ -382,7 +382,7 @@ const mongoose = require('mongoose')
 const url =
   'mongodb+srv://fullstack:sekred@cluster0-ostce.mongodb.net/note-app?retryWrites=true'
 
-mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false, useCreateIndex: true })
+mongoose.connect(url)
 
 const noteSchema = new mongoose.Schema({
   content: String,
@@ -448,7 +448,7 @@ const url = process.env.MONGODB_URI // highlight-line
 
 console.log('connecting to', url) // highlight-line
 
-mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false, useCreateIndex: true })
+mongoose.connect(url)
 // highlight-start
   .then(result => {
     console.log('connected to MongoDB')
@@ -494,7 +494,7 @@ const url = process.env.MONGODB_URI
 
 console.log('connecting to', url)
 
-mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false, useCreateIndex: true })
+mongoose.connect(url)
   .then(result => {
     console.log('connected to MongoDB')
   })


### PR DESCRIPTION
Going through the tutorial, Node give errors regarding options parameters of mongoose.connect(url, { ... }). Going off https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options for Mongoose 6.0, the options are true by default and should be removed.