### PR TITLE
tslib @types/node Package Missing

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -39,6 +39,12 @@ As we remember from [part 3](/en/part3) an npm project is set by running the com
 ```
 npm install --save-dev ts-node typescript
 ```
+  
+In some cases, you should install this package as well
+
+```
+npm install -D tslib @types/node
+```
 
 and set up <i>scripts</i> within the package.json: 
 


### PR DESCRIPTION
In my case, if I only install typescript and ts-node, I couldn't run the multiplicator example, also I couldn't console.log anything. But if I install this package everything runs well.

@Edit: Sorry, the @types/node is mentioned later in the material so I think the only package that's missing is the tslib