### PR TITLE
fix: broken link for react-spring

### DIFF
--- a/src/content/10/en/part10d.md
+++ b/src/content/10/en/part10d.md
@@ -1072,7 +1072,7 @@ Because styled-components processes the style definitions, it is possible to use
 
 > react-spring is a spring-physics based animation library that should cover most of your UI related animation needs. It gives you tools flexible enough to confidently cast your ideas into moving interfaces.
 
-[React-spring](https://www.react-spring.io/) is a library that provides a clean [hook API](https://www.react-spring.io/docs/hooks/basics) for animating React Native components.
+[React-spring](https://www.react-spring.io/) is a library that provides a clean [hook API](https://react-spring.io/hooks/use-chain) for animating React Native components.
 
 #### React Navigation
 


### PR DESCRIPTION
They do not have overview of all hooks, so I linked the first hook that they provide.