### PR TITLE
Fix broken github link in Part 4b

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -1204,7 +1204,7 @@ There is still room for improvement, but it is time to move forward.
 This way of testing the API, by making HTTP requests and inspecting the database with Mongoose, is by no means the only nor the best way of conducting API-level integration tests for server applications. There is no universal best way of writing tests, as it all depends on the application being tested and available resources.
 
 
-You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this Github repository](https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6).
+You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6).
 
 </div>
 

--- a/src/content/4/es/part4b.md
+++ b/src/content/4/es/part4b.md
@@ -1161,7 +1161,7 @@ Todavía hay margen de mejora, pero es hora de seguir adelante.
 
 Esta forma de probar la API, al realizar solicitudes HTTP e inspeccionar la base de datos con Mongoose, no es de ninguna manera la única ni la mejor forma de realizar pruebas de integración a nivel de API para aplicaciones de servidor. No existe una mejor forma universal de escribir pruebas, ya que todo depende de la aplicación que se esté probando y de los recursos disponibles.
 
-Puede encontrar el código para nuestra aplicación actual en su totalidad en la rama <i>part4-6</i> de [este repositorio de Github](https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6).
+Puede encontrar el código para nuestra aplicación actual en su totalidad en la rama <i>part4-6</i> de [este repositorio de Github](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6).
 
 </div>
 

--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -1143,7 +1143,7 @@ Testeihin jää vielä parannettavaa mutta on jo aika siirtyä eteenpäin.
 
 Käytetty tapa API:n testaamiseen, eli HTTP-pyyntöinä tehtävät operaatiot ja tietokannan tilan tarkastelu Mongoosen kautta ei ole suinkaan ainoa tai välttämättä edes paras tapa tehdä API-tason integraatiotestausta. Universaalisti parasta tapaa testien tekoon ei ole, vaan kaikki on aina suhteessa käytettäviin resursseihin ja testattavaan ohjelmistoon.
 
-Sovelluksen tämänhetkinen koodi on kokonaisuudessaan [githubissa](https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6), branchissa <i>part4-6</i>
+Sovelluksen tämänhetkinen koodi on kokonaisuudessaan [githubissa](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6), branchissa <i>part4-6</i>
 
 </div>
 

--- a/src/content/4/zh/part4b.md
+++ b/src/content/4/zh/part4b.md
@@ -1345,8 +1345,8 @@ afterAll(() => {
 <!-- This way of testing the API, by making HTTP requests and inspecting the database with Mongoose, is by no means the only nor the best way of conducting API-level integration tests for server applications. There is no universal best way of writing tests, as it all depends on the application being tested and available resources. -->
 这种通过发出 HTTP 请求和用 Mongoose 检查数据库来测试 API 的方法，绝不是对服务器应用进行 API 集成测试的唯一或最佳方法。 没有通用的编写测试的最佳方法，因为这完全取决于被测试的应用和可用资源。
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this Github repository](https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6). -->
-您可以在[this Github repository](https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6)的<i>part4-6</i> 分支中找到我们当前应用的全部代码。
+<!-- You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6). -->
+您可以在[this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6)的<i>part4-6</i> 分支中找到我们当前应用的全部代码。
 
 </div>
 


### PR DESCRIPTION
Broken link: [https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6](https://github.com/fullstack-hy/part3-notes-backend/tree/part4-6)

Fixed link: [https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6)