### PR TITLE
Update part3a.md

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -615,7 +615,7 @@ Let's fix the issue by changing the id parameter from a string into a [number](h
 ```js
 app.get('/api/notes/:id', (request, response) => {
   const id = Number(request.params.id)
-  const note = notes.find(note => note.id === id)
+  const note = notes.find(note => note.id == id)
   response.json(note)
 })
 ```


### PR DESCRIPTION
On line 618, it should be note.id == id, as note.id refers to a number, but id refers to a string. As such the type is not matched, but the value is.