### PR TITLE
Added warning regarding node bug 10638

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -207,6 +207,13 @@ Let's run our code again.
 
 The data is now stored in the right database. The view also offers the <i>create database</i> functionality, that can be used to create new databases from the website. Creating the database like this is not necessary, since MongoDB Atlas automatically creates a new database when an application tries to connect to a database that does not exist yet.
 
+You might encounter following error when running node mongo.js <password> command: 
+  ```bash
+const utf8Encoder = new TextEncoder();
+ReferenceError: TextEncoder is not defined
+```
+Above problem is caused by the known  [node bug](https://github.com/Automattic/mongoose/issues/10638) affecting older node versions 10.x (which might be still used  used as default in some distributions for example Ubuntu 20.04LTS). You might either upgrade node on your OS to newer version or deploy  code to heroku which already uses latest node version.
+  
 ### Schema
 
 After establishing the connection to the database, we define the [schema](http://mongoosejs.com/docs/guide.html) for a note and the matching [model](http://mongoosejs.com/docs/models.html):


### PR DESCRIPTION
When using default node version installed from ubuntu 20.04 repo (10.x version)   running comand node mongo.js <password> following error will be displayed:
const utf8Encoder = new TextEncoder();
ReferenceError: TextEncoder is not defined

I was able to find corresponding bug report:
https://github.com/Automattic/mongoose/issues/10638

Also I was able to run the  same code without any problems through heroku console.