### PR TITLE
Add additional task for part6d

### DIFF
--- a/src/content/6/en/part6d.md
+++ b/src/content/6/en/part6d.md
@@ -618,7 +618,7 @@ The <i>redux store</i> is currently being accessed by the components through the
 Modify the <i>Notification</i> component so that it uses the _connect_ function instead of the hooks. 
 #### 6.20 anecdotes and connect, step2
 
-Do the same for the <i>Filter</i> and <i>AnecdoteForm</i> components.
+Do the same for the <i>Filter</i>, <i>AnecdoteForm</i>, and <i>AnecdoteList</i> components.
 #### 6.21 anecdotes, the grand finale
 
 You (probably) have one nasty bug in your application. If the user clicks the vote button multiple times in a row, the notification is displayed funnily. For example, if a user votes twice in three seconds, 


### PR DESCRIPTION
Instructions in part6d ask you to modify the `Notification`, `Filter`, and `AnecdoteForm` components to use the connect function rather than hooks, but this leaves `AnecdoteList` alone unmodified at the end of the part. I think it's a worthwhile exercise to modify `AnecdoteList` as well since it's the only component in this project that maps both states and dispatches to props when using connect.

In my commit I've added this extra task to exercise 6.20, but it could alternatively be added as a separate exercise (e.g. as exercise 6.21, then `anecdotes, the grand finale` gets pushed to exercise 6.22).