### PR TITLE
[docs]: Update Part8a setup of GraphQL playground

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -407,7 +407,24 @@ has a resolver which returns <i>all</i> objects from the _persons_ array.
 ### GraphQL-playground
 
 When Apollo-server is run on development mode (_node filename.js_), it starts a [GraphQL-playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/) to address [http://localhost:4000/graphql](http://localhost:4000/graphql). This is very useful for a developer, and can be used to make queries to the server. 
-
+To set it up, you should first of all install `apollo-server-core` like so:
+```bash
+npm install apollo-server-core
+```
+after which you import it to the file where you create the ApolloServer, like this:
+```js
+const { ApolloServerPluginLandingPageGraphQLPlayground } = require("apollo-server-core");
+```
+once you've installed it, you can put it to use by calling it in when passing plugins to the ApolloServer constructor function, like this:
+```js
+const server = new ApolloServer({
+	typeDefs,
+	resolvers,
+	plugins: [
+		ApolloServerPluginLandingPageGraphQLPlayground(),
+	],
+});
+```
 Let's try it out
 
 ![](../../images/8/1.png)


### PR DESCRIPTION
While I was going through the course I had a hard time figuring out what to do because after I ran `node index.js` I was taken to https://studio.apollographql.com/sandbox/explorer instead of what was shown, I had to do a bit of digging and googling to find out what I was missing and so I decided to update the course with my findings.