### PR TITLE
Put request instead of get

### DIFF
--- a/src/content/2/en/part2d.md
+++ b/src/content/2/en/part2d.md
@@ -594,7 +594,7 @@ Let's simulate this situation by making the <em>getAll</em> function of the note
 
 ```js
 const getAll = () => {
-  const request = axios.get(baseUrl)
+  const request = axios.put(baseUrl)
   const nonExisting = {
     id: 10000,
     content: 'This note is not saved to server',


### PR DESCRIPTION
Underneath it says:
```
When we try to change the importance of the hardcoded note, we see the following error message in the console. The error says that the backend server responded to our HTTP PUT request with a status code 404 not found.
```
I believe this code sample should have been `.put`