### PR TITLE
Update recommendation for mitigating SQL injection

### DIFF
--- a/src/content/7/en/part7e.md
+++ b/src/content/7/en/part7e.md
@@ -313,7 +313,12 @@ SELECT * FROM Users WHERE name = 'Arto Hell-as'; DROP TABLE Users; --'
 
 
 
-SQL injections are prevented by [sanitizing](https://security.stackexchange.com/questions/172297/sanitizing-input-for-parameterized-queries) the input, which would entail checking that the parameters of the query do not contain any forbidden characters, in this case single quotes. If forbidden characters are found, they are replaced with safe alternatives by [escaping](https://en.wikipedia.org/wiki/Escape_character#JavaScript) them.
+
+SQL injections are prevented using [parameterized queries](https://security.stackexchange.com/questions/230211/why-are-stored-procedures-and-prepared-statements-the-preferred-modern-methods-f). With them, user input isn't mixed with the SQL query, but the database itself inserts the input values at placeholders in the query (usually <code>?</code>).
+
+```js
+execute("SELECT * FROM Users WHERE name = ?", [userName])
+```
 
 
 

--- a/src/content/7/fi/osa7e.md
+++ b/src/content/7/fi/osa7e.md
@@ -284,7 +284,11 @@ eli nimi sisältäisi hipsun <code>'</code>, jonka on SQL:ssä merkkijonon aloit
 SELECT * FROM Users WHERE name = 'Arto Hell-as'; DROP TABLE Users; --'
 ```
 
-SQL-injektiot estetään [sanitoimalla](https://security.stackexchange.com/questions/172297/sanitizing-input-for-parameterized-queries) syöte, eli tarkastamalla, että kyselyjen parametrit eivät sisällä kiellettyjä merkkejä, kuten tässä tapauksessa hipsuja. Jos kiellettyjä merkkejä löytyy, ne korvataan turvallisilla vastineilla [escapettamalla](https://en.wikipedia.org/wiki/Escape_character#JavaScript).
+SQL-injektiot estetään [parametrisoiduilla kyselyillä](https://security.stackexchange.com/questions/230211/why-are-stored-procedures-and-prepared-statements-the-preferred-modern-methods-f). Niissä käyttäjän syötettä ei lisätä lainkaan SQL-kyselyn sekaan, vaan tietokanta itse lisää syötearvot turvallisesti kyselyssä olevien paikkamerkkien (yleensä <code>?</code>) paikalle.
+  
+```js
+execute("SELECT * FROM Users WHERE name = ?", [userName])
+```
 
 Myös NoSQL-kantoihin tehtävät injektiohyökkäykset ovat mahdollisia. Mongoose kuitenkin estää ne [sanitoimalla](https://zanon.io/posts/nosql-injection-in-mongodb) kyselyt. Lisää aiheesta esim. [täällä](https://blog.websecurify.com/2014/08/hacking-nodejs-and-mongodb.html).
 


### PR DESCRIPTION
The current material says that you should escape user input before putting it in a SQL string.

## WRONG. You should basically never put user input in a SQL string.

- The list of people that tried to write SQL sanitation functions, and failed miserably, is long and contains many projects you've heard of. (The list of ways sanitation can go wrong is equally long and contains many things you can't come up with.)
- Parameterized queries were the suggested solution already [in 2008](https://stackoverflow.com/questions/60174/how-can-i-prevent-sql-injection-in-php). Basically every SQL library supports parameterized queries. If yours doesn't, it's far beyond time to upgrade.
- With parameterized queries you have to _try_ to get a SQL injection. And they might even be faster.

See e.g. [this Security.SE post](https://security.stackexchange.com/questions/230211/why-are-stored-procedures-and-prepared-statements-the-preferred-modern-methods-f) (which I'm suggesting for the new reference link), or the _many_ others available, for more explanation. 

This course is, admittedly, not about security, but at least it shouldn't teach insecure methods.