### PR TITLE
Remove props declaration as value is never read

### DIFF
--- a/src/content/1/fi/osa1d.md
+++ b/src/content/1/fi/osa1d.md
@@ -988,7 +988,7 @@ const Button = (props) => (
   </button>
 )
 
-const App = props => {
+const App = () => {
   const [value, setValue] = useState(10)
 
   const setToValue = newValue => {


### PR DESCRIPTION
Remove declaration of 'props' because its value is never read. Then the example code also matches with the English version.