### PR TITLE
Bug fix in use of useImperativeHandle

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -471,7 +471,7 @@ We can now hide the form by calling <i>noteFormRef.current.toggleVisibility()</i
 const App = () => {
   // ...
   const addNote = (noteObject) => {
-    noteFormRef.current.toggleVisibility() // highlight-line
+    noteFormRef.current() // highlight-line
     noteService
       .create(noteObject)
       .then(returnedNote => {     


### PR DESCRIPTION
When `useImperativeHandle` is in the form as below, the ref will be callable in noteFormRef.current() (as stated [here](https://reactjs.org/docs/hooks-reference.html#useref))  

```
 useImperativeHandle(ref, () => {
  return {
    toggleVisibility
    }
  })
```

In order to make it callable with a custom name, the block should be defined as follows (as per [here](https://reactjs.org/docs/hooks-reference.html#useimperativehandle))

```
 useImperativeHandle(ref, () => ({
  toggle: () => {
    toggleVisibility()
    }
  }))
```

This can then be called with noteFormRef.current.toggle().

Proposing to simplify and stick with current definition and changing usage of `noteFormRef.current.toggleVisibility()` to `noteFormRef.current()`