### PR TITLE
Fix: Permissions error "USER node" before WORKDIR

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -231,8 +231,6 @@ One big carelessness we have left is running the application as root instead of 
 
 ```Dockerfile
 FROM node:16
-
-USER node # highlight-line
   
 WORKDIR /usr/src/app
 
@@ -241,6 +239,8 @@ COPY --chown=node:node . .  # highlight-line
 RUN npm ci 
 
 ENV DEBUG=playground:*
+  
+USER node # highlight-line
 
 CMD npm start
 ```


### PR DESCRIPTION
Permission error is raised if "USER node" instruction is defined before WORKDIR.
See the following issue: https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/issues/1520