### PR TITLE
Change toBeDefined() matcher in query selected with not.toBe(null)

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -367,7 +367,7 @@ describe('<Togglable />', () => {
   test('renders its children', () => {
     expect(
       component.container.querySelector('.testDiv')
-    ).toBeDefined()
+    ).not.toBe(null)
   })
 
   test('at start the children are not displayed', () => {


### PR DESCRIPTION
`querySelector` returns `null` if no matches are found: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector

This means that if the class is not found in the test, `querySelector` will return `null` which is not the same as `undefined`, and in fact [is a defined value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null)


 Because of this `expect(<element>).querySelector(<selector>).toBeDefined()` will always pass, regardless of `<selector>` being in the component or not.

`not.toBe(null)` actually checks that matches are found with `querySelector`