### PR TITLE
Fixed link to restcountries.md

### DIFF
--- a/src/content/7/en/part7b.md
+++ b/src/content/7/en/part7b.md
@@ -438,7 +438,7 @@ If no country is found, a message is displayed to the user:
 
 The application is otherwise complete, but in this exercise you have to implement a custom hook _useCountry_, which can be used to search for the details of the country given to the hook as a parameter.
 
-Use the api endpoint [full name](https://restcountries.com/#api-endpoints-full-name) to fetch a country's details in a _useEffect_ hook within your custom hook.
+Use the api endpoint [full name (v2)](https://restcountries.com/#api-endpoints-v2-full-name) to fetch a country's details in a _useEffect_ hook within your custom hook.
 
 Note that in this exercise it is essential to use useEffect's [second parameter](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect) array to control when the effect function is executed.
 


### PR DESCRIPTION
restcountries.com offer a v3 as well that doesn't work with the base app that is provided. Maybe it's a part of the course to figure that out but since the exercises focuses on using hooks it felt a bit farfetched. Suggesting a link that goes to v2 and a clarification in the link.