### PR TITLE
Remove reference to master branch

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -922,7 +922,7 @@ If the data saved in the _body_ variable has the <i>important</i> property, the 
 You can find the code for our current application in its entirety in the <i>part3-1</i> branch of [this github repository](https://github.com/FullStack-HY/part3-notes-backend/tree/part3-1).
 
 
-Notice that the master branch of the repository contains the code from a later version of the application. The code for the current state of the application is specifically in branch [part3-1](https://github.com/FullStack-HY/part3-notes-backend/tree/part3-1).
+The code for the current state of the application is specifically in branch [part3-1](https://github.com/FullStack-HY/part3-notes-backend/tree/part3-1).
 
 ![](../../images/3/21.png)
 


### PR DESCRIPTION
Remove reference to master branch because it does not exist.
Instead, the default branch in the repository is part3-1.