### PR TITLE
exerc 7.7, correct API doc url

### DIFF
--- a/src/content/7/fi/osa7b.md
+++ b/src/content/7/fi/osa7b.md
@@ -411,7 +411,7 @@ jos maata ei löydy, kerrotaan siitä käyttäjälle
 
 Sovellus on muuten valmiiksi toteutettu, mutta joudut tässä tehtävässä toteuttamaan custom hookin _useCountry_, jonka avulla haet hookin parametrina saaman nimisen maan tiedot.
 
-Maan tietojan hakeminen kannattaa hoitaa apin endpointin [full name](https://restcountries.com/#api-endpoints-full-name) avulla, hookin sisällä olevassa _useEffect_-hookissa.
+Maan tietojan hakeminen kannattaa hoitaa apin endpointin [full name(V2)](https://restcountries.com/#api-endpoints-v2-full-name) avulla, hookin sisällä olevassa _useEffect_-hookissa.
 
 Huomaa, että tässä tehtävässä on oleellista hyödyntää useEffectin [toisena parametrina](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect) olevaa taulukkoa sen kontrolloimiseen milloin efektifunktio kannattaa suorittaa. 
 


### PR DESCRIPTION
Current URL takes to the same page as https://restcountries.com/  -  the front page of the documentation. Documentation starts with version 3. It seems that the JSON data format returned from 'full name' endpoint differs from v2. And I assume that the ready coded part of exerc 7.7 expects data returned as v2. I refactured the code in my solution to make it work and later discovered that I used v3 and the exercise expects v2. I found this out by comparing the FI and EN course materials.