### PR TITLE
Import to run GraphQL playground

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -275,7 +275,10 @@ The initial code is as follows:
 
 ```js
 const { ApolloServer, gql } = require('apollo-server')
-
+const {
+  ApolloServerPluginLandingPageGraphQLPlayground
+} = require("apollo-server-core");
+  
 let persons = [
   {
     name: "Arto Hellas",


### PR DESCRIPTION
Without the following import
```
const {
  ApolloServerPluginLandingPageGraphQLPlayground
} = require("apollo-server-core");
```
users will get the following error: `ReferenceError: ApolloServerPluginLandingPageGraphQLPlayground is not defined.`
As reported in [apollographql.com](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages/#graphql-playground-landing-page) "The GraphQL Playground plugin is not installed by default. To install it, import it from apollo-server-core and provide it to the ApolloServer constructor"