### PR TITLE
update action-creator link

### DIFF
--- a/src/content/6/fi/osa6b.md
+++ b/src/content/6/fi/osa6b.md
@@ -494,7 +494,7 @@ Laajenna sovellusta siten, että se näyttää <i>Notification</i>-komponentin a
 
 ![](../../images/6/8ea.png)
 
-Notifikaation asettamista ja poistamista varten kannattaa toteuttaa [action creatorit](https://redux.js.org/basics/actions#action-creators).
+Notifikaation asettamista ja poistamista varten kannattaa toteuttaa [action creatorit](https://redux.js.org/usage/reducing-boilerplate#action-creators).
 
 #### 6.12* paremmat anekdootit, step10
 


### PR DESCRIPTION
documentation has changed from https://redux.js.org/basics/actions#action-creators to https://redux.js.org/usage/reducing-boilerplate#action-creators