### PR TITLE
Umzugin uusi versio

### DIFF
--- a/src/content/13/fi/part13c.md
+++ b/src/content/13/fi/part13c.md
@@ -106,7 +106,7 @@ Talletetaan migraation koodi tiedostoon <i>migrations/20211209\_00\_initialize\_
 Voisimme suorittaa migraatiot komentoriviltä käsin [Sequelizen komentorivityökalun](https://github.com/sequelize/cli) avulla. Päätämme kuitenkin suorittaa migraatiot ohjelmakoodista käsin [Umzug](https://github.com/sequelize/umzug)-kirjastoa käyttäen. Asennetaan kirjasto
 
 ```js
-npm install umzug
+npm install umzug@2.3.0
 ```
 
 Muutetaan tietokantayhteyden muodostavaa tiedostoa <i>utils/db.js</i> seuraavasti:


### PR DESCRIPTION
Umzugista on julkaistu kuusi päivää sitten uusi versio 3.0.0, joka ei ole enää yhteensopiva kurssimateriaalissa esitetyn tavan kanssa käyttää Umzug-kirjastoa. Kurssimateriaalin tapa testattu toimivaksi versiolla 2.3.0.
https://github.com/sequelize/umzug/releases/tag/v3.0.0