### PR TITLE
Change the useEffect second parameter

### DIFF
--- a/src/content/8/en/part8b.md
+++ b/src/content/8/en/part8b.md
@@ -284,7 +284,7 @@ const Persons = ({ persons }) => {
     if (result.data) {
       setPerson(result.data.findPerson)
     }
-  }, [result])
+  }, [result.data])
   // highlight-end
 
 // highlight-start


### PR DESCRIPTION
Changed the second parameter of useEffect from result to result.data.
Maybe I am in the wrong, but I couldn't get it to return to the all persons view without it.
It would, actually, but only for a fraction of the second and then it would switch back to the single person view.
Would love to hear the explanation for that!