### PR TITLE
Fix typo in osa3c.md

### DIFF
--- a/src/content/3/fi/osa3c.md
+++ b/src/content/3/fi/osa3c.md
@@ -162,7 +162,7 @@ const note = new Note({
   important: true,
 })
 
-note.save().then(response => {
+note.save().then(result => {
   console.log('note saved!')
   mongoose.connection.close()
 })


### PR DESCRIPTION
The small code snippets on lines 238 and 257 use ```result``` inside ```then()```, whereas the larger snippet had ```response``` on line 165. Changed ```response``` to ```result```.