### PR TITLE
Fix text to display as inline command

### DIFF
--- a/src/content/12/en/part12c.md
+++ b/src/content/12/en/part12c.md
@@ -331,7 +331,7 @@ services:
     image: busybox
 ```
 
-With _docker-compose up_ the application is available in <http://localhost:3210> at the <i>host machine</i>, but still _docker-compose run debug-helper wget -O - http://hello-front-dev:3000_ works since the port is still 3000 within the docker network.
+With _docker-compose up_ the application is available in <http://localhost:3210> at the <i>host machine</i>, but still `docker-compose run debug-helper wget -O - http://hello-front-dev:3000` works since the port is still 3000 within the docker network.
 
 ![](../../images/12/busybox_networking_drawio.png)
 


### PR DESCRIPTION
The http address is erroneously showing as a clickable link. This address is part of a command which should thus all be formatted as an inline command, denoted enclosed by backticks (`) or other method.