### PR TITLE
Update part4b.md - correction to promiseArray of noteObjects

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -951,7 +951,7 @@ beforeEach(async () => {
 
   const noteObjects = helper.initialNotes
     .map(note => new Note(note))
-  const promiseArray = noteObjects.map(note => note.save())
+  const promiseArray = noteObjects.map(async note => await note.save())
   await Promise.all(promiseArray)
 })
 ```


### PR DESCRIPTION
const promiseArray = noteObjects.map(note => note.save()) can be wrong because it does not produces a promiseArray.
async and await need to be used by the map method to produce a promiseArray
suggested correction:
const promiseArray = noteObjects.map(async note => await note.save())