### PR TITLE
About HTTP Request Types: typo/grammar 1103

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -1097,7 +1097,7 @@ All HTTP requests except POST should be <i>idempotent</i>:
 > <i>Methods can also have the property of "idempotence" in that (aside from error or expiration issues) the side-effects of N > 0 identical requests is the same as for a single request. The methods GET, HEAD, PUT and DELETE share this property</i>
 
 
-This means that if a request has side-effects, then the result should be same regardless of how many times the request is sent.
+This means that if a request has side-effects, then the result should be the same regardless of how many times the request is sent.
 
 
 If we make an HTTP PUT request to the url <i>/api/notes/10</i> and with the request we send the data <em>{ content: "no side effects!", important: true }</em>, the result is the same regardless of how many times the request is sent.


### PR DESCRIPTION
"This means that if a request has side-effects, then the result should be *the* same regardless of how many times the request is sent."

Is "same" always preceded with "the"?

Yes, "same" is always preceded with "the". This is not always the case in speech e.g. "Same thing here". But this is actually a case of elision of the word "the".
In writing, however, "the" always precedes "same" i.e. "it is same thing" is incorrect, and should be "It is the same thing."

The word same is usually used with the definite article. However, it can be used with any central determiner which marks the noun phrase as definite:

these same ideas
those very same people
my same friend
whose same idea
Ben's same problems