### PR TITLE
Fix Typo/Grammar

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -659,7 +659,7 @@ Redis has nothing to do with containers. But since we are already able to add <i
 
 ### Exercises 12.9. - 12.11.
 
-#### Exercise 12.9: Setup Redis to project
+#### Exercise 12.9: Set up Redis for the project
 
 The Express server has already been configured to use Redis, and it is only missing the *REDIS_URL* environment variable. The application will use that environment variable to connect to the Redis. Read through the [Docker Hub page for Redis](https://hub.docker.com/_/redis), add Redis to the <i>todo-app/todo-backend/docker-compose.dev.yml</i> by defining another service after mongo:
 


### PR DESCRIPTION
set up, setup, Setup
"Two words as a verb, one word as an adjective and a noun ... Capitalize Setup when it refers to the Setup program." - https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/set-up-setup