### PR TITLE
Update part2d.md

### DIFF
--- a/src/content/2/en/part2d.md
+++ b/src/content/2/en/part2d.md
@@ -155,9 +155,9 @@ const App = () => {
         </button>
       </div>      
       <ul>
-        {notesToShow.map((note, i) => 
+        {notesToShow.map((note) => 
           <Note
-            key={i}
+            key={note.id}
             note={note} 
             toggleImportance={() => toggleImportanceOf(note.id)} // highlight-line
           />


### PR DESCRIPTION
Remove using the index as key - Described in an earlier part as a practice to avoid. Using the `note.id` property in place.