### PR TITLE
Changed "markup" to "stylesheet" under chapter CSS

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -360,7 +360,7 @@ Even though the page updates on your browser, the changes are not permanent. If 
 
 The <i>head</i> element of the HTML code of the Notes page contains a [link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link) tag, which determines that the browser must fetch a [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) style sheet from the address [main.css](https://studies.cs.helsinki.fi/exampleapp/main.css).
 
-Cascading Style Sheets, or CSS, is a markup language used to determine the appearance of web pages. 
+Cascading Style Sheets, or CSS, is a style sheet language used to determine the appearance of web pages. 
 
 The fetched CSS-file looks as follows: 
 


### PR DESCRIPTION
Changed "CSS, is a markup language"  to "CSS, is a style sheet language". CSS is **NOT** a markup language.
https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics#what_is_css