### PR TITLE
Update test for creating new User with existing username

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -376,7 +376,7 @@ describe('when there is initially one user in db', () => {
     expect(result.body.error).toContain('`username` to be unique')
 
     const usersAtEnd = await helper.usersInDb()
-    expect(usersAtEnd).toHaveLength(usersAtStart.length)
+    expect(usersAtEnd).toEqual(usersAtStart)
   })
 })
 ```


### PR DESCRIPTION
The existing code just checks for equality of length between `usersAtStart` and `usersAtEnd`. But, since we know that the post request fails and no new user is added to the Database, we could go ahead and check for the equality of `usersAtStart` and `usersAtEnd` instead of merely checking their length