### PR TITLE
Removed notes property from request body while creating a new  user

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -437,7 +437,6 @@ usersRouter.get('/', async (request, response) => {
 For making new users in a production or development environment, you may send a POST request to ```/api/users/``` via Postman or REST Client in the following format:
 ```js
 {
-    "notes": [],
     "username": "root",
     "name": "Superuser",
     "password": "salainen"


### PR DESCRIPTION
The `notes` property is not required while creating a new user as :
1. We dont use it in the POST route while saving a new user object
2. And moreover, it is auto-created because of the reference to `notes` in the `userSchema`