### PR TITLE
Changed typo of ender to render

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -68,7 +68,7 @@ test('renders content', () => {
 After the initial configuration, the test renders the component with the [render](https://testing-library.com/docs/react-testing-library/api#render) function provided by the react-testing-library:
 
 ```js
-ender(<Note note={note} />)
+render(<Note note={note} />)
 ```
 
 Normally React components are rendered to the <i>DOM</i>. The render method we used renders the components in a format that is suitable for tests without rendering them to the DOM.


### PR DESCRIPTION
The spelling of render was misspelled to ender on line 71.