### PR TITLE
Fix: failing cypress tests

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -883,6 +883,7 @@ describe('when logged in', function() {
     })
 
     it('one of those can be made important', function () {
+      cy.contains('show all').click()
       cy.contains('second note')
         .contains('make important')
         .click()
@@ -944,6 +945,7 @@ One way to fix this is the following:
 
 ```js
 it('one of those can be made important', function () {
+  cy.contains('show all').click()
   cy.contains('second note').parent().find('button').click()
   cy.contains('second note').parent().find('button')
     .should('contain', 'make not important')
@@ -962,6 +964,7 @@ In these kinds of situations, it is possible to use the [as](https://docs.cypres
 
 ```js
 it('one of those can be made important', function () {
+  cy.contains('show all').click()
   cy.contains('second note').parent().find('button').as('theButton')
   cy.get('@theButton').click()
   cy.get('@theButton').should('contain', 'make not important')

--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -345,6 +345,7 @@ describe('Note app', function() {
       cy.contains('new note').click()
       cy.get('input').type('a note created by cypress')
       cy.contains('save').click()
+      cy.contains('show all').click()
 
       cy.contains('a note created by cypress')
     })
@@ -531,6 +532,7 @@ describe('Note app', function() {
       })
 
       it('it can be made important', function () {
+        cy.contains('show all').click()
         cy.contains('another note cypress')
           .contains('make important')
           .click()


### PR DESCRIPTION
I found that several of the test examples in the course material fails. When running these tests cypress
actually required the show all button to be clicked for the '.contains' function to be able to access the notes that are defined as not important.