### PR TITLE
Update part0a.md

### DIFF
--- a/src/content/0/en/part0a.md
+++ b/src/content/0/en/part0a.md
@@ -228,7 +228,7 @@ See [more information on the project](https://github.com/FullStack-HY/misc/blob/
 
 ### Interview promise
 
-Our collaborators, [Houston Inc.](https://houston-inc.com/), [Terveystalo](https://www.terveystalo.com/en/) and [Smartly.io](https://www.smartly.io/), have given the <i>promise of a job interview</i> for everyone who completes the course and the project work with maximum credits (12 + 10). The parts 12 and 13 that where released during 2021 are not required if you finish the project by 15.3.2022.
+Our collaborators, [Houston Inc.](https://houston-inc.com/), [Terveystalo](https://www.terveystalo.com/en/) and [Smartly.io](https://www.smartly.io/), have given the <i>promise of a job interview</i> for everyone who completes the course and the project work with maximum credits (12 + 10). The parts 12 and 13 that were released during 2021 are not required if you finish the project by 15.3.2022.
 
 This means that the student can, if they so choose, sign up for a job interview with a collaborator who has given the promise. The teacher of the course, Matti Luukkainen, will send instructions to the student after the courses have been completed with maximum credits.
 


### PR DESCRIPTION
Changed "The parts 12 and 13 that where released" to "The parts 12 and 13 that were released" since we need the plural past tense of the verb *to be* and not the adverb "where".