### PR TITLE
Update osa6d.md

### DIFF
--- a/src/content/6/fi/osa6d.md
+++ b/src/content/6/fi/osa6d.md
@@ -15,7 +15,7 @@ Tarkastellaan tämän osan lopuksi toista, hieman vanhempaa ja jonkin verran mon
 
 ### Redux Storen välittäminen komponentille connect-funktiolla
 
-Muutetaan sovelluksen komponenttia <i>Notes</i>, siten että korvataan hook-apin eli funktioiden _useDispatch_ ja _useSelector_ käyttö funktioilla _connect_. Komponentin seuraavat osat tulee siis muuttaa:
+Muutetaan sovelluksen komponenttia <i>Notes</i> siten, että korvataan hook-apin eli funktioiden _useDispatch_ ja _useSelector_ käyttö funktioilla _connect_. Komponentin seuraavat osat tulee siis muuttaa:
 
 ````js
 import { useDispatch, useSelector } from 'react-redux' // highlight-line
@@ -403,7 +403,7 @@ näemme eron:
 
 Ensimmäinen funktioista siis on normaali <i>action creator</i>, toinen taas connectin muotoilema funktio, joka sisältää storen metodin dispatch-kutsun.
 
-Connect on erittäin kätevä työkalu, mutta abstraktiuutensa takia se voi aluksi tuntua hankalalta.
+Connect on erittäin kätevä työkalu, mutta abstraktisuutensa takia se voi aluksi tuntua hankalalta.
 
 ### mapDispatchToPropsin vaihtoehtoinen käyttötapa
 
@@ -507,7 +507,7 @@ Connect-funktiota hyödyntävä versio komponentista <i>Notes</i> keskittyy läh
 - Are concerned with how things look.
 - May contain both presentational and container components inside, and usually have some DOM markup and styles of their own.
 - Often allow containment via props.children.
-- Have no dependencies on the rest of the app, such Redux actions or stores.
+- Have no dependencies on the rest of the app, such as Redux actions or stores.
 - Don’t specify how the data is loaded or mutated.
 - Receive data and callbacks exclusively via props.
 - Rarely have their own state (when they do, it’s UI state rather than data).
@@ -558,11 +558,11 @@ Abramov mainitsee jaon [eduiksi](https://medium.com/@dan_abramov/smart-and-dumb-
 - Better reusability. You can use the same presentational component with completely different state sources, and turn those into separate container components that can be further reused.
 - Presentational components are essentially your app’s “palette”. You can put them on a single page and let the designer tweak all their variations without touching the app’s logic. You can run screenshot regression tests on that page.
 
-Abramov mainitsee termin [high order component](https://reactjs.org/docs/higher-order-components.html). Esim. <i>Notes</i> on normaali komponentti, React-reduxin _connect_ metodi taas on <i>high order komponentti</i>, eli käytännössä funktio, joka haluaa parametrikseen komponentin muuttuakseen "normaaliksi" komponentiksi.
+Abramov mainitsee termin [higher-order component](https://reactjs.org/docs/higher-order-components.html). Esim. <i>Notes</i> on normaali komponentti, React-reduxin _connect_ metodi taas on <i>higher-order komponentti</i>, eli käytännössä funktio, joka haluaa parametrikseen komponentin muuttuakseen "normaaliksi" komponentiksi.
 
-High order componentit eli HOC:t ovat yleinen tapa määritellä geneeristä toiminnallisuutta, joka sitten erikoistetaan esim. renderöitymisen määrittelyn suhteen parametrina annettavan komponentin avulla. Kyseessä on funktionaalisen ohjelmoinnin etäisesti olio-ohjelmoinnin perintää muistuttava käsite.
+Higher-order componentit eli HOC:t ovat yleinen tapa määritellä geneeristä toiminnallisuutta, joka sitten erikoistetaan esim. renderöitymisen määrittelyn suhteen parametrina annettavan komponentin avulla. Kyseessä on funktionaalisen ohjelmoinnin etäisesti olio-ohjelmoinnin perintää muistuttava käsite.
 
-HOC:it ovat oikeastaan käsitteen [High Order Function](https://en.wikipedia.org/wiki/Higher-order_function) (HOF) yleistys. HOF:eja ovat sellaiset funkiot, jotka joko ottavat parametrikseen funktioita tai palauttavat funkioita. Olemme oikeastaan käyttäneet HOF:eja läpi kurssin, esim. lähes kaikki taulukoiden käsittelyyn tarkoitetut metodit, kuten _map, filter ja find_ ovat HOF:eja.
+HOC:it ovat oikeastaan käsitteen [Higher-Order Function](https://en.wikipedia.org/wiki/Higher-order_function) (HOF) yleistys. HOF:eja ovat sellaiset funktiot, jotka joko ottavat parametrikseen funktioita tai palauttavat funktioita. Olemme oikeastaan käyttäneet HOF:eja läpi kurssin, esim. lähes kaikki taulukoiden käsittelyyn tarkoitetut metodit, kuten _map, filter ja find_ ovat HOF:eja.
 
 Reactin hook-apin ilmestymisen jälkeen HOC:ien suosio on kääntynyt laskuun, ja melkein kaikki kirjastot, joiden käyttö on aiemmin perustunut HOC:eihin, ovat saaneet hook-perustaisen apin. Useimmiten, kuten myös reduxin kohdalla, hook-perustaiset apit ovat HOC-apeja huomattavasti yksinkertaisempia.
 
@@ -596,7 +596,7 @@ Tee sama <i>Filter</i> ja <i>AnecdoteForm</i> komponenteille.
 
 Sovellukseen on (todennäköisesti) jäänyt eräs hieman ikävä bugi. Jos vote-näppäintä painellaan useasti peräkkäin, notifikaatio näkyy ruudulla hieman miten sattuu. Esimerkiksi jos äänestetään kaksi kertaa kolmen sekunnin välein, näkyy jälkimmäinen notifikaatio ruudulla ainoastaan kahden sekunnin verran (olettaen että notifikaation näyttöaika on 5 sekuntia). Tämä johtuu siitä, että ensimmäisen äänestyksen notifikaation tyhjennys tyhjentääkin myöhemmän äänestyksen notifikaation.
 
-Korjaa bugi, siten että usean peräkkäisen äänestyksen viimeistä notifikaatiota näytetään aina viiden sekunnin ajan. Korjaus tapahtuu siten, että uuden notifikaation tullessa edellisen notifikaation nollaus tarvittaessa perutaan, ks. funktion setTimeout [dokumentaatio](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout).
+Korjaa bugi siten, että usean peräkkäisen äänestyksen viimeistä notifikaatiota näytetään aina viiden sekunnin ajan. Korjaus tapahtuu siten, että uuden notifikaation tullessa edellisen notifikaation nollaus tarvittaessa perutaan, ks. funktion setTimeout [dokumentaatio](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout).
 
 Tämä oli osan viimeinen tehtävä ja on aika pushata koodi githubiin sekä merkata tehdyt tehtävät [palautussovellukseen](https://studies.cs.helsinki.fi/stats/courses/fullstackopen).
 


### PR DESCRIPTION
Materiaalissa viitatuissa lähteissä lukee ainoastaan "higher-order".

Lähteessä lukee samoin "such as": "Have no dependencies on the rest of the app, such as Flux actions or stores."

Materiaalissa lukee "abstraktiuutensa", mikä ehdottaa sanan "abstraktiuus" olemassaoloa, mutta Kielitoimiston sanakirjan mukaan on olemassa vain "abstraktisuus" ja "abstraktius", joista "abstraktisuus" on mahdollisesti yleisemmin käytössä, koska siinä on sanan selitys samalla kuin sanan "abstraktius" kohdalla on vain viite sanaan "abstraktisuus".
![bild](https://user-images.githubusercontent.com/36277211/154977120-5479c9d0-08e8-49bf-a355-eb3d81ffa03e.png)
![bild](https://user-images.githubusercontent.com/36277211/154977175-606d9ea9-cc72-4a7b-849f-e6e8b515543c.png)


