### PR TITLE
Update osa7b.md

### DIFF
--- a/src/content/7/fi/osa7b.md
+++ b/src/content/7/fi/osa7b.md
@@ -21,7 +21,7 @@ Käytimme [osassa 5](/osa5/props_children_ja_proptypet#ref-eli-viite-komponentti
 Muutaman edellisen vuoden aikana moni Reactin apukirjasto on ruvennut tarjoamaan hook-perustaisen rajapinnan. [Osassa 6](/osa6/flux_arkkitehtuuri_ja_redux#redux-storen-valittaminen-eri-komponenteille)
 käytimme react-redux-kirjaston hookeja [useSelector](https://react-redux.js.org/api/hooks#useselector) ja [useDispatch](https://react-redux.js.org/api/hooks#usedispatch) välittämään redux-storen ja dispatch-funktion niitä tarvitseville komponenteille. Reduxin hook-perustainen api onkin huomattavasti helpompi käyttää kuin vanhempi, mutta edelleen käytössä oleva [connect](/osa6/connect)-api.
 
-Myös edellisessä [luvussa](/osa7/react_router/) käsitellyn [React Routerin](https://reacttraining.com/react-router/web/guides) api perustuu osin [hookeihin](https://reacttraining.com/react-router/web/api/Hooks), joiden avulla päästiin käsiksi routejen parametroituun osaan, sekä _navigation_-olioon, joka mahdollistaa selaimen osoiterivin manipuloinnin koodista.
+Myös edellisessä [luvussa](/osa7/react_router/) käsitellyn [React Routerin](https://v5.reactrouter.com/web/guides) api perustuu osin [hookeihin](https://reacttraining.com/react-router/web/api/Hooks), joiden avulla päästiin käsiksi routejen parametroituun osaan, sekä _navigation_-olioon, joka mahdollistaa selaimen osoiterivin manipuloinnin koodista.
 
 Kuten [osassa 1](/osa1/monimutkaisempi_tila_reactin_debuggaus#hookien-saannot)  mainittiin, hookit eivät ole mitä tahansa funktiota, niitä on käytettävä tiettyjä [sääntöjä](https://reactjs.org/docs/hooks-rules.html) noudattaen. Seuraavassa vielä hookien käytön säännöt suoraan Reactin dokumentaatiosta kopioituna:
 


### PR DESCRIPTION
Osoite
https://reacttraining.com/react-router/web/guides uudelleenohjaa sivulle
https://reactrouter.com/web/guides, jossa lukee "404 The page was not found!"

Syöttämällä osoiteriville
https://reactrouter.com/web/ ohjataan sivulle
https://v5.reactrouter.com/web/guides

Seuraava linkki luentomateriaalissa
https://reacttraining.com/react-router/web/api/Hooks ohjautuu itsestään toimivalle sivulle, joka on
https://v5.reactrouter.com/web/api/Hooks