### PR TITLE
Fix: the width of hightlighted code line

### DIFF
--- a/src/templates/ContentTemplate.scss
+++ b/src/templates/ContentTemplate.scss
@@ -153,6 +153,8 @@
 code[class*='language-'],
 pre[class*='language-'] {
   text-shadow: none;
+  float: left;
+  min-width: 100%;
 }
 
 .arrow-go-up {


### PR DESCRIPTION
Currently, the width of highlighted code line may be shorter than the code block when the code block makes a horizontally scrolling. It is not perfect, and this PR aims to solve this appearance issue.

For example:

- Now:
![image](https://user-images.githubusercontent.com/60653216/156842076-55ed4f44-983b-46ba-95c6-dc9420f36216.png)

- Fixed:
![image](https://user-images.githubusercontent.com/60653216/156842500-53fd32ae-4d93-4273-8052-75908eeca3f1.png)

or 

- Now:
![image](https://user-images.githubusercontent.com/60653216/156843116-ba90ad09-559b-4ab4-a2d8-b40e242e8806.png)


- Fixed:
![image](https://user-images.githubusercontent.com/60653216/156843051-c2ad81bf-2415-42a0-8a30-5a6cb5b9cb6a.png)


Hope this PR can be helpful!
