### PR TITLE
Update Part 1a: No need to import React anymore

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -192,7 +192,7 @@ but when writing JSX, the tag needs to be closed:
 
 ### Multiple components
 
-Let's modify the file <i>App.js</i> as follows (NB: import at the top of the file and export at the bottom are left out in these <i>examples</i>, now and in the future. They are still needed for the code to work):
+Let's modify the file <i>App.js</i> as follows (NB: export at the bottom is left out in these <i>examples</i>, now and in the future. It is still needed for the code to work):
 
 ```js
 // highlight-start


### PR DESCRIPTION
`npx create-react-app my-app` creates latest version (5.0.0) and uses react 17.0.2, so there is no need to import React for individual components anymore. 

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html