### PR TITLE
Fixed missing parentheses

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -388,7 +388,7 @@ has a resolver which returns <i>all</i> objects from the _persons_ array.
 
 ### Apollo Studio Explorer
 
-When Apollo server is run in development mode the page [http://localhost:4000](http://localhost:4000) has a button <i>Query your server</i> that takes us to  [Apollo Studio Explorer]https://www.apollographql.com/docs/studio/explorer/explorer/).  This is very useful for a developer, and can be used to make queries to the server. 
+When Apollo server is run in development mode the page [http://localhost:4000](http://localhost:4000) has a button <i>Query your server</i> that takes us to [Apollo Studio Explorer](https://www.apollographql.com/docs/studio/explorer/explorer/).  This is very useful for a developer, and can be used to make queries to the server. 
 
 Let's try it out:
 


### PR DESCRIPTION
`[Apollo Studio Explorer]https://www.apollographql.com/docs/studio/explorer/explorer/)`
corrected to
`[Apollo Studio Explorer](https://www.apollographql.com/docs/studio/explorer/explorer/)`
to fix broken link