### PR TITLE
Part2d: Fix eslint warning

### DIFF
--- a/src/content/2/en/part2d.md
+++ b/src/content/2/en/part2d.md
@@ -557,7 +557,8 @@ const update = (id, newObject) => {
   return request.then(response => response.data)
 }
 
-export default { getAll, create, update } // highlight-line
+const noteService = { getAll, create, update } // highlight-line
+export default noteService // highlight-line
 ```
 
 In defining the object using this shorter notation, we make use of a [new feature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Property_definitions) that was introduced to JavaScript through ES6, enabling a slightly more compact way of defining objects using variables.


### PR DESCRIPTION
Current version of create-react-app and eslint config will give a warning:
`Assign object to a variable before exporting as module default eslint[import/no-anonymous-default-export](https://github.com/import-js/eslint-plugin-import/blob/v2.25.4/docs/rules/no-anonymous-default-export.md)`