### PR TITLE
Fixed typo

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -1075,7 +1075,7 @@ Your solution could look like this:
 
 #### 9.21: patientor, step6
 
-Fetch and add diagnoses to the application state from the <i>/api/diagnosis</i> endpoint. Use the new diagnosis data to show the descriptions for patient's diagnosis codes:
+Fetch and add diagnoses to the application state from the <i>/api/diagnoses</i> endpoint. Use the new diagnosis data to show the descriptions for patient's diagnosis codes:
 
 ![](../../images/9/42.png)
 


### PR DESCRIPTION
`/api/diagnosis` -> `/api/diagnoses` to match the endpoint route used repeatedly before