### PR TITLE
Fix strict equality comparison bug

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -540,7 +540,7 @@ We can define [parameters](http://expressjs.com/en/guide/routing.html#route-para
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
-  const id = request.params.id
+  const id = Number(request.params.id)
   const note = notes.find(note => note.id === id)
   response.json(note)
 })


### PR DESCRIPTION
Id in notes are of type number and id in request param is of type string. So strict equal (===) won't work in notes.find().
Fixed this bug by converting id request param to of type Number