### PR TITLE
Fixed typo

### DIFF
--- a/src/content/11/en/part11d.md
+++ b/src/content/11/en/part11d.md
@@ -209,7 +209,7 @@ jobs:
       // steps here
 ```
 
-As was mentioned [earlied](/en/part11/getting_started_with_git_hub_actions#getting-started-with-workflows) jobs of a workflow are executed in parallel but since we want the linting, testing and deployment to be done first, we set a dependency that the <i>tag\_release</i> waits the another job to execute first since we do not want to tag the release unless it passes tests and is deployed.
+As was mentioned [earlied](/en/part11/getting_started_with_git_hub_actions#getting-started-with-workflows) jobs of a workflow are executed in parallel but since we want the linting, testing and deployment to be done first, we set a dependency that the <i>tag\_release</i> waits for the other job to execute first since we do not want to tag the release unless it passes tests and is deployed.
 
 If you're uncertain of the configuration, you can set  <code>DRY_RUN</code> to <code>true</code>, which will make the action output the next version number without creating or tagging the release!
 


### PR DESCRIPTION
`we set a dependency that the <i>tag\_release</i> waits the another job to execute first`
changed to
`we set a dependency that the <i>tag\_release</i> waits for the other job to execute first`