### PR TITLE
Update 5d, allowing Cypress to function on M1

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -79,6 +79,8 @@ Let's add an npm-script to <i>the backend</i> which starts it in test mode, or s
 
 NB! In order to get Cypress working with WSL2 one might need to do some additional configuring first. These two [links](https://docs.cypress.io/guides/getting-started/installing-cypress#Windows-Subsystem-for-Linux) are great places to [start](https://nickymeuleman.netlify.app/blog/gui-on-wsl2-cypress).
 
+NB! For macbooks with m1 CPU instead of intel ones, cypress wouldn't work since it doesn't support m1 yet. To fix that, installing Rosetta 2 then configuring your terminal is a must. For step by step intrsutcions follow [here](https://www.cypress.io/blog/2021/01/20/running-cypress-on-the-apple-m1-silicon-arm-architecture-using-rosetta-2/).
+  
 When both backend and frontend are running, we can start Cypress with the command
 
 ```js


### PR DESCRIPTION
Currently cypress doesn't support macbooks with m1 cpu. One solution is to download rosetta 2, which bridge any intel processer-based app to M1.