### PR TITLE
Update link to Redux DevTools in part6b

### DIFF
--- a/src/content/6/en/part6b.md
+++ b/src/content/6/en/part6b.md
@@ -602,7 +602,7 @@ describe('noteReducer', () => {
 
 ### Redux DevTools
 
-[Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=fi) is a Chrome addon that offers useful development tools for Redux. It can be used for example to inspect the Redux store's state and dispatch actions through the browser's console. When the store is created using Redux Toolkit's <em>configureStore</em> function, no additional configuration is needed for Redux DevTools to work.
+[Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) is a Chrome addon that offers useful development tools for Redux. It can be used for example to inspect the Redux store's state and dispatch actions through the browser's console. When the store is created using Redux Toolkit's <em>configureStore</em> function, no additional configuration is needed for Redux DevTools to work.
 
 Once the addon in installed, clicking the <i>Redux</i> tab in the browser's console should open the development tools:
 


### PR DESCRIPTION
Old link went to the Finnish page for the extension (from the English translation of the course)