### PR TITLE
Fix spacing for self-closing tags in part 6a

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -1095,7 +1095,7 @@ const App = () => {
   return (
     <div>
       <NewNote />
-      <Notes  />
+      <Notes />
     </div>
   )
 }
@@ -1172,7 +1172,7 @@ const App = () => {
     <div>
       <h2>Anecdotes</h2>
       <AnecdoteForm />
-      <AnecdoteList  />
+      <AnecdoteList />
     </div>
   )
 }

--- a/src/content/6/es/part6a.md
+++ b/src/content/6/es/part6a.md
@@ -1162,7 +1162,7 @@ const App = () => {
   return (
     <div>
       <NewNote />
-      <Notes  />
+      <Notes />
     </div>
   )
 }
@@ -1253,7 +1253,7 @@ const App = () => {
     <div>
       <h2>Anecdotes</h2>
       <AnecdoteForm />
-      <AnecdoteList  />
+      <AnecdoteList />
     </div>
   )
 }

--- a/src/content/6/fi/osa6a.md
+++ b/src/content/6/fi/osa6a.md
@@ -1069,7 +1069,7 @@ const App = () => {
   return (
     <div>
       <NewNote />
-      <Notes  />
+      <Notes />
     </div>
   )
 }

--- a/src/content/6/zh/part6a.md
+++ b/src/content/6/zh/part6a.md
@@ -1250,7 +1250,7 @@ const App = () => {
   return (
     <div>
       <NewNote />
-      <Notes  />
+      <Notes />
     </div>
   )
 }
@@ -1342,7 +1342,7 @@ const App = () => {
     <div>
       <h2>Anecdotes</h2>
       <AnecdoteForm />
-      <AnecdoteList  />
+      <AnecdoteList />
     </div>
   )
 }


### PR DESCRIPTION
It's a minor thing, but it would be nice if all self-closing tags would only have a single space before `/>`.