### PR TITLE
options usefindandmodify, usecreateindex are not supported

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -61,9 +61,9 @@ const Person = require('./models/person')
 
 const MONGODB_URI = 'mongodb+srv://databaseurlhere'
 
-console.log('connecting to', MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false, useCreateIndex: true })
+console.log('connecting to', MONGODB_URI)
 
-mongoose.connect(MONGODB_URI)
+mongoose.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
   .then(() => {
     console.log('connected to MongoDB')
   })


### PR DESCRIPTION
1) The config for connection is misplaced - we just log it instead of using it.
2) But even if use it like mongoose.connect(MONGODB_URI, {
    useNewUrlParser: true,
    useUnifiedTopology: true,
    useFindAndModify: false,
    useCreateIndex: true
  })
it gives following error message ("mongoose": "^6.2.8"): options usefindandmodify, usecreateindex are not supported.
So maybe these are deprecated. Project works with just plain mongoose.connect(MONGODB_URI), but it also doesn't give any warning for using useNewUrlParser and useUnifiedTopology. Thanks!