### PR TITLE
apollo-server-core is redundant

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -250,7 +250,7 @@ Let's implement a GraphQL server with today's leading library: [Apollo Server](h
 Create a new npm project with _npm init_ and install the required dependencies.
 
 ```bash
-npm install apollo-server graphql apollo-server-core
+npm install apollo-server graphql
 ```
 
 The initial code is as follows: 


### PR DESCRIPTION
apollo-server-core is redundant in the line "npm install apollo-server graphql apollo-server-core". The server and queries work without providing an apollo-server-core package. I believe it installs anyway as a dependency of an apollo-server package, at least for the latest version.