### PR TITLE
Add courseinfo to the example folder of part 2

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -625,6 +625,7 @@ part1
   unicafe
   anecdotes
 part2
+  courseinfo
   phonebook
   countries
 ```


### PR DESCRIPTION
As the courseinfo is continued in part 2, redoing the folder in said part is required. Not having it in the example has caused some confusion with the students, so adding a copy to part2 example might solve this issue.