### PR TITLE
Add forward slash to the start of Part 4 URL path

### DIFF
--- a/src/content/13/en/part13b.md
+++ b/src/content/13/en/part13b.md
@@ -272,7 +272,7 @@ At this point, the situations that require error handling by the application are
 
 ### User management
 
-Next, let's add a database table <i>users</i> to the application, where the users of the application will be stored. In addition, we will add the ability to create users and token-based login as we implemented in [part 4](en/part4/token_authentication). For simplicity, we will adjust the implementation so that all users will have the same password <i>secret</i>.
+Next, let's add a database table <i>users</i> to the application, where the users of the application will be stored. In addition, we will add the ability to create users and token-based login as we implemented in [part 4](/en/part4/token_authentication). For simplicity, we will adjust the implementation so that all users will have the same password <i>secret</i>.
 
 The model defining users in the file <i>models/user.js</i> is straightforward
 


### PR DESCRIPTION
Currently the part 4 link under `User management` directs to the invalid URL https://fullstackopen.com/en/part13/en/part4/token_authentication. This fixes the link to the correct URL of https://fullstackopen.com/en/part4/token_authentication.