### PR TITLE
Change content -> container in an example

### DIFF
--- a/src/content/5/fi/osa5c.md
+++ b/src/content/5/fi/osa5c.md
@@ -616,9 +616,9 @@ const NoteForm = ({ createNote }) => {
 testi löytäisi elementin seuraavasti:
 
 ```js
-const { content } = render(<NoteForm createNote={createNote} />)
+const { container } = render(<NoteForm createNote={createNote} />)
 
-const input = content.querySelector('#note-input')
+const input = container.querySelector('#note-input')
 ```
 
 Jätämme koodiin placeholderiin perustuvan ratkaisun.


### PR DESCRIPTION
Tehtäviä tehdessäni huomasin, että esimerkin `const { content }` ei toimi, vaan viittaus pitäisi luultavasti olla renderin palauttamaan container-kenttään.