### PR TITLE
Update part5c.md

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -128,7 +128,7 @@ test('renders content', () => {
 })
 ```
 
-Text fails if _getByText_ does not find the element it is looking for.
+Test fails if _getByText_ does not find the element it is looking for.
 
 We could also use [CSS-selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) to find rendered elements by using the method [querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) of the object [container](https://testing-library.com/docs/react-testing-library/api/#containerr) that is one of the fields returned by the render:
  


### PR DESCRIPTION
I assumed that the context is "Test fails if getByText does not find the element it is looking for.
" instead of "Text fails if getByText does not find the element it is looking for."