### PR TITLE
Fixed className for Nav element

### DIFF
--- a/src/content/7/en/part7c.md
+++ b/src/content/7/en/part7c.md
@@ -198,7 +198,7 @@ Lastly, let's alter the application's navigation menu to use Bootstrap's [Navbar
 <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
   <Navbar.Toggle aria-controls="responsive-navbar-nav" />
   <Navbar.Collapse id="responsive-navbar-nav">
-    <Nav className="mr-auto">
+    <Nav className="me-auto">
       <Nav.Link href="#" as="span">
         <Link style={padding} to="/">home</Link>
       </Nav.Link>


### PR DESCRIPTION
According to react-bootstrap documentation, "className" for "Nav" element should be "me-auto" and not "mr-auto". (Navigation structure subheading)