### PR TITLE
react-ga -> react-ga4

### DIFF
--- a/src/content/7/en/part7e.md
+++ b/src/content/7/en/part7e.md
@@ -515,7 +515,7 @@ The [immutable.js](https://github.com/facebook/immutable-js/) library maintained
 
 [Redux-saga](https://redux-saga.js.org/) provides an alternative way to make asynchronous actions for [redux thunk](/en/part6/communicating_with_server_in_a_redux_application#asynchronous-actions-and-redux-thunk) familiar from part 6. Some embrace the hype and like it. I don't.
 
-For single-page applications, the gathering of analytics data on the interaction between the users and the page is [more challenging](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) than for traditional web applications where the entire page is loaded. The [React Google Analytics](https://github.com/react-ga/react-ga) library offers a solution.
+For single-page applications, the gathering of analytics data on the interaction between the users and the page is [more challenging](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) than for traditional web applications where the entire page is loaded. The [React Google Analytics](https://github.com/PriceRunner/react-ga4) library offers a solution.
 
 You can take advantage of your React know-how when developing mobile applications using Facebook's extremely popular [React Native](https://facebook.github.io/react-native/) library, which is the topic of [part 10](/en/part10) of the course.
 

--- a/src/content/7/es/part7e.md
+++ b/src/content/7/es/part7e.md
@@ -535,7 +535,7 @@ La biblioteca [immutable.js](https://github.com/facebook/immutable-js/) mantenid
 
 [Redux-saga](https://redux-saga.js.org/) proporciona una forma alternativa de hacer las acciones asincrónicas para [redux thunk](/es/part6/communicating_with_server_in_a_redux_application#asynchronous-actions-and-redux-thunk) que vimos en la parte 6. Algunos abrazan el hype y les gusta. Yo no.
 
-Para las aplicaciones de una sola página, la recopilación de datos analíticos sobre la interacción entre los usuarios y la página es [más desafiante](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) que para las aplicaciones web tradicionales donde se carga toda la página. La biblioteca [React Google Analytics](https://github.com/react-ga/react-ga) ofrece una solución.
+Para las aplicaciones de una sola página, la recopilación de datos analíticos sobre la interacción entre los usuarios y la página es [más desafiante](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) que para las aplicaciones web tradicionales donde se carga toda la página. La biblioteca [React Google Analytics](https://github.com/PriceRunner/react-ga4) ofrece una solución.
 
 Puede aprovechar su conocimiento de React al desarrollar aplicaciones móviles utilizando la extremadamente popular biblioteca [React Native](https://facebook.github.io/react-native/) de Facebook.
 

--- a/src/content/7/fi/osa7e.md
+++ b/src/content/7/fi/osa7e.md
@@ -518,7 +518,7 @@ Lomakkeiden käyttöä helpottavia kirjastoja ovat [Formik](https://www.npmjs.co
 
 [Redux-saga](https://redux-saga.js.org/) tarjoaa osassa 6 käsitellylle [redux thunkille](/osa6/redux_sovelluksen_kommunikointi_palvelimen_kanssa#asynkroniset-actionit-ja-redux-thunk) vaihtoehtoisen tavan tehdä asynkronisia actioneja. Jotkut hypettää ja tykkää, itse en.
 
-Single page -sovelluksissa analytiikkatietojen kerääminen käyttäjien sivuston kanssa käymästä vuorovaikutuksesta on [haastavampaa](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) kuin perinteisissä, kokonaiseen sivun lataamiseen perustuvissa web-sovelluksissa. [React Google Analytics](https://github.com/react-ga/react-ga) -kirjasto tuo tähän avun.
+Single page -sovelluksissa analytiikkatietojen kerääminen käyttäjien sivuston kanssa käymästä vuorovaikutuksesta on [haastavampaa](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) kuin perinteisissä, kokonaiseen sivun lataamiseen perustuvissa web-sovelluksissa. [React Google Analytics](https://github.com/PriceRunner/react-ga4) -kirjasto tuo tähän avun.
 
 Voit hyödyntää React-osaamistasi myös mobiilisovellusten toteuttamiseen Facebookin erittäin suositun [React Native](https://facebook.github.io/react-native/) -kirjaston avulla. Kurssin [osa 10](/osa10) käsittelee React Nativea.
 

--- a/src/content/7/zh/part7e.md
+++ b/src/content/7/zh/part7e.md
@@ -681,8 +681,8 @@ Lambda 的主要特点是，它支持在云中执行单个函数，如今 Google
 <!-- [Redux-saga](https://redux-saga.js.org/) provides an alternative way to make asynchronous actions for [redux thunk](/zh/part6/在_redux应用中与后端通信#asynchronous-actions-and-redux-thunk) familiar from part 6. Some embrace the hype and like it. I don't. -->
 [Redux-saga](https://redux-saga.js.org/)提供了另一种方法，用于为[redux thunk](/zh/part6/在_redux应用中与后端通信#asynchronous-actions-and-redux-thunk)制作异步操作，类似于第6章节。 有些人欣然接受这种炒作，并且喜欢这种炒作。 我不这么认为。
 
-<!-- For single page applications the gathering of analytics data on the interaction between the users and the page is [more challenging](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) than for traditional web-applications where the entire page is loaded. The [React Google Analytics](https://github.com/react-ga/react-ga) -library offers a solution. -->
-对于单页应用来说，收集用户和页面交互的分析数据比传统的加载整个页面的网页应用 [更具有挑战性](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications)。 [React Google Analytics](https://github.com/react-ga/react-ga)  数据库提供了一个解决方案。
+<!-- For single page applications the gathering of analytics data on the interaction between the users and the page is [more challenging](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications) than for traditional web-applications where the entire page is loaded. The [React Google Analytics](https://github.com/PriceRunner/react-ga4) -library offers a solution. -->
+对于单页应用来说，收集用户和页面交互的分析数据比传统的加载整个页面的网页应用 [更具有挑战性](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications)。 [React Google Analytics](https://github.com/PriceRunner/react-ga4)  数据库提供了一个解决方案。
 
 <!-- You can take advantage of your React know-how when developing mobile applications using Facebook's extremely popular [React Native](https://facebook.github.io/react-native/) -library, that is topic of the [part 10](/en/part10) of the course.-->
 在使用 Facebook 非常流行的 [React Native](https://facebook.github.io/react-native/) 库开发移动应用时，你可以利用你的 React 知道如何开发，这也是本课程[第十章](/zh/part10)的内容。


### PR DESCRIPTION
Suoritin _npm-check-updates_, _ncu -u_ ja _npm install_ itselleni forkatun kurssimateriaalin juuressa, minkä jälkeen käynnistäminen epäonnistui, koska React Google Analytics ei tule toimeen uusimpien Reactien kanssa:
![bild](https://user-images.githubusercontent.com/36277211/165180301-485b4ba1-6112-4ada-b7b4-c911bb5cb47a.png)

Tässä ehdotetaan korvausta:
https://github.com/react-ga/react-ga/issues/520#issuecomment-1078675278
, joka on react-ga4: https://www.npmjs.com/package/react-ga4

Kun päivitin Reactin 18:aan versioon ja korvasin react-ga:n react-ga4:llä, sitten sovellus käynnistyi.