### PR TITLE
replaced last year's bloglist-frontend-repo with this year's repo in fi, en and zh

### DIFF
--- a/src/content/5/en/part5a.md
+++ b/src/content/5/en/part5a.md
@@ -538,10 +538,10 @@ While doing the exercises, remember all of the debugging methods we have talked 
 
 #### 5.1: bloglist frontend, step1
 
-Clone the application from [Github](https://github.com/fullstack-hy/bloglist-frontend) with the command: 
+Clone the application from [Github](https://github.com/fullstack-hy2020/bloglist-frontend) with the command: 
 
 ```bash
-git clone https://github.com/fullstack-hy/bloglist-frontend
+git clone https://github.com/fullstack-hy2020/bloglist-frontend
 ```
 
 <i>remove the git configuration of the cloned application</i>

--- a/src/content/5/fi/osa5a.md
+++ b/src/content/5/fi/osa5a.md
@@ -527,7 +527,7 @@ Tämän osan alun tehtävät kertaavat käytännössä kaiken oleellisen tämän
 
 Muista tehtäviä tehdessäsi kaikki debuggaukseen liittyvät käytänteet, erityisesti konsolin tarkkailu.
 
-**Varoitus:** Jos huomaat kirjoittavasi samaan funktioon sekaisin async/awaitia ja _then_-kutsuja, on 99.9-prosenttisen varmaa, että teet jotain väärin. Käytä siis jompaa kumpaa tapaa, älä missään tapauksessa "varalta" molempia.
+**Varoitus:** Jos huomaat kirjoittavasi samaan funktioon sekaisin async/awaitia ja _then_-kutsuja, on 99,9-prosenttisen varmaa, että teet jotain väärin. Käytä siis jompaa kumpaa tapaa, älä missään tapauksessa "varalta" molempia.
 
 #### 5.1: blogilistan frontend, step1
 

--- a/src/content/5/fi/osa5a.md
+++ b/src/content/5/fi/osa5a.md
@@ -531,10 +531,10 @@ Muista tehtäviä tehdessäsi kaikki debuggaukseen liittyvät käytänteet, erit
 
 #### 5.1: blogilistan frontend, step1
 
-Ota tehtävien pohjaksi [GitHubissa](https://github.com/fullstack-hy/bloglist-frontend) oleva sovellusrunko kloonaamalla se sopivaan paikkaan:
+Ota tehtävien pohjaksi [GitHubissa](https://github.com/fullstack-hy2020/bloglist-frontend) oleva sovellusrunko kloonaamalla se sopivaan paikkaan:
 
 ```bash
-git clone https://github.com/fullstack-hy/bloglist-frontend
+git clone https://github.com/fullstack-hy2020/bloglist-frontend
 ```
 
 Seuraavaksi poista kloonatun sovelluksen Git-konfiguraatio:

--- a/src/content/5/zh/part5a.md
+++ b/src/content/5/zh/part5a.md
@@ -613,8 +613,8 @@ window.localStorage.clear()
 
 
 ### Exercises 5.1.-5.4.
-<!-- We will now create a frontend for the bloglist backend we created in the last part. You can use [this application](https://github.com/fullstack-hy/bloglist-frontend) from GitHub as the base of your solution. The application expects your backend to be running on port 3001.  -->
-现在我们将为上一章节创建的博客列表后端创建一个前端。 你可以使用 GitHub 上的[这个应用](https://github.com/fullstack-hy/bloglist-frontend/)作为你的解决方案的基础。 应用期望您的后端在3003端口上运行。
+<!-- We will now create a frontend for the bloglist backend we created in the last part. You can use [this application](https://github.com/fullstack-hy2020/bloglist-frontend) from GitHub as the base of your solution. The application expects your backend to be running on port 3001.  -->
+现在我们将为上一章节创建的博客列表后端创建一个前端。 你可以使用 GitHub 上的[这个应用](https://github.com/fullstack-hy2020/bloglist-frontend/)作为你的解决方案的基础。 应用期望您的后端在3003端口上运行。
 
 <!-- It is enough to submit your finished solution. You can do a commit after each exercise, but that is not necessary.  -->
 只要提交完成的解决方案就足够了。 您可以在每次练习之后进行一次提交，但这并不强制。
@@ -632,11 +632,11 @@ window.localStorage.clear()
 **警告:**如果你注意到你正在混合 async/await 和_then_ 命令，你99.9% 正在做错误的事情。 要么使用其中之一，不要两者都使用。
 
 #### 5.1: bloglist frontend, 步骤1
-<!-- Clone the application from [Github](https://github.com/fullstack-hy/bloglist-frontend) with the command:  -->
-使用如下命令从[Github](https://Github.com/fullstack-hy/bloglist-frontend)克隆应用:
+<!-- Clone the application from [Github](https://github.com/fullstack-hy2020/bloglist-frontend) with the command:  -->
+使用如下命令从[Github](https://github.com/fullstack-hy2020/bloglist-frontend)克隆应用:
 
 ```bash
-git clone https://github.com/fullstack-hy/bloglist-frontend
+git clone https://github.com/fullstack-hy2020/bloglist-frontend
 ```
 
 <!-- <i>remove the git configuration of the cloned application</i> -->


### PR DESCRIPTION
This pull request is in response to https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/pull/1970#issuecomment-1108757004

The Spanish version had already links to this year's repo: https://fullstackopen.com/es/part5/iniciar_sesion_en_la_interfaz#ejercicios-5-1-5-4