### PR TITLE
Add note about Redux Thunk installation

### DIFF
--- a/src/content/6/fi/osa6c.md
+++ b/src/content/6/fi/osa6c.md
@@ -407,7 +407,7 @@ const NewNote = () => {
 
 Molemmat komponentit dispatchaisivat ainoastaan actionin välittämättä siitä, että taustalla tapahtuu todellisuudessa palvelimen kanssa tapahtuvaa kommunikointia. Tämän kaltaisten <i>asynkronisten actioneiden</i> käyttö onnistuu [Redux Thunk](https://github.com/reduxjs/redux-thunk)-kirjaston avulla. Kirjaston käyttö ei vaadi ylimääräistä konfiguraatiota, kun Redux-store on luotu Redux Toolkitin <em>configureStore</em>-funktiolla.
 
-Asennetaan kirjasto:
+Asennetaan kirjasto (Huom! Jos olet jo asentanut Redux Toolkitin, Redux Thunkia ei tarvitse asentaa erikseen):
 
 ```
 npm install redux-thunk


### PR DESCRIPTION
Huom! En ole kovinkaan mukavuusalueella npm:n kanssa, mutta oma tuntumani on, että jos Redux Toolkit on jo asennettuna, niin Redux Thunkia ei tarvitse asentaa erikseen.

Aloin ensin ihmettelemään, että miten tehtävän 6.15 tekemiseksi koodissa ei tarvinnut "mainita" Redux Thunkia mitenkään. Sen jälkeen yritin uninstalloida Redux Thunkin (`npm uninstall redux-thunk`) ja kokeilla, että lopettaako koodi toimimisen ilman Redux Thunkia, mutta uninstallointi ei tuntunut onnistuvan. `npm list`:n ja Redux Toolkitin dokumentaation avulla tulin kuitenkin siihen tulokseen, että ilmeisesti Redux Thunk tulee Redux Toolkitin mukana automaattisesti. Ja tuo Redux Thunk toimii jotenkin maagisesti ilman, että sitä importtaa koodissa mitenkään.

Jos on jo asentanut Redux Toolkitin ja sen jälkeen asentaa (`npm install redux-thunk`), niin voi aiheuttaa pientä hämmennystä, että miksi ainoastaan `package.json` muuttuu ja `package-lock-json` pysyy ennallaan. Tämä toki kokeneemmalle antaa jo osviittaa siitä, että Redux Thunk on jo asentunut jotain muuta kautta - sikäli mikäli yllä oleva ajatuksenjuoksu menee oikein.