### PR TITLE
Fixing imported redux action

### DIFF
--- a/src/content/6/en/part6c.md
+++ b/src/content/6/en/part6c.md
@@ -223,7 +223,7 @@ import NewNote from './components/NewNote'
 import Notes from './components/Notes'
 import VisibilityFilter from './components/VisibilityFilter'
 import noteService from './services/notes'  // highlight-line
-import { initializeNotes } from './reducers/noteReducer' // highlight-line
+import { setNotes } from './reducers/noteReducer' // highlight-line
 import { useDispatch } from 'react-redux' // highlight-line
 
 const App = () => {


### PR DESCRIPTION
"initializeNotes" is introduced only in "Asynchronous actions and redux thunk" section, the imported action should be "setNotes" as used inside the useEffect hook or in the index.js implementation example (lines 195 to 212 in the source code).