### PR TITLE
doc: JS Refactor has been deprecated

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -671,7 +671,7 @@ const total = parts.reduce((s, p) => {
 })
 ```
 
-**Pro tip 2:** There is a [plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=cmstead.jsrefactor) that automatically changes short form arrow functions into their longer form, and vice versa. 
+**Pro tip 2:** There is a [plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=cmstead.js-codeformer) that automatically changes short form arrow functions into their longer form, and vice versa. 
 
 ![](../../images/2/5b.png)
 


### PR DESCRIPTION
> JS Refactor has been retired. This project is now an extension installer for its replacement, JS CodeFormer. If you install this extension, you will get that one.
You can install JS CodeFormer directly:
https://marketplace.visualstudio.com/items?itemName=cmstead.js-codeformer  

the old plugin has been deprecated and the author recommend another plugin to replace.