### PR TITLE
Fix wrong order on send and status

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -931,7 +931,7 @@ app.post('/calculate', (req, res) => {
 
 // highlight-start
   if ( !value1 || isNaN(Number(value1))) {
-    return res.send({ error: '...'}).status(400);
+    return res.status(400).send({ error: '...'});
   }
   // highlight-end
 


### PR DESCRIPTION
`.send(...).status(400)` results in a `200` status regardless of what is put in `status`, as `send` finalizes the chain.

Thanks to awabdi#5736 on Discord for noticing this issue.