### PR TITLE
Fix typo in credit requirements

### DIFF
--- a/src/content/0/en/part0a.md
+++ b/src/content/0/en/part0a.md
@@ -72,8 +72,8 @@ You can only take the exam after submitting enough exercises for five credits. I
 <i>You do not need to attend the course exam or register to the Open University course in order to obtain the course certificate.</i>
 
 #### Part 6 - Full Stack Web Development, extension 1 (1 cr, CSM141082)
-By submitting at least 127 of the exercises for parts 0-7 while working on the core course, you can receive an additional credit through this extension. 
-- Submit at least 127 exercises for parts 0-7. 
+By submitting at least 127 of the exercises for parts 0-6 while working on the core course, you can receive an additional credit through this extension. 
+- Submit at least 127 exercises for parts 0-6. 
 - [Enroll in part 6 through the Open University](https://www.avoin.helsinki.fi/palvelut/esittely.aspx?s=otm-c67dc747-1d6a-43cb-b40b-9eacf425dcc0). 
 - [Request credits for part 6](https://fullstackopen.com/en/part0/general_info/#how-to-get-your-credits).
 


### PR DESCRIPTION
The requirements for getting credits in Part 6 should be completion of exercises in parts 0-6 and not parts 0-7