### PR TITLE
Edit the console.log example for matching output

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -20,7 +20,7 @@ When something does not work, don't just guess what's wrong. Instead, log or use
 **NB** As explained in part 1, when you use the command _console.log_ for debugging, don't concatenate things 'the Java way' with a plus. Instead of writing:
 
 ```js
-console.log('props value is' + props)
+console.log('props value is ' + props)
 ```
 
 separate the things to be printed with a comma:


### PR DESCRIPTION
The following command on line 23 does not match the supposed output on line 35. I got confused while reading the material and decided to test it.

 https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/blob/2f09411ca1c6e6026f9016409dedc29073d981e6/src/content/2/en/part2a.md?plain=1#L23

https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/blob/2f09411ca1c6e6026f9016409dedc29073d981e6/src/content/2/en/part2a.md?plain=1#L35

How to fix it.

```javascript
// prints "props value is[object Object]"
// notice the lack of space
console.log('props value is' + props)

// prints "props value is [object Object]"
console.log('props value is ' + props)
```