### PR TITLE
part13c | "// highlight-line" to start/end instead

### DIFF
--- a/src/content/13/en/part13c.md
+++ b/src/content/13/en/part13c.md
@@ -147,7 +147,9 @@ const runMigrations = async () => {
 const connectToDatabase = async () => {
   try {
     await sequelize.authenticate()
-    await runMigrations() // highlight-line
+    // highlight-start
+    await runMigrations()
+    // highlight-end
     console.log('connected to the database')
   } catch (err) {
     console.log('failed to connect to the database')


### PR DESCRIPTION
One line of code shows up as "await runMigrations() // highlight-line" on the site instead of highlighting the line. 
Perhaps a workaround is to wrap the line with "// highlight-start" "// highlight-end" instead.

![image](https://user-images.githubusercontent.com/45342505/171666267-ce20036b-1795-42f3-95bd-299ec52fdcce.png)
