### PR TITLE
part13c | change snake case in Membership Model to camel case

### DIFF
--- a/src/content/13/en/part13c.md
+++ b/src/content/13/en/part13c.md
@@ -620,12 +620,12 @@ Membership.init({
     primaryKey: true,
     autoIncrement: true
   },
-  user_id: {
+  userId: {
     type: DataTypes.INTEGER,
     allowNull: false,
     references: { model: 'users', key: 'id' },
   },
-  team_id: {
+  teamId: {
     type: DataTypes.INTEGER,
     allowNull: false,
     references: { model: 'teams', key: 'id' },


### PR DESCRIPTION
Model example Membership for many-many relationships shows user_id & team_id instead of userId & teamId.