### PR TITLE
Update part6a.md

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -847,8 +847,7 @@ const store = createStore(noteReducer)
 ReactDOM.createRoot(document.getElementById('root')).render(
   <Provider store={store}>  // highlight-line
     <App />
-  </Provider>,  // highlight-line
-  document.getElementById('root')
+  </Provider>  // highlight-line
 )
 ```
 


### PR DESCRIPTION
document.getElementById('root') is no longer needed to be passed in the render function