### PR TITLE
part3 - Update links from w3.org to rfc-editor.org

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -637,7 +637,7 @@ If we search for a note with an id that does not exist, the server responds with
 The HTTP status code that is returned is 200, which means that the response succeeded. There is no data sent back with the response, since the value of the <i>content-length</i> header is 0, and the same can be verified from the browser. 
 
 
-The reason for this behavior is that the _note_ variable is set to _undefined_ if no matching note is found. The situation needs to be handled on the server in a better way. If no note is found, the server should respond with the status code [404 not found](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) instead of 200.
+The reason for this behavior is that the _note_ variable is set to _undefined_ if no matching note is found. The situation needs to be handled on the server in a better way. If no note is found, the server should respond with the status code [404 not found](https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found) instead of 200.
 
 
 Let's make the following change to our code:
@@ -683,7 +683,7 @@ app.delete('/api/notes/:id', (request, response) => {
 })
 ```
 
-If deleting the resource is successful, meaning that the note exists and it is removed, we respond to the request with the status code [204 no content](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) and return no data with the response.
+If deleting the resource is successful, meaning that the note exists and it is removed, we respond to the request with the status code [204 no content](https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content) and return no data with the response.
 
 
 There's no consensus on what status code should be returned to a DELETE request if the resource does not exist. Really, the only two options are 204 and 404. For the sake of simplicity our application will respond with 204 in both cases.
@@ -874,7 +874,7 @@ app.post('/api/notes', (request, response) => {
 The logic for generating the new id number for notes has been extracted into a separate _generateId_ function.
 
 
-If the received data is missing a value for the <i>content</i> property, the server will respond to the request with the status code [400 bad request](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1):
+If the received data is missing a value for the <i>content</i> property, the server will respond to the request with the status code [400 bad request](https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request):
 
 ```js
 if (!body.content) {
@@ -1051,7 +1051,7 @@ Respond to requests like these with the appropriate status code, and also send b
 
 ### About HTTP request types
 
-[The HTTP standard](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) talks about two properties related to request types, **safety** and **idempotence**.
+[The HTTP standard](https://www.rfc-editor.org/rfc/rfc9110.html#name-common-method-properties) talks about two properties related to request types, **safety** and **idempotence**.
 
 The HTTP GET request should be <i>safe</i>:
 
@@ -1064,7 +1064,7 @@ Safety means that the executing request must not cause any <i>side effects</i> i
 Nothing can ever guarantee that a GET request is actually <i>safe</i>, this is in fact just a recommendation that is defined in the HTTP standard. By adhering to RESTful principles in our API, GET requests are in fact always used in a way that they are <i>safe</i>.
 
 
-The HTTP standard also defines the request type [HEAD](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4), that ought to be safe. In practice HEAD should work exactly like GET but it does not return anything but the status code and response headers. The response body will not be returned when you make a HEAD request.
+The HTTP standard also defines the request type [HEAD](https://www.rfc-editor.org/rfc/rfc9110.html#name-head), that ought to be safe. In practice HEAD should work exactly like GET but it does not return anything but the status code and response headers. The response body will not be returned when you make a HEAD request.
 
 
 All HTTP requests except POST should be <i>idempotent</i>:


### PR DESCRIPTION
All links to www.w3.org/Protocols/... have a warning message, "This document has been superseded. See IETF Documents for more information."
This pull request changes 5 links to rfc-editor.org.

Fullstackopen   section | Link text | Current Link | Suggested Link
-- | -- | -- | --
https://fullstackopen.com/en/part3/node_js_and_express#fetching-a-single-resource | 404 not found | https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5 | https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found
https://fullstackopen.com/en/part3/node_js_and_express#deleting-resources | 204 no content | https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5 | https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content
https://fullstackopen.com/en/part3/node_js_and_express#receiving-data | 400 bad request | https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1 | https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request
https://fullstackopen.com/en/part3/node_js_and_express#about-http-request-types | The HTTP standard | https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html | https://www.rfc-editor.org/rfc/rfc9110.html#name-common-method-properties
https://fullstackopen.com/en/part3/node_js_and_express#about-http-request-types | HEAD | https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4 | https://www.rfc-editor.org/rfc/rfc9110.html#name-head