### PR TITLE
Add NOTE about creating Cypress spec file name

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -104,6 +104,8 @@ We start the test from the opened window:
 ![](../../images/5/40x.png)
 
 **NOTE**: you might need to restart Cypress after deleting the example tests.
+  
+**NOTE**: If you are using Cypress ^10.1.0, the <i>integration</i> subdirectory is gone and replaced with <i>e2e</i> subdirectory due to the introduction of component testing. It is also recommended to name E2E test file with this convention <i>note\_app.cy.js</i> but you can specify any pattern using specPattern option in the <i>cypress.config.js</i> file.
 
 Running the test opens your browser and shows how the application behaves as the test is run:
 


### PR DESCRIPTION
I came across the issue where *.spec.js was not being picked up by Cypress ^10.1.0 so upon research found that new extension convention should be *.cy.js. So, I am proposing an added NOTE for anyone using Cypress ^10.1.0