### PR TITLE
Fix broken links in the Finnish version of FAQ

### DIFF
--- a/src/content/pages/faq.json
+++ b/src/content/pages/faq.json
@@ -3,13 +3,13 @@
     {
       "title": "Miten kurssille ilmoittaudutaan?",
       "text": [
-        "Kurssille ei tarvitse varsinaisesti ilmoittautua ennen kuin haluat tehdä kurssin kokeen ja tarvitset virallisen suoritusmerkinnän. Koe tehdään Avoimen yliopiston Moodle-järjestelmään. Katso lisää <a href='/osa0/yleista#arvosteluperusteet'>täältä</a>."
+        "Kurssille ei tarvitse varsinaisesti ilmoittautua ennen kuin haluat tehdä kurssin kokeen ja tarvitset virallisen suoritusmerkinnän. Koe tehdään Avoimen yliopiston Moodle-järjestelmään. Katso lisää <a href='/osa0/yleista#osat-ja-suorittaminen'>täältä</a>."
       ]
     },
     {
       "title": "Mikä on kurssin laajuus?",
       "text": [
-        "Kurssin laajuus on <a href='/osa0/yleista#arvosteluperusteet'>riippuen tekemiesi tehtävien määrästä</a> 5-14 opintopistettä. Suoritettuasi kurssin voit jatkaa aihepiiriin syventymistä 1-10 opintopisteen laajuisen <a href='/osa0/yleista#full-stack-harjoitustyo'>Full stack -harjoitustyön</a> parissa."
+        "Kurssin laajuus on <a href='/osa0/yleista#osat-ja-suorittaminen'>riippuen tekemiesi tehtävien määrästä</a> 5-14 opintopistettä. Suoritettuasi kurssin voit jatkaa aihepiiriin syventymistä 1-10 opintopisteen laajuisen <a href='/osa0/yleista#full-stack-harjoitustyo'>Full stack -harjoitustyön</a> parissa."
       ]
     },
     {
@@ -39,7 +39,7 @@
     {
       "title": "Milloin ja miten saan kurssilta suoritusmerkinnän?",
       "text": [
-        "Saat suoritusmerkinnän sen jälkeen kun olet tehnyt hyväksyttävään suoritukseen oikeuttavan määrän tehtäviä, suorittanut kokeen hyväksytysti ja ilmoittanut palautussovelluksessa olevasi valmis kurssin suorituksen kanssa. Viimeinen mahdollinen suorituspäivä on 10.1.2023. Lue lisää <a href='/osa0/yleista#arvosteluperusteet'>täältä</a>."
+        "Saat suoritusmerkinnän sen jälkeen kun olet tehnyt hyväksyttävään suoritukseen oikeuttavan määrän tehtäviä, suorittanut kokeen hyväksytysti ja ilmoittanut palautussovelluksessa olevasi valmis kurssin suorituksen kanssa. Viimeinen mahdollinen suorituspäivä on 10.1.2023. Lue lisää <a href='/osa0/yleista#osat-ja-suorittaminen'>täältä</a>."
       ]
     },
     {


### PR DESCRIPTION
I already fixed these links earlier in the English version of the FAQ page. Turns out, they are not working in the Finnish version either.