### PR TITLE
Make the spelling of all [this GitHub repository] references consistent

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -904,7 +904,7 @@ If the data saved in the _body_ variable has the <i>important</i> property, the 
 > To be exact, when the <i>important</i> property is <i>false</i>, then the <em>body.important || false</em> expression will in fact return the <i>false</i> from the right-hand side...
 
 
-You can find the code for our current application in its entirety in the <i>part3-1</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-1).
+You can find the code for our current application in its entirety in the <i>part3-1</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-1).
 
 
 The code for the current state of the application is specifically in branch [part3-1](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-1).
@@ -1137,7 +1137,7 @@ app.use(unknownEndpoint)
 ```
 
 
-You can find the code for our current application in its entirety in the <i>part3-2</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-2).
+You can find the code for our current application in its entirety in the <i>part3-2</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-2).
 
 </div>
 

--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -615,7 +615,7 @@ It's probably a good idea to integrate the frontend and backend one functionalit
 
 Once we introduce a database into the mix, it is useful to inspect the state persisted in the database, e.g. from the control panel in MongoDB Atlas. Quite often little Node helper programs like the <i>mongo.js</i> program we wrote earlier can be very helpful during development.
 
-You can find the code for our current application in its entirety in the <i>part3-4</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-4).
+You can find the code for our current application in its entirety in the <i>part3-4</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-4).
 
 </div>
 
@@ -885,7 +885,7 @@ There is one important detail regarding the use of the <em>findByIdAndUpdate</em
 
 After testing the backend directly with Postman and the VS Code REST client, we can verify that it seems to work. The frontend also appears to work with the backend using the database. 
 
-You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-5).
+You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-5).
 
 </div>
 

--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -142,7 +142,7 @@ The application should now work. Sometimes things don't go according to plan. If
 
 For some reason the URL of the database was undefined. The <i>heroku config</i> command revealed that I had accidentally defined the URL to the <em>MONGO\_URL</em> environment variable, when the code expected it to be in <em>MONGODB\_URI</em>.
 
-You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this github repository](https://github.com/fullstack-hy2019/part3-notes-backend/tree/part3-5).
+You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this GitHub repository](https://github.com/fullstack-hy2019/part3-notes-backend/tree/part3-5).
 
 </div>
 
@@ -388,7 +388,7 @@ If there is something wrong in your configuration file, the lint plugin can beha
 
 Many companies define coding standards that are enforced throughout the organization through the ESlint configuration file. It is not recommended to keep reinventing the wheel over and over again, and it can be a good idea to adopt a ready-made configuration from someone else's project into yours. Recently many projects have adopted the Airbnb [Javascript style guide](https://github.com/airbnb/javascript) by taking Airbnb's [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) configuration into use.
 
-You can find the code for our current application in its entirety in the <i>part3-7</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-7).
+You can find the code for our current application in its entirety in the <i>part3-7</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-7).
 </div>
 
 <div class="tasks">

--- a/src/content/3/zh/part3a.md
+++ b/src/content/3/zh/part3a.md
@@ -1065,7 +1065,7 @@ important: body.important || false,
  > 确切地说，当<i>重要</i>属性是<i>false</i>时，那么<em>body.important || false</em>表达式实际上将从右侧返回<i>false</i>...
 
 
-<!-- You can find the code for our current application in its entirety in the <i>part3-1</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-1).-->
+<!-- You can find the code for our current application in its entirety in the <i>part3-1</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-1).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-1)的<i>part3-1</i>分支中找到我们当前应用的全部代码。
 
 
@@ -1348,7 +1348,7 @@ app.use(unknownEndpoint)
 ```
 
 
-<!-- You can find the code for our current application in its entirety in the <i>part3-2</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-2).-->
+<!-- You can find the code for our current application in its entirety in the <i>part3-2</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-2).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-2)的<i>part3-2</i>分支中找到我们当前应用的全部代码。
 
 </div>

--- a/src/content/3/zh/part3c.md
+++ b/src/content/3/zh/part3c.md
@@ -724,7 +724,7 @@ app.get('/api/notes/:id', (request, response) => {
 <!-- Once we introduce a database into the mix, it is useful to inspect the state persisted in the database, e.g. from the control panel in MongoDB Atlas. Quite often little Node helper programs like the <i>mongo.js</i> program we wrote earlier can be very helpful during development.-->
  一旦我们引入数据库，检查数据库中持久化的状态是很有用的，例如从MongoDB Atlas的控制面板中。很多时候，像我们之前写的<i>mongo.js</i>程序这样的小Node辅助程序在开发过程中会很有帮助。
 
-<!-- You can find the code for our current application in its entirety in the <i>part3-4</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-4).-->
+<!-- You can find the code for our current application in its entirety in the <i>part3-4</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-4).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-4)的<i>part3-4</i>分支中找到我们当前应用的全部代码。
 
 </div>
@@ -1006,7 +1006,7 @@ There is one important detail regarding the use of the <em>findByIdAndUpdate</em
 
 After testing the backend directly with Postman and the VS Code REST client, we can verify that it seems to work. The frontend also appears to work with the backend using the database.
 
-You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-5).
+You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-5).
 
 </div>
 

--- a/src/content/3/zh/part3d.md
+++ b/src/content/3/zh/part3d.md
@@ -160,7 +160,7 @@ heroku config:set MONGODB_URI='mongodb+srv://fullstack:secretpasswordhere@cluste
 <!-- For some reason the URL of the database was undefined. The <i>heroku config</i> command revealed that I had accidentally defined the URL to the <em>MONGO\_URL</em> environment variable, when the code expected it to be in <em>MONGODB\_URI</em>.-->
  由于某些原因，数据库的URL未被定义。<i>heroku config</i>命令显示，我不小心将URL定义在<em>MONGO\_URL</em>环境变量中，而代码希望它在<em>MONGODB\_URI</em>。
 
-<!-- You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this github repository](https://github.com/fullstack-hy2019/part3-notes-backend/tree/part3-5).-->
+<!-- You can find the code for our current application in its entirety in the <i>part3-5</i> branch of [this GitHub repository](https://github.com/fullstack-hy2019/part3-notes-backend/tree/part3-5).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2019/part3-notes-backend/tree/part3-5)的<i>part3-5</i>分支中找到我们当前应用的全部代码。
 
 </div>
@@ -448,7 +448,7 @@ build
 <!-- Many companies define coding standards that are enforced throughout the organization through the ESlint configuration file. It is not recommended to keep reinventing the wheel over and over again, and it can be a good idea to adopt a ready-made configuration from someone else's project into yours. Recently many projects have adopted the Airbnb [Javascript style guide](https://github.com/airbnb/javascript) by taking Airbnb's [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) configuration into use.-->
  许多公司定义了编码标准，并通过ESlint配置文件在整个组织内强制执行。我们不建议一次又一次地重新发明轮子，从别人的项目中采用一个现成的配置到你的项目中是一个好主意。最近，许多项目采用了Airbnb的[Javascript style guide](https://github.com/airbnb/javascript)，将Airbnb的[ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb)配置运用到了其中。
 
-<!-- You can find the code for our current application in its entirety in the <i>part3-7</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-7).-->
+<!-- You can find the code for our current application in its entirety in the <i>part3-7</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-7).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part3-7)的<i>part3-7</i>分支中找到我们当前应用的全部代码。
 </div>
 

--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -335,7 +335,7 @@ For smaller applications the structure does not matter that much. Once the appli
 
 There is no strict directory structure or file naming convention that is required for Express applications. To contrast this, Ruby on Rails does require a specific structure. Our current structure simply follows some of the best practices you can come across on the internet.
 
-You can find the code for our current application in its entirety in the <i>part4-1</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-1).
+You can find the code for our current application in its entirety in the <i>part4-1</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-1).
 
 If you clone the project for yourself, run the _npm install_ command before starting the application with _npm start_.
 

--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -115,7 +115,7 @@ The _config_ module that we have implemented slightly resembles the [node-config
 
 These are the only changes we need to make to our application's code.
 
-You can find the code for our current application in its entirety in the <i>part4-2</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-2).
+You can find the code for our current application in its entirety in the <i>part4-2</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-2).
 
 
 ### supertest
@@ -476,7 +476,7 @@ notesRouter.get('/', async (request, response) => {
 
 We can verify that our refactoring was successful by testing the endpoint through the browser and by running the tests that we wrote earlier.
 
-You can find the code for our current application in its entirety in the <i>part4-3</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-3).
+You can find the code for our current application in its entirety in the <i>part4-3</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-3).
 
 ### More tests and refactoring the backend
 
@@ -803,7 +803,7 @@ notesRouter.delete('/:id', async (request, response, next) => {
 })
 ```
 
-You can find the code for our current application in its entirety in the <i>part4-4</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-4).
+You can find the code for our current application in its entirety in the <i>part4-4</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-4).
 
 ### Eliminating the try-catch
 
@@ -1222,7 +1222,7 @@ There is still room for improvement, but it is time to move forward.
 This way of testing the API, by making HTTP requests and inspecting the database with Mongoose, is by no means the only nor the best way of conducting API-level integration tests for server applications. There is no universal best way of writing tests, as it all depends on the application being tested and available resources.
 
 
-You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6).
+You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6).
 
 </div>
 

--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -421,7 +421,7 @@ The list looks like this:
 ![](../../images/4/9.png)
 
 
-You can find the code for our current application in its entirety in the <i>part4-7</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-7).
+You can find the code for our current application in its entirety in the <i>part4-7</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-7).
 
 ### Creating a new note
 
@@ -556,6 +556,6 @@ const noteSchema = new mongoose.Schema({
 })
 ```
 
-You can find the code for our current application in its entirety in the <i>part4-8</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-8).
+You can find the code for our current application in its entirety in the <i>part4-8</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-8).
 
 </div>

--- a/src/content/4/zh/part4a.md
+++ b/src/content/4/zh/part4a.md
@@ -367,7 +367,7 @@ module.exports = mongoose.model('Note', noteSchema)
 <!-- There is no strict directory structure or file naming convention that is required for Express applications. To contrast this, Ruby on Rails does require a specific structure. Our current structure simply follows some of the best practices you can come across on the internet.-->
  Express应用没有严格的目录结构或文件命名惯例要求。与此相反，Ruby on Rails确实需要一个特定的结构。我们目前的结构只是简单地遵循了一些你可以在网上看到的最佳实践。
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-1</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-1).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-1</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-1).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-1)的<i>part4-1</i>分支中找到我们当前应用的全部代码。
 
 <!-- If you clone the project for yourself, run the _npm install_ command before starting the application with _npm start_.-->

--- a/src/content/4/zh/part4b.md
+++ b/src/content/4/zh/part4b.md
@@ -134,7 +134,7 @@ TEST_MONGODB_URI=mongodb+srv://fullstack:<password>@cluster0.o1opl.mongodb.net/t
 <!-- These are the only changes we need to make to our application's code.-->
  这些是我们需要对我们的应用的代码进行的唯一修改。
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-2</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-2).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-2</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-2).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-2)的<i>part4-2</i>分支中找到我们当前应用的全部代码。
 
 
@@ -549,7 +549,7 @@ notesRouter.get('/', async (request, response) => {
 <!-- We can verify that our refactoring was successful by testing the endpoint through the browser and by running the tests that we wrote earlier.-->
  我们可以通过浏览器测试端点和运行我们之前写的测试来验证我们的重构是否成功。
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-3</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-3).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-3</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-3).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-3)的<i>part4-3</i>分支中找到我们当前应用的全部代码。
 
 ### More tests and refactoring the backend
@@ -897,7 +897,7 @@ notesRouter.delete('/:id', async (request, response, next) => {
 })
 ```
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-4</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-4).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-4</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-4).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-4)的<i>part4-4</i>分支中找到我们当前应用的全部代码。
 
 ### Eliminating the try-catch
@@ -1367,7 +1367,7 @@ afterAll(() => {
  这种测试API的方式，即通过HTTP请求和用Mongoose检查数据库，决不是对服务器应用进行API级集成测试的唯一或最佳方式。编写测试没有通用的最佳方式，因为它完全取决于被测试的应用和可用的资源。
 
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this Github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-6</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-6)的<i>part4-6</i>分支中找到我们当前应用的全部代码。
 
 </div>

--- a/src/content/4/zh/part4c.md
+++ b/src/content/4/zh/part4c.md
@@ -463,7 +463,7 @@ usersRouter.get('/', async (request, response) => {
 ![](../../images/4/9.png)
 
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-7</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-7).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-7</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-7).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-7)的<i>part4-7</i>分支中找到我们当前应用的全部代码。
 
 ### Creating a new note
@@ -617,7 +617,7 @@ const noteSchema = new mongoose.Schema({
 })
 ```
 
-<!-- You can find the code for our current application in its entirety in the <i>part4-8</i> branch of [this github repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-8).-->
+<!-- You can find the code for our current application in its entirety in the <i>part4-8</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-8).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-8)的<i>part4-8</i>分支中找到我们当前应用的全部代码。
 
 </div>

--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -289,7 +289,7 @@ Next let's define the form component inside of a <i>Togglable</i> component:
 ```
 
 
-You can find the code for our current application in its entirety in the <i>part5-4</i> branch of [this github repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-4).
+You can find the code for our current application in its entirety in the <i>part5-4</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-4).
 
 
 ### State of the forms
@@ -475,7 +475,7 @@ This trick works for changing the state of a component, but it looks a bit unple
 
 There are also [other use cases](https://reactjs.org/docs/refs-and-the-dom.html) for refs than accessing React components.
 
-You can find the code for our current application in its entirety in the <i>part5-6</i> branch of [this github repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-6).
+You can find the code for our current application in its entirety in the <i>part5-6</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-6).
 
 ### One point about components
 
@@ -829,7 +829,7 @@ Togglable.displayName = 'Togglable' // highlight-line
 export default Togglable
 ```
 
-You can find the code for our current application in its entirety in the <i>part5-7</i> branch of [this github repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-7).
+You can find the code for our current application in its entirety in the <i>part5-7</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-7).
 
 Note that create-react-app has also a [default ESLint-configuration](https://www.npmjs.com/package/eslint-config-react-app), that we have now overriden. [The documentation](https://create-react-app.dev/docs/setting-up-your-editor/#extending-or-replacing-the-default-eslint-config) mentions that it is ok to replace the default but does not encourage to that:
  <i>We highly recommend extending the base config, as removing it could introduce hard-to-find issues</i>.

--- a/src/content/5/zh/part5b.md
+++ b/src/content/5/zh/part5b.md
@@ -314,7 +314,7 @@ const NoteForm = ({ onSubmit, handleChange, value}) => {
 ```
 
 
-<!-- You can find the code for our current application in its entirety in the <i>part5-4</i> branch of [this github repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-4).-->
+<!-- You can find the code for our current application in its entirety in the <i>part5-4</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-4).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part2-notes/tree/part5-4)的<i>part5-4</i>分支中找到我们当前应用的全部代码。
 
 
@@ -525,7 +525,7 @@ const App = () => {
 <!-- There are also [other use cases](https://reactjs.org/docs/refs-and-the-dom.html) for refs than accessing React components.-->
 除了访问React组件，还有[其他用例](https://reactjs.org/docs/refs-and-the-dom.html)的参考文献。
 
-<!-- You can find the code for our current application in its entirety in the <i>part5-6</i> branch of [this github repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-6).-->
+<!-- You can find the code for our current application in its entirety in the <i>part5-6</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-6).-->
 你可以在[这个github仓库](https://github.com/fullstack-hy2020/part2-notes/tree/part5-6)的<i>part5-6</i>分支中找到我们当前应用的全部代码。
 
 ### One point about components
@@ -926,7 +926,7 @@ Togglable.displayName = 'Togglable' // highlight-line
 export default Togglable
 ```
 
-<!-- You can find the code for our current application in its entirety in the <i>part5-7</i> branch of [this github repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-7).-->
+<!-- You can find the code for our current application in its entirety in the <i>part5-7</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/part2-notes/tree/part5-7).-->
  你可以在[这个github仓库](https://github.com/fullstack-hy2020/part2-notes/tree/part5-7)的<i>part5-7</i>分支中找到我们当前应用的全部代码。
 
 <!-- Note that create-react-app has also a [default ESLint-configuration](https://www.npmjs.com/package/eslint-config-react-app), that we have now overriden. [The documentation](https://create-react-app.dev/docs/setting-up-your-editor/#extending-or-replacing-the-default-eslint-config) mentions that it is ok to replace the default but does not encourage to that:-->

--- a/src/content/6/en/part6b.md
+++ b/src/content/6/en/part6b.md
@@ -615,7 +615,7 @@ It is also possible to dispatch actions to the store using the development tools
 
 ![](../../images/6/13ea.png)
 
-You can find the code for our current application in its entirety in the <i>part6-2</i> branch of [this Github repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-2).
+You can find the code for our current application in its entirety in the <i>part6-2</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-2).
 
 </div>
 

--- a/src/content/6/en/part6d.md
+++ b/src/content/6/en/part6d.md
@@ -340,7 +340,7 @@ export default connect(
 Since the component does not need to access the store's state, we can simply pass <i>null</i> as the first parameter to _connect_. 
 
 
-You can find the code for our current application in its entirety in the <i>part6-5</i> branch of [this Github repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-5).
+You can find the code for our current application in its entirety in the <i>part6-5</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-5).
 
 ### Referencing action creators passed as props
 

--- a/src/content/6/zh/part6b.md
+++ b/src/content/6/zh/part6b.md
@@ -667,7 +667,7 @@ describe('noteReducer', () => {
 
 ![](../../images/6/13ea.png)
 
-<!-- You can find the code for our current application in its entirety in the <i>part6-2</i> branch of [this Github repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-2).-->
+<!-- You can find the code for our current application in its entirety in the <i>part6-2</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-2).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/redux-notes/tree/part6-2)的<i>part6-2</i>分支中找到我们当前应用的全部代码。
 
 </div>

--- a/src/content/6/zh/part6d.md
+++ b/src/content/6/zh/part6d.md
@@ -367,7 +367,7 @@ export default connect(
  由于该组件不需要访问商店的状态，我们可以简单地传递<i>null</i>作为_connect_的第一个参数。
 
 
-<!-- You can find the code for our current application in its entirety in the <i>part6-5</i> branch of [this Github repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-5).-->
+<!-- You can find the code for our current application in its entirety in the <i>part6-5</i> branch of [this GitHub repository](https://github.com/fullstack-hy2020/redux-notes/tree/part6-5).-->
  你可以在[这个Github仓库](https://github.com/fullstack-hy2020/redux-notes/tree/part6-5)的<i>part6-5</i>分支中找到我们当前应用的全部代码。
 
 ### Referencing action creators passed as props


### PR DESCRIPTION
The course material contains multiple references to code examples on GitHub. However, these lines are not consistent in their spelling of the name *GitHub*. I am suggesting making all these references use the same spelling.