### PR TITLE
Requires camelCase instead of snake_case.

### DIFF
--- a/src/content/13/en/part13c.md
+++ b/src/content/13/en/part13c.md
@@ -620,12 +620,12 @@ Membership.init({
     primaryKey: true,
     autoIncrement: true
   },
-  user_id: {
+  userId: {
     type: DataTypes.INTEGER,
     allowNull: false,
     references: { model: 'users', key: 'id' },
   },
-  team_id: {
+  teamId: {
     type: DataTypes.INTEGER,
     allowNull: false,
     references: { model: 'teams', key: 'id' },


### PR DESCRIPTION
In model definition of membership model it requires camelCase instead of snake_case.