### PR TITLE
Removed Note regarding M1 CPU's not supported by Cypress

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -78,8 +78,6 @@ Let's add an npm-script to <i>the backend</i> which starts it in test mode, or s
 ```
 
 NB! In order to get Cypress working with WSL2 one might need to do some additional configuring first. These two [links](https://docs.cypress.io/guides/getting-started/installing-cypress#Windows-Subsystem-for-Linux) are great places to [start](https://nickymeuleman.netlify.app/blog/gui-on-wsl2-cypress).
-
-NB! For macbooks with m1 CPU instead of intel ones, cypress wouldn't work since it doesn't support m1 yet. To fix that, installing Rosetta 2 then configuring your terminal is a must. For step by step instructions follow [here](https://www.cypress.io/blog/2021/01/20/running-cypress-on-the-apple-m1-silicon-arm-architecture-using-rosetta-2/).
   
 When both backend and frontend are running, we can start Cypress with the command
 


### PR DESCRIPTION
On June 21, 2022 Cypress released their version [10.2.0](https://docs.cypress.io/guides/references/changelog#10-2-0) which added Native Support for Apple Silicon Chips (M1 and M2), so now the Rosetta 2 translation layer is no longer required for running cypress. [Announcement regarding the Native Support on their Blog.](https://cypress-io.ghost.io/blog/2022/06/21/cypress-10-2-0-run-tests-up-to-2x-faster-on-apple-silicon-m1/)