### PR TITLE
Fix description about using switch statement and store's subscribe methodd

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -74,7 +74,7 @@ const counterReducer = (state, action) => {
 
 The first parameter is the <i>state</i> in the store. Reducer returns a <i>new state</i> based on the actions type. 
 
-Let's change the code a bit. It is customary to use the [switch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch) -command instead of ifs in a reducer. 
+Let's change the code a bit. We have used if-else statements to respond to an action and change the state. However, the [switch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch) statement is the most common approach to write a reducer.
 
 Let's also define a [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) of 0 for the parameter <i>state</i>. Now the reducer works even if the store -state has not been primed yet. 
 
@@ -138,7 +138,7 @@ would print the following to the console
 
 because at first the state of the store is 0. After three <i>INCREMENT</i>-actions the state is 3. In the end, after <i>ZERO</i> and <i>DECREMENT</i> actions, the state is -1.
 
-The third important method the store has is [subscribe](https://redux.js.org/api/store#subscribelistener), which is used to create callback functions the store calls when its state is changed.
+The third important method the store has is [subscribe](https://redux.js.org/api/store#subscribelistener), which is used to create callback functions the store calls whenever an action is dispatched to the store.
 
 If, for example, we would add the following function to subscribe, <i>every change in the store</i> would be printed to the console.
 


### PR DESCRIPTION
## Changes

Changed course material descriptions that were incorrect according to the Redux official documentation  -
- text mentioning customary usage of switch statement inside a reducer - This is just a common approach and not mandatory. [docs reference](https://redux.js.org/faq/reducers/#do-i-have-to-use-the-switch-statement-to-handle-actions) 
- text stating store.subscribe() being called only when the state changes - The method is called whenever an action is dispatched irrespective of state being changed. [docs reference](https://redux.js.org/api/store#subscribelistener) 