### PR TITLE
Changed "and and to" to "and"

### DIFF
--- a/src/content/0/en/part0a.md
+++ b/src/content/0/en/part0a.md
@@ -188,7 +188,7 @@ You will receive your credits after you have submitted enough exercises for a pa
 
 ![](../../images/0/28a.png)
 
-You can view your grade in University of Helsinki Sisu and and to [Opintopolku](https://opintopolku.fi/oma-opintopolku/) approximately four weeks after notifying us.
+You can view your grade in University of Helsinki Sisu and [Opintopolku](https://opintopolku.fi/oma-opintopolku/) approximately four weeks after notifying us.
 
 **Please note** that in order to get university credits you need a registration for each completed part, please see [more info about registration](/en/part0/general_info#parts-and-completion).
 


### PR DESCRIPTION
Was "University of Helsinki Sisu and and to "Opintopolku" -> unclear / bad grammar
Now "University of Helsinki Sisu and Opintopolku" -> is this what it was meant to say?