### PR TITLE
Add more context about the notes project

### DIFF
--- a/src/content/2/en/part2c.md
+++ b/src/content/2/en/part2c.md
@@ -11,7 +11,7 @@ For a while now we have only been working on "frontend", i.e. client-side (brows
 
 Let's use a tool meant to be used during software development called [JSON Server](https://github.com/typicode/json-server) to act as our server.
 
-Create a file named <i>db.json</i> in the root directory of the project with the following content:
+Create a file named <i>db.json</i> in the root directory of the previous notes project with the following content:
 
 ```json
 {


### PR DESCRIPTION
This change reminds readers that we are adding code to the notes project, not the phonebook app. Since the exercises from the previous section (2b) deal with the phonebook app, it can be easy to forget to switch back to the notes project without any context in section 2C. The only cue currently is the `notes` property in the json file which is easy to miss, and later down in the effects-hook section. I've added a simple reference at the top to the notes project to avoid confusion and mistakes.