### PR TITLE
Remove trailing comma in expected JSON output

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -729,7 +729,7 @@ Implement a todo counter that saves the number of created todos to Redis:
 
 ```json
 {
-  "added_todos": 0,
+  "added_todos": 0
 }
 ```
 


### PR DESCRIPTION
Unlike JavaScript, JSON doesn't allow trailing commas.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas