### PR TITLE
Remove space from PUT request example in ex7.8

### DIFF
--- a/src/content/7/en/part7b.md
+++ b/src/content/7/en/part7b.md
@@ -457,7 +457,7 @@ const create = async newObject => {
 }
 
 const update = async (id, newObject) => {
-  const response = await axios.put(`${ baseUrl } /${id}`, newObject)
+  const response = await axios.put(`${ baseUrl }/${id}`, newObject)
   return response.data
 }
 


### PR DESCRIPTION
Space at line 460 between baseUrl and '/' should be removed from template literal