### PR TITLE
Make the reducer sample match the unicafe-redux repository

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -600,8 +600,9 @@ const counterReducer = (state = initialState, action) => {
       return state
     case 'ZERO':
       return state
+    default: return state
   }
-  return state
+
 }
 
 export default counterReducer


### PR DESCRIPTION
The reducer example differs slightly from the [corresponding file](https://github.com/fullstack-hy2020/unicafe-redux/blob/main/src/reducer.js) in the unicafe-redux repository.