### PR TITLE
part 5c: convert test function to async since findAllByText returns a promise

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -365,8 +365,8 @@ describe('<Togglable />', () => {
     ).container
   })
 
-  test('renders its children', () => {
-    screen.findAllByText('togglable content')
+  test('renders its children', async () => {
+    await screen.findAllByText('togglable content')
   })
 
   test('at start the children are not displayed', () => {


### PR DESCRIPTION
Convert test function to async since `findAllByText` [returns a promise](https://testing-library.com/docs/queries/about/#types-of-queries). In its current form, the test passes regardless of the query text (if test ends within the `findAllByText` timeout). Alternatively, convert test function to `getAllByText`.