### PR TITLE
Update part8c.md

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -307,12 +307,15 @@ const server = new ApolloServer({
   context: async ({ req }) => {
     const auth = req ? req.headers.authorization : null
     if (auth && auth.toLowerCase().startsWith('bearer ')) {
-      const decodedToken = jwt.verify(
+      try {
+        const decodedToken = jwt.verify(
         auth.substring(7), JWT_SECRET
-      )
-
-      const currentUser = await User.findById(decodedToken.id).populate('friends')
-      return { currentUser }
+        )
+        const currentUser = await User.findById(decodedToken.id).populate('friends')
+        return { currentUser }
+      } catch(error) {
+        // It is OK to let the request proceed and reach unauthorized resolvers
+      }
     }
   }
   // highlight-end


### PR DESCRIPTION
I found that without gracefully handling exceptions from jwt.verify() Apollo Studio Explorer is not able to introspect the schema since its requests fail at the context creation.