### PR TITLE
missing exporting the App component

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -617,6 +617,8 @@ const App = () => {
 
   return <Course course={course} />
 }
+
+export default App
 ```
 
 Define a component responsible for formatting a single course called <i>Course</i>. 

--- a/src/content/2/es/part2a.md
+++ b/src/content/2/es/part2a.md
@@ -638,6 +638,8 @@ const App = () => {
 
   return <Course course={course} />
 }
+
+export default App
 ```
 
 Defina un componente responsable de formatear un solo curso llamado <i>Course</i>.

--- a/src/content/2/fi/osa2a.md
+++ b/src/content/2/fi/osa2a.md
@@ -617,6 +617,8 @@ const App = () => {
     </div>
   )
 }
+
+export default App
 ```
 
 Määrittele sovellukseen yksittäisen kurssin muotoilusta huolehtiva komponentti <i>Course</i>.

--- a/src/content/2/zh/part2a.md
+++ b/src/content/2/zh/part2a.md
@@ -720,6 +720,8 @@ const App = () => {
 
   return <Course course={course} />
 }
+
+export default App
 ```
 
 <!-- Define a component responsible for formatting a single course called <i>Course</i>.-->


### PR DESCRIPTION
it's not something important but it may confuse someone if he just copy and past the component you give him.

the exercise `2.1: Course information step6` in part 2 say:
**Let's change the App component like so:**
```js
const App = () => {
  const course = {
    id: 1,
    name: 'Half Stack application development',
    parts: [
      {
        name: 'Fundamentals of React',
        exercises: 10,
        id: 1
      },
      {
        name: 'Using props to pass data',
        exercises: 7,
        id: 2
      },
      {
        name: 'State of a component',
        exercises: 14,
        id: 3
      }
    ]
  }

  return <Course course={course} />
}
```
just copying and pasting this will cause an error `export 'default' (imported as 'App') was not found in './App' (module has no exports)` .. because of missing exporting the App component 