### PR TITLE
Update grammar in part9b.md

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -72,7 +72,7 @@ Let us add the project a configuration file _tsconfig.json_ with the following c
 }
 ```
 
-The <i>tsconfig.json</i> file is used to define how the TypeScript compiler should interpret the code, how strictly the compiler should work, which files to watch or ignore, and [much much more](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
+The <i>tsconfig.json</i> file is used to define how the TypeScript compiler should interpret the code, how strictly the compiler should work, which files to watch or ignore, and [much more](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 For now we will only use the compiler option [noImplicitAny](https://www.typescriptlang.org/tsconfig#noImplicitAny), that does not require to have types for all variables used.
 
 Let's start by creating a simple Multiplier. It looks exactly as it would in JavaScript.


### PR DESCRIPTION
While "much much more" is grammatically correct, it is better expressed using a comma as "much, much more". Further, I wouldn't use it in formal writing (e.g. teaching material). I think simply writing "much more" is better for this type of material.