### PR TITLE
Update outdated links

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -789,7 +789,7 @@ The response is what we expect it to be:
 
 ### Exercises 9.10.-9.11.
 
-Similarly to Ilari's flight service, we do not use a real database in our app but instead use hardcoded data that is in the files [diagnoses.json](https://github.com/fullstack-hy/misc/blob/master/diagnoses.json) and [patients.json](https://github.com/fullstack-hy/misc/blob/master/patients.json). Get the files and store those in a directory called <i>data</i> in your project. All data modification can be done in runtime memory, so during this part it is <i>not necessary to write to a file</i>.
+Similarly to Ilari's flight service, we do not use a real database in our app but instead use hardcoded data that is in the files [diagnoses.json](https://github.com/fullstack-hy2020/misc/blob/master/diagnoses.json) and [patients.json](https://github.com/fullstack-hy2020/misc/blob/master/patients.json). Get the files and store those in a directory called <i>data</i> in your project. All data modification can be done in runtime memory, so during this part it is <i>not necessary to write to a file</i>.
 
 #### 9.10: Patientor backend, step3
 


### PR DESCRIPTION
Alternatively, the links could be directed to the following, which reflects the changes from the `master` branch to the `main` branch:
- [diagnoses.json](https://github.com/fullstack-hy/misc/blob/main/diagnoses.json): `https://github.com/fullstack-hy/misc/blob/main/diagnoses.json`
- [patients.json](https://github.com/fullstack-hy/misc/blob/main/patients.json): `https://github.com/fullstack-hy/misc/blob/main/patients.json`

I chose to use the `https://github.com/fullstack-hy2020/misc` repo since that's what the other links in the course have used up to this point.