### PR TITLE
Remove deprecation warning options

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -63,7 +63,7 @@ const MONGODB_URI = 'mongodb+srv://databaseurlhere'
 
 console.log('connecting to', MONGODB_URI)
 
-mongoose.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
+mongoose.connect(MONGODB_URI)
   .then(() => {
     console.log('connected to MongoDB')
   })


### PR DESCRIPTION
As per [this page](https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options), Mongoose V6 no longer requires/supports these options.