### PR TITLE
Typo in 'Eliminating the try-catch' section

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -896,7 +896,7 @@ notesRouter.post('/', async (request, response) => {
   })
 
   const savedNote = await note.save()
-  response.json(savedNote)
+  response.status(201).json(savedNote)
 })
 
 notesRouter.get('/:id', async (request, response) => {


### PR DESCRIPTION
Typo in the notesRouter.post method which causes the tests to fail. The code is correct in the Github branch part4-5 I believe.