### PR TITLE
mongo is replaced with mongosh

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -596,7 +596,7 @@ Refresh the page, and our message is displayed! Now we know how exec can be used
 
 While the MongoDB from the previous exercise is running, access the database with mongo command-line interface (CLI). You can do that using docker exec. Then add a new todo using the CLI.
 
-The command to open CLI when inside the container is _mongo_
+The command to open CLI when inside the container is _mongosh_
 
 The mongo CLI will require the username and password flags to authenticate correctly. Flags _-u root -p example_ should work, the values are from the docker-compose.dev.yml.
 


### PR DESCRIPTION
[mongo is replaced with mongosh command to enter into the mongo cli when in a container](https://stackoverflow.com/questions/73582703/mongo-command-not-found-on-mongodb-6-0-docker-container
)