### PR TITLE
Fix console warning

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -224,9 +224,8 @@ const App = () => {
   )
 }
 
-const renderApp = () => {
-  ReactDOM.createRoot(document.getElementById('root')).render(<App />)
-}
+const root = ReactDOM.createRoot(document.getElementById('root'))
+const renderApp = () => root.render(<App />)
 
 renderApp()
 store.subscribe(renderApp)


### PR DESCRIPTION
As the code is structure now, a console warning is thrown:
```
You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. Instead, call root.render() on the existing root instead if you want to update it.
```
This PR refactors the code so that we are not calling createRoot() multiple times.