### PR TITLE
Grammar correction

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -202,7 +202,7 @@ We defined a new type, _WelcomeProps_, and passed it to the function's parameter
 const Welcome = (props: WelcomeProps) => {
 ```
 
-You could write the same thing using a less verbose syntax:
+You could write the same thing using a more verbose syntax:
 
 ```jsx
 const Welcome = ({ name }: { name: string }) => (


### PR DESCRIPTION
Less verbose would mean less words, or more concise, but the example below is more "complicated" than the example above. The adjective could also be removed entirely, since verbose just means "containing more words than necessary".