### PR TITLE
Add web archive link for angular 2.0 announcement

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -580,7 +580,7 @@ jQuery was developed back when web applications mainly followed the traditional 
 
 The rise of the single page app brought several more "modern" ways of web development than jQuery. The favorite of the first wave of developers was [BackboneJS](http://backbonejs.org/). After its [launch](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#100-temporal-domination-2012-06-13) in 2012, Google's [AngularJS](https://angularjs.org/) quickly became almost the de facto standard of modern web development. 
 
-However, the popularity of Angular plummeted in October 2014 after the [Angular team announced that support for version 1 will end](https://jaxenter.com/angular-2-0-announcement-backfires-112127.html), and Angular 2 will not be backwards compatible with the first version. Angular 2 and the newer versions have not gotten too warm of a welcome. 
+However, the popularity of Angular plummeted in October 2014 after the [Angular team announced that support for version 1 will end](https://web.archive.org/web/20151208002550/https://jaxenter.com/angular-2-0-announcement-backfires-112127.html), and Angular 2 will not be backwards compatible with the first version. Angular 2 and the newer versions have not gotten too warm of a welcome. 
 
 Currently the most popular tool for implementing the browser-side logic of web-applications is Facebook's [React](https://reactjs.org/) library. 
 During this course, we will get familiar with React and the [Redux](https://github.com/reactjs/redux) library, which are frequently used together. 


### PR DESCRIPTION
The original URL <https://jaxenter.com/angular-2-0-announcement-backfires-112127.html> is unreachable, so I added a web.archive.org link instead.