### PR TITLE
Fix frontpage hero z-index issue

### DIFF
--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -323,6 +323,7 @@ a {
 
 .frontpage-hero__content {
   @include to($desktop) {
+    z-index: 1;
     margin-bottom: 3rem;
   }
 }


### PR DESCRIPTION
Fixes issue with #2279, hero button was only partially clickable in mobile due to image overlap