### PR TITLE
Update part12c.md

### DIFF
--- a/src/content/12/en/part12c.md
+++ b/src/content/12/en/part12c.md
@@ -255,6 +255,7 @@ A word of warnig for Windows users: it has been reported that the hot relading d
 
 Create <i>todo-frontend/docker-compose.dev.yml</i> and use volumes to enable the development of the todo-frontend while it is running <i>inside</i> a container.
 
+However, take note that in Widows system, hot update might still not work despite bind mounting - container needs to be restarted to see changes. The reason might be <a href="https://github.com/microsoft/WSL/issues/6255#issuecomment-730701001">this</a>. Even setting  environment: - WATCHPACK_POLLING=true does not help the situation.
 </div>
 
 <div class="content">


### PR DESCRIPTION
In Windows react app in browser does not update despite container bind mount to app files. File changes are correctly seen by container. However file& folder inodes are different in container and host machine: inode_container = inode_host+2. Why is this?