### PR TITLE
Create part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -404,7 +404,13 @@ We can verify in the browser that the backend works for displaying all of the do
 
 The application works almost perfectly. The frontend assumes that every object has a unique id in the <i>id</i> field. We also don't want to return the mongo versioning field <i>\_\_v</i> to the frontend.
 
-One way to format the objects returned by Mongoose is to [modify](https://stackoverflow.com/questions/7034848/mongodb-output-id-instead-of-id) the _toJSON_ method of the schema, which is used on all instances of the models produced with that schema. Modifying the method works like this:
+One way to format the objects returned by Mongoose is to [modify](https://stackoverflow.com/questions/7034848/mongodb-output-id-instead-of-id) the _toJSON_ method of the schema, which is used on all instances of the models produced with that schema.
+  
+to modify the method we need to change the configurable options of the schema, options can be changed using the set method of the schema see here for more info on this method: https://mongoosejs.com/docs/guide.html#options
+
+see https://mongoosejs.com/docs/guide.html#toJSON and  https://mongoosejs.com/docs/api.html#document_Document-toObject for more info on the toJSON option.
+  
+see https://mongoosejs.com/docs/api.html#transform for more info on the transform function.
 
 ```js
 noteSchema.set('toJSON', {


### PR DESCRIPTION
without providing more info on the set method on the schema it may seem to a beginer like myself that we are setting some sort of instance method, i did some research and found out that this is not the case and that we are actually configuring options on the schema. i have added some links to the docs that explain what we are actually doing here. this seems like quite and advanced use of mongoose and i wonder if it is only adding confusion to make this change so early on.