### PR TITLE
Remove accidental extra sentence from the Finnish version

### DIFF
--- a/src/content/7/fi/osa7d.md
+++ b/src/content/7/fi/osa7d.md
@@ -325,8 +325,6 @@ Sovellusta voi nyt kokeilla avaamalla tiedoston <i>build/index.html</i> selaimen
 
 ![](../../images/7/22.png)
 
-Asian korjaamiseksi on asennettava vielä yksi puuttuva riippuvuus, [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill).
-
 On kuitenkin huomionarvoista, että jos sovelluksemme sisältää <i>async/await</i>-toiminnallisuutta, selaimeen ei joillain selaimilla renderöidy mitään. [Konsoliin tulostuneen virheviestin googlaaminen](https://stackoverflow.com/questions/33527653/babel-6-regeneratorruntime-is-not-defined) valaisee asiaa. Ongelma korjaantuu asentamalla kirjastot [core-js](https://www.npmjs.com/package/core-js) ja [regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime)
 
 ```bash


### PR DESCRIPTION
The removed sentence is missing from the English version [here](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/blob/source/src/content/7/en/part7d.md?plain=1#L333), and the corresponding sentence was removed in commit 41556e496bf0063aef5282ed10322333f9ef422d due to [@babel/polyfill deprecation](https://babeljs.io/docs/en/babel-polyfill).