### PR TITLE
Updated part8 links and replacing deprecated API option

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -538,10 +538,10 @@ const resolvers = {
 
 
 
-With subscriptions, the communication happens using the [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) principle utilizing the object [PubSub](https://www.apollographql.com/docs/graphql-subscriptions/setup/#setup).
+With subscriptions, the communication happens using the [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) principle utilizing the object [PubSub](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#the-pubsub-class).
 
 There is only few lines of code added, but quite much is happening under the hood. The resolver of the _personAdded_ subscription registers and saves info about all the clients that do the subscription. The clients are saved to an 
-["iterator object"](https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema.html) called <i>PERSON\_ADDED</i>  thanks to the following code:
+["iterator object"](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#listening-for-events) called <i>PERSON\_ADDED</i>  thanks to the following code:
 
 ```js
 Subscription: {

--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -136,7 +136,7 @@ Technically speaking, the HTTP protocol is not well-suited for communication fro
 
 ### Refactoring the backend
 
-Since version 3.0 Apollo Server has not provided support for subscriptions out of the box so we need to do some changes to get it set up. Let us also clean the app structure a bit.
+Since version 3.0 Apollo Server does not support subscriptions out of the box so we need to do some changes before we set up subscriptions. Let us also clean the app structure a bit.
 
 Let us start by extracting the schema definition to file
 <i>schema.js</i>
@@ -403,7 +403,7 @@ type Subscription {
 
 So when a new person is added, all of its details are sent to all subscribers.
 
-First, we have to install two packages for adding subscriptions to GraphQL:
+First, we have to install two packages for adding subscriptions to GraphQL and a Node.js WebSocket library:
 
 ```
 npm install graphql-subscriptions ws graphql-ws
@@ -483,7 +483,7 @@ start()
 
 When queries and mutations are used, GraphQL uses the HTTP protocol in the communication. In case of subscriptions, the communication between client and server happens with [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
 
-The below code registers a WebSocketServer object to listen the WebSocket connections, besides the usual HTTP connections that the server listens. The second part of the definition registers a function that closes the WebSocket connection on server shutdown.
+The above code registers a WebSocketServer object to listen the WebSocket connections, besides the usual HTTP connections that the server listens. The second part of the definition registers a function that closes the WebSocket connection on server shutdown.
 
 WebSockets are a perfect match for communication in the case of GraphQL subscriptions since when WebSockets are used, also the server can initiate the communication.
 

--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -684,8 +684,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      console.log(subscriptionData)
+    onData: ({ data }) => {
+      console.log(data)
     }
   })
 
@@ -699,7 +699,7 @@ When a new person is now added to the phonebook, no matter where it's done, the 
 ![](../../images/8/32e.png)
 
 
-When a new person is added, the server sends a notification to the client, and the callback function defined in the _onSubscriptionData_ attribute is called and given the details of the new person as parameters. 
+When a new person is added, the server sends a notification to the client, and the callback function defined in the _onData_ attribute is called and given the details of the new person as parameters. 
 
 Let's extend our solution so that when the details of a new person are received, the person is added to the Apollo cache, so it is rendered to the screen immediately. 
 
@@ -708,8 +708,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
 
       // highlight-start
@@ -760,8 +760,8 @@ const App = () => {
   const client = useApolloClient() 
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData, client }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data, client }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
       updateCache(client.cache, { query: ALL_PERSONS }, addedPerson) // highlight-line
     },

--- a/src/content/8/es/part8e.md
+++ b/src/content/8/es/part8e.md
@@ -329,8 +329,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      console.log(subscriptionData)
+    onData: ({ data }) => {
+      console.log(data)
     }
   })
 
@@ -342,7 +342,7 @@ Cuando se agrega una nueva persona a la agenda, no independientemente de dónde 
 
 ![](../../images/8/32e.png)
 
-Cuando se agrega una nueva persona, el servidor envía una notificación al cliente y se llama a la función de devolución de llamada definida en el atributo _onSubscriptionData_ y se le dan los detalles. de la nueva persona como parámetros.
+Cuando se agrega una nueva persona, el servidor envía una notificación al cliente y se llama a la función de devolución de llamada definida en el atributo _onData_ y se le dan los detalles. de la nueva persona como parámetros.
 
 Extendamos nuestra solución para que cuando se reciban los detalles de una nueva persona, la persona se agregue a la caché de Apollo, de modo que se muestre en la pantalla de inmediato.
 
@@ -366,8 +366,8 @@ const App = () => {
   }
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
       updateCacheWith(addedPerson)
     }

--- a/src/content/8/es/part8e.md
+++ b/src/content/8/es/part8e.md
@@ -132,7 +132,7 @@ Las suscripciones son radicalmente diferentes a todo lo que hemos visto en este 
 Con las suscripciones la situación es la contraria. Una vez que una aplicación se ha suscrito, comienza a escuchar al servidor.
 Cuando ocurren cambios en el servidor, envía una notificación a todos sus <i>suscriptores</i>.
 
-Técnicamente hablando, el protocolo HTTP no es adecuado para la comunicación desde el servidor al navegador, por lo que Apollo usa [WebSockets] (https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API ) para la comunicación del suscriptor del servidor.
+Técnicamente hablando, el protocolo HTTP no es adecuado para la comunicación desde el servidor al navegador, por lo que Apollo usa [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API ) para la comunicación del suscriptor del servidor.
 
 ### Suscripciones en el servidor
 
@@ -189,9 +189,9 @@ const pubsub = new PubSub() // highlight-line
   // highlight-end
 ```
 
-Con las suscripciones, la comunicación ocurre usando el principio [publicar-suscribir](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) utilizando un objeto usando un [PubSub](https://www.apollographql.com/docs/graphql-subscriptions/setup/#setup) interfaz. Agregar una nueva persona <i> publica </i> una notificación sobre la operación a todos los suscriptores con el método _publish_ de PubSub.
+Con las suscripciones, la comunicación ocurre usando el principio [publicar-suscribir](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) utilizando un objeto usando un [PubSub](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#the-pubsub-class) interfaz. Agregar una nueva persona <i> publica </i> una notificación sobre la operación a todos los suscriptores con el método _publish_ de PubSub.
 
-_personAdded_ subscriptions resolver registra a todos los suscriptores devolviéndoles un [objeto iterador] adecuado (https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema/).
+_personAdded_ subscriptions resolver registra a todos los suscriptores devolviéndoles un [objeto iterador](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#listening-for-events) adecuado .
 
 Hagamos los siguientes cambios en el código que inicia el servidor
 
@@ -219,7 +219,7 @@ Es posible probar las suscripciones con el patio de juegos de GraphQL de esta ma
 
 Cuando presiona "reproducir" en una suscripción, el área de juegos espera las notificaciones de la suscripción.
 
-El código de backend se puede encontrar en [Github] (https://github.com/fullstack-hy2020/graphql-phonebook-backend/tree/part8-6), rama <i>part8-6</i>.
+El código de backend se puede encontrar en [Github](https://github.com/fullstack-hy2020/graphql-phonebook-backend/tree/part8-6), rama <i>part8-6</i>.
 
 ### Suscripciones en el cliente
 
@@ -565,13 +565,13 @@ Si modificamos _allPersons_ para hacer una consulta de combinación porque a vec
 > <i>Los programadores pierden una enorme cantidad de tiempo pensando o preocupándose por la velocidad de las partes no críticas de sus programas, y estos intentos de eficiencia en realidad tienen un fuerte impacto negativo cuando se consideran la depuración y el mantenimiento. Deberíamos olvidarnos de las pequeñas eficiencias, digamos alrededor del 97% del tiempo: <strong>la optimización prematura es la raíz de todos los males.</strong></i>
 
 [DataLoader](https://github.com/facebook/dataloader) de Facebook ofrece una buena solución para el problema n + 1 entre otros problemas.
-Más sobre el uso de DataLoader con el servidor Apollo [aquí] (https://www.robinwieruch.de/graphql-apollo-server-tutorial/#graphql-server-data-loader-caching-batching) y [aquí](http://www.petecorey.com/blog/2017/08/14/batching-graphql-queries-with-dataloader/).
+Más sobre el uso de DataLoader con el servidor Apollo [aquí](https://www.robinwieruch.de/graphql-apollo-server-tutorial/#graphql-server-data-loader-caching-batching) y [aquí](http://www.petecorey.com/blog/2017/08/14/batching-graphql-queries-with-dataloader/).
 
 ### Epílogo
 
 La aplicación que creamos en esta parte no está estructurada de manera óptima: el esquema, las consultas y las mutaciones deben al menos moverse fuera del código de la aplicación. En Internet se pueden encontrar ejemplos para una mejor estructuración de las aplicaciones GraphQL. Por ejemplo, para el servidor [aquí](https://blog.apollographql.com/modularizing-your-graphql-schema-code-d7f71d5ed5f2) y el cliente [aquí](https://medium.com/@peterpme/thoughts-on-structuring-your-apollo-queries-mutations-939ba4746cd8).
 
-GraphQL ya es una tecnología bastante antigua, que ha sido utilizada por Facebook desde 2012, por lo que ya podemos verla como "probada en batalla". Desde que Facebook publicó GraphQL en 2015, poco a poco ha recibido más y más atención, y en un futuro cercano podría amenazar el dominio de REST. La muerte de REST también ha sido [predicha] (https://www.stridenyc.com/podcasts/52-is-2018-the-year-graphql-kills-rest). Aunque eso no sucederá todavía, GraphQL es absolutamente digno de [aprender] (https://blog.graphqleditor.com/javascript-predictions-for-2019-by-npm/).
+GraphQL ya es una tecnología bastante antigua, que ha sido utilizada por Facebook desde 2012, por lo que ya podemos verla como "probada en batalla". Desde que Facebook publicó GraphQL en 2015, poco a poco ha recibido más y más atención, y en un futuro cercano podría amenazar el dominio de REST. La muerte de REST también ha sido [predicha](https://www.stridenyc.com/podcasts/52-is-2018-the-year-graphql-kills-rest). Aunque eso no sucederá todavía, GraphQL es absolutamente digno de [aprender](https://blog.graphqleditor.com/javascript-predictions-for-2019-by-npm/).
 
 </div>
 

--- a/src/content/8/fi/osa8e.md
+++ b/src/content/8/fi/osa8e.md
@@ -527,9 +527,9 @@ const resolvers = {
 }
 ```
 
-Tilausten yhteydessä kommunikaatio tapahtuu [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern)-periaatteella käyttäen olioa [PubSub](https://www.apollographql.com/docs/graphql-subscriptions/setup.html#setup).
+Tilausten yhteydessä kommunikaatio tapahtuu [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern)-periaatteella käyttäen olioa [PubSub](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#the-pubsub-class).
 
-Koodia on vähän mutta konepellin alla tapahtuu paljon. Tilauksen _personAdded_ resolverissa palvelin rekisteröi ja tallettaa muistiin tiedon kaikista sille tilauksen tehneistä clienteista. Nämä tallentuvat seuraavan koodinpätkän ansiosta nimellä <i>PERSON\_ADDED</i> varustettuun ["iteraattoriolioon"](https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema.html):
+Koodia on vähän mutta konepellin alla tapahtuu paljon. Tilauksen _personAdded_ resolverissa palvelin rekisteröi ja tallettaa muistiin tiedon kaikista sille tilauksen tehneistä clienteista. Nämä tallentuvat seuraavan koodinpätkän ansiosta nimellä <i>PERSON\_ADDED</i> varustettuun ["iteraattoriolioon"](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#listening-for-events):
 
 ```js
 Subscription: {

--- a/src/content/8/fi/osa8e.md
+++ b/src/content/8/fi/osa8e.md
@@ -670,8 +670,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      console.log(subscriptionData)
+    onData: ({ data }) => {
+      console.log(data)
     }
   })
 
@@ -683,7 +683,7 @@ Kun puhelinluetteloon nyt lisätään henkilöitä, tapahtuupa se mistä tahansa
 
 ![](../../images/8/32e.png)
 
-Kun luetteloon lisätään uusi henkilö, palvelin lähettää siitä tiedot clientille ja attribuutin _onSubscriptionData_ arvoksi määriteltyä callback-funktiota kutsutaan antaen sille parametriksi palvelimelle lisätty henkilö. 
+Kun luetteloon lisätään uusi henkilö, palvelin lähettää siitä tiedot clientille ja attribuutin _onData_ arvoksi määriteltyä callback-funktiota kutsutaan antaen sille parametriksi palvelimelle lisätty henkilö. 
 
 Laajennetaan ratkaisua vielä siten, että uuden henkilön tietojen saapuessa henkilö lisätään Apollon välimuistiin, jolloin se renderöityy heti ruudulle:
 
@@ -692,8 +692,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
 
 // highlight-start
@@ -744,8 +744,8 @@ const App = () => {
   const client = useApolloClient() 
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData, client }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data, client }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
       updateCache(client.cache, { query: ALL_PERSONS }, addedPerson) // highlight-line
     },

--- a/src/content/8/zh/part8e.md
+++ b/src/content/8/zh/part8e.md
@@ -688,8 +688,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      console.log(subscriptionData)
+    onData: ({ data }) => {
+      console.log(data)
     }
   })
 
@@ -704,8 +704,8 @@ const App = () => {
 ![](../../images/8/32e.png)
 
 
-<!-- When a new person is added, the server sends a notification to the client, and the callback function defined in the _onSubscriptionData_ attribute is called and given the details of the new person as parameters.-->
- 当一个新的人被添加时，服务器向客户端发送一个通知，在_onSubscriptionData_属性中定义的回调函数被调用，并给出新的人的细节作为参数。
+<!-- When a new person is added, the server sends a notification to the client, and the callback function defined in the _onData_ attribute is called and given the details of the new person as parameters.-->
+ 当一个新的人被添加时，服务器向客户端发送一个通知，在_onData_属性中定义的回调函数被调用，并给出新的人的细节作为参数。
 
 <!-- Let's extend our solution so that when the details of a new person are received, the person is added to the Apollo cache, so it is rendered to the screen immediately.-->
  让我们扩展我们的解决方案，当收到一个新的人的详细资料时，这个人被添加到Apollo缓存中，所以它被立即渲染到屏幕上。
@@ -715,8 +715,8 @@ const App = () => {
   // ...
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
 
       // highlight-start
@@ -766,8 +766,8 @@ const App = () => {
   const client = useApolloClient()
 
   useSubscription(PERSON_ADDED, {
-    onSubscriptionData: ({ subscriptionData, client }) => {
-      const addedPerson = subscriptionData.data.personAdded
+    onData: ({ data, client }) => {
+      const addedPerson = data.data.personAdded
       notify(`${addedPerson.name} added`)
       updateCache(client.cache, { query: ALL_PERSONS }, addedPerson) // highlight-line
     },

--- a/src/content/8/zh/part8e.md
+++ b/src/content/8/zh/part8e.md
@@ -555,11 +555,11 @@ const pubsub = new PubSub() // highlight-line
   // highlight-end
 ```
 
-<!-- With subscriptions, the communication happens using the [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) principle utilizing the object [PubSub](https://www.apollographql.com/docs/graphql-subscriptions/setup/#setup). Adding a new person <i>publishes</i> a notification about the operation to all subscribers with PubSub's method _publish_.-->
- 通过订阅，通信是利用对象[PubSub](https://www.apollographql.com/docs/graphql-subscriptions/setup/#setup)的[发布-订阅](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern)原则进行的。添加一个新的人<i>发布</i>一个关于该操作的通知给所有使用PubSub's方法_publish_的订阅者。
+<!-- With subscriptions, the communication happens using the [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) principle utilizing the object [PubSub](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#the-pubsub-class). Adding a new person <i>publishes</i> a notification about the operation to all subscribers with PubSub's method _publish_.-->
+ 通过订阅，通信是利用对象[PubSub](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#the-pubsub-class)的[发布-订阅](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern)原则进行的。添加一个新的人<i>发布</i>一个关于该操作的通知给所有使用PubSub's方法_publish_的订阅者。
 
-<!-- _personAdded_ subscriptions resolver registers all of the subscribers by returning them a suitable [iterator object](https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema/).-->
- _personAdded_订阅解析器通过返回一个合适的[迭代器对象](https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema/)来注册所有的订阅者。
+<!-- _personAdded_ subscriptions resolver registers all of the subscribers by returning them a suitable [iterator object](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#listening-for-events).-->
+ _personAdded_订阅解析器通过返回一个合适的[迭代器对象](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#listening-for-events)来注册所有的订阅者。
 
 <!-- It's possible to test the subscriptions with the Apollo Explorer like this:-->
  可以这样用Apollo Explorer来测试订阅。


### PR DESCRIPTION
Hello, 

This PR has the following changes

- Small fixes for English translation

- Links updated to point to the correct part of the Apollo GraphQL documentation.

- Updated deprecated `onSubscriptionData` option of `useSubscription` API to `onData` 
Currently using `onSubscriptionData` will give a warning on the browser console that its been deprecated and we should use `onData`. 

![onSubscriptionData is deprecated warning in browser console](https://user-images.githubusercontent.com/39148877/196989574-30c814c1-ab78-4fc0-924f-896e85d69dde.png)

The documentation for [`useSubscription` API](https://www.apollographql.com/docs/react/data/subscriptions/#usesubscription-api-reference) says that `useSubscriptionData` and the returned data as `subscriptionData` has now been replaced by `onData` which returns subscription data as `data` instead.

![onSubscriptionData - onData](https://user-images.githubusercontent.com/39148877/196989976-bfbcecfc-d3cf-466f-aa63-2109d4ed6f4e.png)


I tried it and it works. So I replaced the code in the content for the same. 

This will also need fixing in the [graphql-phonebook-frontend](https://github.com/fullstack-hy2020/graphql-phonebook-frontend/tree/part8-9/src) repo. I wasn't sure if that repo is open for contributions by us, So if it is open to be updated by us, let me know I can help with that too.

Thank you. 