### PR TITLE
change ClassName to Id

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -317,7 +317,7 @@ data.forEach(function(note) {
 Finally, the tree branch of the <em>ul</em> variable is connected to its proper place in the HTML tree of the whole page: 
 
 ```js
-document.getElementsByClassName('notes').appendChild(ul)
+document.getElementById('notes').appendChild(ul)
 ```
 
 ### Manipulating the document-object from console


### PR DESCRIPTION
the code section depicted used the `document.getElementsByClassName` DOM API to get the `element` with the class of `notes` but no such elements exists. It should rather be the id of `notes`