### PR TITLE
Update part3b.md

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -95,7 +95,7 @@ If you know some other good and easy to use services for hosting NodeJS, please 
 For both Fly.io and Heroku, we need to change the definition of the port our application uses at the bottom of the <i>index.js</i> file like so: 
 
 ```js
-const PORT = process.env.PORT || 3001  // highlight-line
+const PORT = process.env.PORT || "3001"  // highlight-line
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)
 })


### PR DESCRIPTION
In line 98, about the configuration of port for Fly.io or Heroku, I tried the port number without double quotes but it did not work for me, as I tried couple of times. But when I placed the port number inside double quotes then it started working. Is there anything that I have misunderstood or does the port number should be inside double quotes?