### PR TITLE
Update part3d.md

### DIFF
--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -231,7 +231,7 @@ We will answer all of the questions:
 
 ![](../../images/3/52be.png)
 
-The configuration will be saved in the _.eslintrc.js_ file:
+The configuration will be saved in the _.eslintrc.cjs_ file:
 
 ```js
 module.exports = {


### PR DESCRIPTION
When I installed eslint and configured, the configuration is saved in a file named .eslintrc.cjs but according to your instruction, configurations are saved in a file named .eslintrc.js What is the difference between these two extensions of .cjs and .js or does the instruction on material needs to be modified?