### PR TITLE
Space removed between catch and parameter to keep consistency 

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -797,7 +797,7 @@ notesRouter.delete('/:id', async (request, response, next) => {
   try {
     await Note.findByIdAndRemove(request.params.id)
     response.status(204).end()
-  } catch (exception) {
+  } catch(exception) {
     next(exception)
   }
 })


### PR DESCRIPTION
Purpose change is about keeping consistency with no space between catch and parameter as in previous examples.