### PR TITLE
Update typescript docs link

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -545,7 +545,7 @@ Let's specify the following configurations in our <i>tsconfig.json</i> file:
 
 Do not worry too much about the <i>compilerOptions</i>; they will be under closer inspection later on.
 
-You can find explanations for each of the configurations from the TypeScript documentation, or from the really handy [tsconfig page](https://www.staging-typescript.org/tsconfig), or from the tsconfig [schema definition](http://json.schemastore.org/tsconfig), which unfortunately is formatted a little worse than the first two options. 
+You can find explanations for each of the configurations from the TypeScript documentation, or from the really handy [tsconfig page](https://www.typescriptlang.org/tsconfig), or from the tsconfig [schema definition](http://json.schemastore.org/tsconfig), which unfortunately is formatted a little worse than the first two options. 
 
 ### Adding Express to the mix
 


### PR DESCRIPTION
The current link for the tsconfig docs page goes to TypeScript's staging system. Replaced it with a prod link.