### PR TITLE
Update part13a.md

### DIFF
--- a/src/content/13/en/part13a.md
+++ b/src/content/13/en/part13a.md
@@ -311,7 +311,7 @@ The Fly.io connect-string is of the form
 
 ```bash
 $ cat .env
-DATABASE_URL=postgres://postgres:<password>@localhost:5432/postgres
+DATABASE_URL=postgres://postgres:<password>@127.0.0.1:5432/postgres
 ```
 
 Password was shown when the database was created, so hopefully you have not lost it!


### PR DESCRIPTION
Under section 'Node application using a relational database'. fly.io DATABASE_URL. localhost doesn't work. But if change to 127.0.0.1 it works.