### PR TITLE
Removing the need for jest-watch-typeahead@0.6.5 (Part 5c)

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -255,12 +255,6 @@ Let us install a library [user-event](https://testing-library.com/docs/user-even
 npm install --save-dev @testing-library/user-event
 ```
 
-At the moment of writing (28.1.2022) there is a mismatch between the version of a dependency jest-watch-typeahead that create-react-app and user-event are using. The problem is fixed by installing a specific version:
-
-```
-npm install -D --exact jest-watch-typeahead@0.6.5
-```
-
 Testing this functionality can be accomplished like this:
 
 ```js


### PR DESCRIPTION
The tests needed for Part 5c from Section "Clicking buttons in tests" to the end of Part 5c no longer require this specific version of jest-watch-typeahead as long as the version of @testing-library/user-event is at least 14.4.3 running with react@18.2.0. The specific dependencies of node packages I used to verify this can be found here: https://github.com/leekahung/fullstackopen-tutorial/blob/main/part5c/package.json

Can make a note of versions in case error occurs due to previous versions of packages causing mismatch dependencies.