### PR TITLE
Use current apollographql.com link

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -331,7 +331,7 @@ const server = new ApolloServer({
 
 The first parameter, _typeDefs_, contains the GraphQL schema. 
 
-The second parameter is an object, which contains the [resolvers](https://www.apollographql.com/docs/tutorial/resolvers/) of the server. These are the code, which defines <i>how</i> GraphQL queries are responded to. 
+The second parameter is an object, which contains the [resolvers](https://www.apollographql.com/tutorials/fullstack-quickstart/04-writing-query-resolvers) of the server. These are the code, which defines <i>how</i> GraphQL queries are responded to. 
 
 The code of the resolvers is the following: 
 


### PR DESCRIPTION
The `apollographql.com` website seems to have changed their link structure. The link used in the course, https://www.apollographql.com/docs/tutorial/resolvers/ , is resolved to https://www.apollographql.com/tutorials/fullstack-quickstart/writing-query-resolvers. However, this link does not seem to work anymore. The one I proposed seems to work at the moment.