### PR TITLE
Part8a, updated import for Apollo Server v3

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -260,7 +260,7 @@ Also create a `index.js` file in your project's root directory.
 The initial code is as follows: 
 
 ```js
-const { ApolloServer, gql } = require('@apollo/server')
+const { ApolloServer, gql } = require('apollo-server')
 
 let persons = [
   {


### PR DESCRIPTION
The `apollo-server` package is part of Apollo Server v2 and v3, and has to be imported/required from 'apollo-server', not '@apollo/server'. The latter is for version 4.