### PR TITLE
Update part3b.md

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -109,7 +109,7 @@ If you know some other good and easy-to-use services for hosting NodeJS, please 
 For both Fly.io and Heroku, we need to change the definition of the port our application uses at the bottom of the <i>index.js</i> file like so: 
 
 ```js
-const PORT = process.env.PORT || 3001  // highlight-line
+const PORT = process.env.PORT || 8080  // highlight-line
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)
 })


### PR DESCRIPTION
For fly.io, the internal port should be 8080. The line of code: "const PORT = process.env.PORT || 3001" won't work for fly.io