### PR TITLE
small correction

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -165,12 +165,7 @@ notesRouter.post('/', async (request, response) => {
   const body = request.body
 //highlight-start
   const token = getTokenFrom(request)
-
   const decodedToken = jwt.verify(token, process.env.SECRET)
-  if (!decodedToken.id) {
-    return response.status(401).json({ error: 'token missing or invalid' })
-  }
-
   const user = await User.findById(decodedToken.id)
 //highlight-end
 
@@ -196,16 +191,6 @@ const decodedToken = jwt.verify(token, process.env.SECRET)
 ```
 
 The object decoded from the token contains the <i>username</i> and <i>id</i> fields, which tell the server who made the request. 
-
-If the object decoded from the token does not contain the user's identity (_decodedToken.id_ is undefined), error status code [401 unauthorized](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2) is returned and the reason for the failure is explained in the response body. 
-
-```js
-if (!decodedToken.id) {
-  return response.status(401).json({
-    error: 'token missing or invalid'
-  })
-}
-```
 
 When the identity of the maker of the request is resolved, the execution continues as before. 
 
@@ -249,7 +234,7 @@ const errorHandler = (error, request, response, next) => {
     })
   } else if (error.name === 'JsonWebTokenError') {  // highlight-line
     return response.status(401).json({ // highlight-line
-      error: 'invalid token' // highlight-line
+      error: 'token missing or invalid' // highlight-line
     }) // highlight-line
   }
 


### PR DESCRIPTION
```js  
const decodedToken = jwt.verify(token, process.env.SECRET)
```
The snippet above will throw an error if the signature is not valid, therefore the following snippet is redundant because it will never execute:

```js
  if (!decodedToken.id) {
    return response.status(401).json({ error: 'token missing or invalid' })
  }
```
As a result, the following paragraph is incorrect:
> If the object decoded from the token does not contain the user's identity (_decodedToken.id_ is undefined) 

The token is initially created based on the value stored in `process.env.SECRET`  as well as the following object:
```js
  const userForToken = {
    username: user.username,
    id: user._id
  };
```

if something is wrong with the hash computation when `jwt.verify` is invoked, a `JsonWebTokenError` is thrown and NOT an object with a missing `id` property.   

According to the docs of the `jsonwebtoken` library: 

> jwt.verify(token, secretOrPublicKey, [options, callback])
(Asynchronous) If a callback is supplied, function acts asynchronously. The callback is called with the decoded payload if the signature is valid and optional expiration, audience, or issuer are valid. If not, it will be called with the error.

> (Synchronous) If a callback is not supplied, the function acts synchronously. Returns the payload decoded if the signature is *valid* and optional expiration, audience, or issuer are valid. If not, **it will throw the error**.


JsonWebTokenError
Error object:

* name: 'JsonWebTokenError'
* message:
  - 'invalid token' - the header or payload could not be parsed
  - 'jwt malformed' - the token does not have three components (delimited by a .)
  - 'jwt signature is required'
  - 'invalid signature'
  - 'jwt audience invalid. expected: [OPTIONS AUDIENCE]'
  - 'jwt issuer invalid. expected: [OPTIONS ISSUER]'
  - 'jwt id invalid. expected: [OPTIONS JWT ID]'
  - 'jwt subject invalid. expected: [OPTIONS SUBJECT]'


The only scenario that I can think of, where the following snippet might be executed :
```js
  if (!decodedToken.id) {
    return response.status(401).json({ error: 'token missing or invalid' })
  }
```

is if we built the jwt tokens around a plain object that doesn't have an `id` property in the `loginRouter.post` handler within `./controllers/login.js`.  like so :
```js
loginRouter.post('/', async (request, response) => {
  const { username, password } = request.body;

  const user = await User.findOne({ username });
  const passwordCorrect = user === null ? false : await bcrypt.compare(password, user.passwordHash);

  if (!(user && passwordCorrect)) {
    return response.status(401).json({
      error: 'invalid usernamee or password'
    });
  }

  const userForToken = {
    username: user.username,
    // id: user._id           // we remove this property here
  };

  const token = jwt.sign(userForToken, process.env.SECRET, { expiresIn: 60*60 });

  response
    .status(200)
    .send({ token, username: user.username, name: user.name})
})
```

But since that's not part of the course implementation, that conditional expression is redundant. 

In the event an error is thrown, it will be handled by the `errorHandler` middleware within `/utils/middleware.js`, which effectively does the same thing and returns the `status` code we want along with the error message