### PR TITLE
Update config.js-Spanish term for Spanish

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,6 @@ export const TRANSLATION_LANGUAGE_OPTIONS = [
   { value: 'fi', label: 'Suomi' },
   { value: 'en', label: 'English' },
   { value: 'zh', label: '中文' },
-  { value: 'es', label: 'Spanish' },
+  { value: 'es', label: 'Español' },
   { value: 'fr', label: 'Français' },
 ];


### PR DESCRIPTION
All other language option labels are in their respective language except for Spanish which is written in English. Spanish in Spanish is Español.