### PR TITLE
Fix markdown formatting for 2 underlines

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -513,7 +513,7 @@ Open the <i>Network</i> tab and empty it. When you now create a new note, you'll
 
 ![Network tab in developer tools](../../images/0/26e.png)
 
-The POST request to the address <i>new_note_spa</i> contains the new note as JSON data containing both the content of the note (<i>content</i>) and the timestamp (<i>date</i>):
+The POST request to the address <i>new\_note\_spa</i> contains the new note as JSON data containing both the content of the note (<i>content</i>) and the timestamp (<i>date</i>):
 
 ```js
 {
@@ -570,7 +570,7 @@ var sendToServer = function(note) {
 The code determines that the data is to be sent with an HTTP POST request and the data type is to be JSON. The data type is determined with a <i>Content-type</i> header. Then the data is sent as JSON string.
 
 The application code is available at <https://github.com/mluukkai/example_app>.
-It's worth remembering that the application is only meant to demonstrate the concepts of the course. The code follows a poor style of development in some measures, and should not be used as an example when creating your applications. The same is true for the URLs used. The URL <i>new_note_spa</i> that new notes are sent to, does not adhere to current best practices.
+It's worth remembering that the application is only meant to demonstrate the concepts of the course. The code follows a poor style of development in some measures, and should not be used as an example when creating your applications. The same is true for the URLs used. The URL <i>new\_note\_spa</i> that new notes are sent to, does not adhere to current best practices.
 
 ### JavaScript-libraries
 


### PR DESCRIPTION
new_note_spa is shown as new _note_ spa with false formatting because the underlines are wrongly interpreted if not escaped.

see just above the heading of this section [Part0 JavaScript-libraries](https://fullstackopen.com/en/part0/fundamentals_of_web_apps#java-script-libraries)