### PR TITLE
fix: InfoBanner dark theme styles

### DIFF
--- a/src/components/InfoBanner.js
+++ b/src/components/InfoBanner.js
@@ -16,7 +16,7 @@ const InfoBanner = ({ visible, onHide }) => {
     flexWrap: 'wrap',
     flexDirection: 'row',
     alignContent: 'space-between',
-    backgroundColor: '#E8E8E8',
+    backgroundColor: 'var(--color-background)',
     zIndex: 2147483647,
   };
 
@@ -38,11 +38,13 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
+    color: 'var(--color-text)',
+    cursor: 'pointer',
   };
 
   return (
     <div style={style}>
-      <div stule={textStyle}>
+      <div style={textStyle}>
         <p>Part 6 has new content about React Query, useReducer hook and React context.</p>
         <p>The new content replaces the chapter on Redux connect (that still remains online for a while).</p>
         <div style={{ marginTop: 10 }}><i>If you have already completed the part 6, this change has no effect on your progress.</i></div>


### PR DESCRIPTION
When using the dark theme, the banner has white text on a light background, making it unreadable.  This commit changes the background colour to an existing CSS variable. Also adjusts the close button colour to match text.