### PR TITLE
fix: typo and grammar

### DIFF
--- a/src/content/0/en/part0a.md
+++ b/src/content/0/en/part0a.md
@@ -43,7 +43,7 @@ Exercise completion time statistics can be found via the [submission system](htt
 
 You can discuss the course and related topics in our dedicated group on Discord <a target='_blank' href='https://study.cs.helsinki.fi/discord/join/fullstack'>https://study.cs.helsinki.fi/discord/join/fullstack</a> and on Telegram: <a target='_blank' href='https://t.me/fullstackcourse'>https://t.me/fullstackcourse</a>. Discord has fullstack_general and part-specific (channel names with fullstack prefix) channels for course-related discussion. Note that Discord's <i>chat channel is not suitable for course-related discussions</i>. Please join the conversation!
 
-### How to ask help in Discord/Telegam
+### How to get help in Discord/Telegram
 
 When you ask for help for a problem in the Discord/Telegram group your question should be as informative and precise as possible. If your question look like this
 


### PR DESCRIPTION
telegram had a typo: 'Telegam' to Telegram
"how to ask help" is also grammatically incorrect, "how to ask for help" would be correct, however, I wanted to keep character count relatively the same as other headers to avoid spacing issues.
I decided to use "how to get help" instead of "how to ask for help".