### PR TITLE
updated lesson content to match branch content

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -902,8 +902,10 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
     },
     baseUrl: 'http://localhost:3000',
-    BACKEND: 'http://localhost:3001/api' // highlight-line
   },
+  env: {
+    BACKEND: 'http://localhost:3001/api' // highlight-line
+  }
 })
 ```
 
@@ -912,14 +914,15 @@ Let's replace all the backend addresses from the tests in the following way
 ```js
 describe('Note ', function() {
   beforeEach(function() {
-    cy.visit('')
-    cy.request('POST', `${Cypress.env('EXTERNAL_API')}/testing/reset`) // highlight-line
+
+    cy.request('POST', `${Cypress.env('BACKEND')}/testing/reset`) // highlight-line
     const user = {
       name: 'Matti Luukkainen',
       username: 'mluukkai',
       password: 'secret'
     }
-    cy.request('POST', `${Cypress.env('EXTERNAL_API')}/users`, user) // highlight-line
+    cy.request('POST', `${Cypress.env('BACKEND')}/users`, user) // highlight-line
+    cy.visit('')
   })
   // ...
 })


### PR DESCRIPTION
The repo content on branch `part 5-10` doesn't match lesson content. This will create confusion for prospective students when their tests fail without any clear instruction as to why that happens.

I've updated the lesson content to reflect the changes made recently in the branch `part 5-10`.

On a side note, shouldn't clearing the database content be made through an HTTP `DELETE` request and not a `POST` request.
I am referring to `line 3` in the below snippet:
```js
describe('Note ', function() {
  beforeEach(function() {
    cy.request('POST', `${Cypress.env('BACKEND')}/testing/reset`) // highlight-line
    const user = {
      name: 'Matti Luukkainen',
      username: 'mluukkai',
      password: 'secret'
    }
    cy.request('POST', `${Cypress.env('BACKEND')}/users`, user) // highlight-line
    cy.visit('')
  })
  // ...
})
```

I understand that it is a destructive server operation. However, we're not posting/creating any content on the server(backend side) and only deleting the test notes and users. Wouldn't an HTTP `DELETE` request be more appropriate(RESTful) in this case?

Obviously, making the change would require updating the `tests` controller in the backend as well.  