### PR TITLE
Fix link in part6d - missing one char at the end of the link

### DIFF
--- a/src/content/6/en/part6e.md
+++ b/src/content/6/en/part6e.md
@@ -9,7 +9,7 @@ lang: en
 
 <div class="tasks">
 
-**NOTE**: this is the old ending section of the 6 part that has 30th January 2023 been replaced with material about [React Query, useReducer and context](/en/part6/react_query_use_reducer_and_the_contex). This section remains here for couple of weeks.
+**NOTE**: this is the old ending section of the 6 part that has 30th January 2023 been replaced with material about [React Query, useReducer and context](/en/part6/react_query_use_reducer_and_the_context). This section remains here for couple of weeks.
 
 If you have started with the exercises (6.19-6.21) that use the Redux connect you may continue with those. If you have not yet started, I recommend to proceed with the new section.
 </div>


### PR DESCRIPTION
Link to new material is leading to a 404 page - the "t" is missing from "context" at the end of the link