### PR TITLE
Update osa8a.md: Fix Typo

### DIFF
--- a/src/content/8/fi/osa8a.md
+++ b/src/content/8/fi/osa8a.md
@@ -947,7 +947,7 @@ pitäisi alustavalla datalla tuottaa vastaus
 }
 ```
 
-#### 8.2: kaikki kirjat ja kirjailijat
+#### 8.2: kaikki kirjat
 
 Toteuta kysely _allBooks_, joka palauttaa kaikki kirjat.
 


### PR DESCRIPTION
Tehtävässä 8.2 ei käsittääkseni ole vielä mitään tekemistä kirjailijoiden kanssa, ja englanninkielisellä sivulla kyseisen tehtävän nimi on "All Books". Luulen siis että kyseessä on kirjoitusvirhe.