### PR TITLE
Update osa4c.md

### DIFF
--- a/src/content/4/fi/osa4c.md
+++ b/src/content/4/fi/osa4c.md
@@ -402,7 +402,7 @@ Sovelluksen tämänhetkinen koodi on kokonaisuudessaan [GitHubissa](https://gith
 Muistiinpanot luovaa koodia on nyt mukautettava siten, että uusi muistiinpano tulee liitetyksi sen luoneeseen käyttäjään.
 
 Laajennetaan ensin olemassaolevaa toteutusta siten, että tieto muistiinpanon luovan käyttäjän id:stä lähetetään pyynnön rungossa kentän <i>userId</i> arvona:
-
+(TÄMÄ LAAJENNUS EI OLE GITHUBIN MALLIVERIOSSA JA NÄIN MYÖS NYKYISET TESIT EPÄONNISTUVAT)
 ```js
 const User = require('../models/user')
 


### PR DESCRIPTION
Githubin malliversio /controllers/notes.js on jäänyt jälkeen luvun 4c esimerkeistä. 