### PR TITLE
Fix to tests failing in Part 4 - Error handling and async/await

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -750,7 +750,8 @@ test('a specific note can be viewed', async () => {
     .expect(200)
     .expect('Content-Type', /application\/json/)
 // highlight-end
-
+  
+  resultNote.body.date = new Date(resultNote.body.date)
   expect(resultNote.body).toEqual(noteToView)
 })
 


### PR DESCRIPTION
Currently, line 755 fails the tests. Comparing resultNote.body to noteToView fails since resultNote.body.date is a date formatted as a String whereas noteToView.date is a Date object.

The solution is to simply use the date String in resultNote.body.date to create a new Date object and reassign to itself.

![Part4_ErrorHandlingAndAsyncAwait](https://user-images.githubusercontent.com/55110856/218555128-bb7bf496-d7a6-432c-9546-7ac32d00d590.PNG)

