### PR TITLE
Change wording in part4b.md

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -181,7 +181,7 @@ When running your tests you may run across the following console warning:
 The problem is quite likely caused by the Mongoose version 6.x, the problem does not appear when version 5.x is used. [Mongoose documentation](https://mongoosejs.com/docs/jest.html) does not recommend testing Mongoose applications with Jest.
 
 [One way](https://stackoverflow.com/questions/50687592/jest-and-mongoose-jest-has-detected-opened-handles) to get rid of this is to
-create to the directory <i>tests</i> a file <i>teardown.js</i> with the following content
+add to the directory <i>tests</i> a file <i>teardown.js</i> with the following content
 
 ```js
 module.exports = () => {
@@ -1031,7 +1031,7 @@ Notice that you will have to make similar changes to the code that were made [in
 ![Warning to read docs on connecting mongoose to jest](../../images/4/8a.png)
 
 [One way](https://stackoverflow.com/questions/50687592/jest-and-mongoose-jest-has-detected-opened-handles) to get rid of this is to
-create to the <i>tests</i> directory a file <i>teardown.js</i> with the following content
+add to the <i>tests</i> directory a file <i>teardown.js</i> with the following content
 
 ```js
 module.exports = () => {


### PR DESCRIPTION
Replace two instances of the phrase "create to the tests directory a file" with "add to the tests directory a file".

While "create to the directory" can be understood, it is an uncommon (and potentially incorrect) wording. Instead, the phrase "add to the directory" makes more sense. Alternatively, "create in the directory" would also make sense.