### PR TITLE
Update part0b.md

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -324,7 +324,7 @@ data.forEach(function(note) {
 Finally, the tree branch of the <em>ul</em> variable is connected to its proper place in the HTML tree of the whole page:
 
 ```js
-document.getElementsByClassName('notes').appendChild(ul)
+document.getElementById('notes').appendChild(ul)
 ```
 
 ### Manipulating the document object from console

--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -154,7 +154,7 @@ xhttp.onreadystatechange = function() {
       li.appendChild(document.createTextNode(note.content))
     })
 
-    document.getElementsByClassName('notes').appendChild(ul)
+    document.getElementById('notes').appendChild(ul)
   }
 }
 


### PR DESCRIPTION
Fixed Javascript example code mismatch between initial overview and detailed description. My changes also reflect the code that is used inside 'main.js' for the example website.

On lines 157 and 327(in part0b.md), the getElementsByClassName method is used but in the code breakdown(line 206), the getElementById is used. 

Line 157 can be confusing to readers because of two reasons:
1. There's no appendChild method on a HTML collection, and
2. The 'notes' class is assigned to the 'ul' element(see lines 147-148), so the code on line 157 is trying to append the 'ul' element to itself. 