### PR TITLE
Update part2d.md

### DIFF
--- a/src/content/2/en/part2d.md
+++ b/src/content/2/en/part2d.md
@@ -707,7 +707,7 @@ Full stack development is <i> extremely hard</i>, that is why I will use all the
 - I progress with small steps
 - I will write lots of _console.log_ statements to make sure I understand how the code behaves and to help pinpoint problems
 - If my code does not work, I will not write more code. Instead, I start deleting the code until it works or just return to a state when everything was still working
-- When I ask for help in the course Discord or Telegram channel or elsewhere I formulate my questions properly, see [here](https://fullstackopen.com/en/part0/general_info#how-to-ask-help-in-discord-telegam) how to ask for help
+- When I ask for help in the course Discord or Telegram channel or elsewhere I formulate my questions properly, see [here](https://fullstackopen.com/en/part0/general_info#how-to-get-help-in-discord-telegram) how to ask for help
 
 </div>
 


### PR DESCRIPTION
Fixed a typo to the following link: https://fullstackopen.com/en/part0/general_info#how-to-get-help-in-discord-telegram. As a result, the user should be directed to the correct part of the page that explains how to get help.