### PR TITLE
'highlight-lines' typo

### DIFF
--- a/src/content/9/en/part9e.md
+++ b/src/content/9/en/part9e.md
@@ -54,7 +54,7 @@ From typing point of view, there are a couple of interesting things. Component _
 
 ```js
 const App = () => {
-  const [patients, setPatients] = useState<Patient[]>([]); // highlight-lines
+  const [patients, setPatients] = useState<Patient[]>([]); // highlight-line
 
   // ...
   
@@ -67,7 +67,7 @@ const App = () => {
             <Route path="/" element={
               <PatientListPage
                 patients={patients}
-                setPatients={setPatients} // highlight-lines
+                setPatients={setPatients} // highlight-line
               />} 
             />
           </Routes>


### PR DESCRIPTION
putting 'highlight-lines'  instead of 'highlight-line' results in an extra 's' in the code next to the semicolon on lines => Here` const [patients, setPatients] = useState<Patient[]>([]);s` and Here  => ` setPatients={setPatients}s` 