### PR TITLE
refactored error handling for easier debugging of JsonWebTokenErrors

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -202,7 +202,7 @@ const errorHandler = (error, request, response, next) => {
   } else if (error.name === 'ValidationError') {
     return response.status(400).json({ error: error.message })
   } else if (error.name ===  'JsonWebTokenError') { // highlight-line
-    return response.status(400).json({ error: 'token missing or invalid' }) // highlight-line
+    return response.status(400).json({ error: error.message }) // highlight-line
   }
 
   next(error)


### PR DESCRIPTION
I refactored the handling of the error message returned when dealing with JsonWebTokenError's because it makes debugging this particular type of errors easier.

As alluded to in the lesson and according to the Docs, a JsonWebTokenError could occur for many reasons:
JsonWebTokenError
Error object:
 * name: 'JsonWebTokenError'
 * message:
   * 'invalid token' - the header or payload could not be parsed
   * 'jwt malformed' - the token does not have three components (delimited by a .)
   * 'jwt signature is required'
   * 'invalid signature'
   * 'jwt audience invalid. expected: [OPTIONS AUDIENCE]'
   * 'jwt issuer invalid. expected: [OPTIONS ISSUER]'
   * 'jwt id invalid. expected: [OPTIONS JWT ID]'
   * 'jwt subject invalid. expected: [OPTIONS SUBJECT]'
   

Debugging this particular type of error is extremely difficult when using an arbitrary error message(like it is the case in the lesson) that doesn't pinpoint the potential cause of the error. By leveraging the exact message associated with the error, we can pinpoint the cause of the error more accurately and be on our way to debug it quickly.