### PR TITLE
Update part2b.md

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -342,7 +342,7 @@ The comparison operator is redundant, since the value of <em>note.important</em>
 notes.filter(note => note.important)
 ```
 
-The reason we showed the comparison operator first was to emphasize an important detail: in JavaScript <em>val1 == val2</em> does not work as expected in all situations and it's safer to use <em>val1 === val2</em> exclusively in comparisons. You can read more about the topic [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness).
+We showed the comparison operator first to emphasize an important detail: in JavaScript <em>val1 == val2</em> does not always work as expected. When performing comparisons, it's therefore safer to exclusively use <em>val1 === val2</em>. You can read more about the topic [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness).
 
 You can test out the filtering functionality by changing the initial value of the <em>showAll</em> state.
 


### PR DESCRIPTION
The prior explanation about when to use '===' is confusing at best, and probably logically incorrect.

This suggested update should simplify and clarify.