### PR TITLE
Fix typo on line 818 part9d.md

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -815,7 +815,7 @@ It does not quite work, there is an Eslint error complaining about implicit any:
 
 ![](../../images/9/68new.png)
 
-TypeScript compiler has now no clue what is the type of the parameter, so that is why the type is the infamous implicit any that we wan to [avoid](/en/part9/first_steps_with_type_script#the-horrors-of-any) at all costs. The React TypeScript cheatsheet comes again to rescue, the chapter about
+TypeScript compiler has now no clue what is the type of the parameter, so that is why the type is the infamous implicit any that we want to [avoid](/en/part9/first_steps_with_type_script#the-horrors-of-any) at all costs. The React TypeScript cheatsheet comes again to rescue, the chapter about
 [forms and events](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forms_and_events) reveals that the right type of event handler is _React.SyntheticEvent_. 
 
 The code becomes


### PR DESCRIPTION
On line 818, theres a sentence which states: "... so that is why the type is the infamous implicit any that we wan to avoid at all costs."

The fix just changes wan for want

Please let me know if the PR was not created correctly. 