### PR TITLE
Update part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -97,6 +97,9 @@ Next, we have to define the IP addresses that are allowed access to the database
 
 ![mongodb network access/add ip access list](../../images/3/mongo4.png)
 
+Note: In case the modal menu is different for you, according to MongoDB documentation, adding 0.0.0.0 as an IP allows access from anywhere as well.
+  
+  
 Finally, we are ready to connect to our database. Start by clicking <i>connect</i>:
 
 ![mongodb database deployment connect](../../images/3/mongo5.png)


### PR DESCRIPTION
If the user has added his own IP while creating the cluster, they won't be able to see Allow Access From Anywhere prompt in the Network Access menu thus they need to type in 0.0.0.0. I think this could be a small heads up!