### PR TITLE
Update translation of Promise in Simplified Chinese

### DIFF
--- a/src/content/10/zh/part10c.md
+++ b/src/content/10/zh/part10c.md
@@ -52,7 +52,7 @@ fetch('https://my-api.com/post-end-point', {
  注意，这些URL是编造的，不会（很可能）对你的请求发出响应。与Axios相比，Fetch API的操作水平要低一些。例如，没有任何请求或响应体的序列化和解析。这意味着你必须自己设置<i>Content-Type</i>头并使用<em>JSON.stringify</em>方法来序列化请求体。
 
 <!-- The <em>fetch</em> function returns a promise which resolves a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object. Note that error status codes such as 400 and 500 <i>are not rejected</i> like for example in Axios. In case of a JSON formatted response we can parse the response body using the <em>Response.json</em> method:-->
- <em>fetch</em>函数返回一个承诺，它解决了一个[Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) 对象。请注意，错误状态代码如400和500 <i>不会被拒绝</i>，例如在Axios中。如果是JSON格式的响应，我们可以使用<em>Response.json</em>方法解析响应体。
+ <em>fetch</em>函数返回一个 Promise ，它解决了一个[Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) 对象。请注意，错误状态代码如400和500 <i>不会被拒绝</i>，例如在Axios中。如果是JSON格式的响应，我们可以使用<em>Response.json</em>方法解析响应体。
 
 ```javascript
 const fetchMovies = async () => {

--- a/src/content/12/zh/part12b.md
+++ b/src/content/12/zh/part12b.md
@@ -863,13 +863,13 @@ Emitted 'error' event on RedisClient instance at:
 #### Exercise 12.10:
 
 <!-- The project already has [https://www.npmjs.com/package/redis](https://www.npmjs.com/package/redis) installed and two functions "promisified" - getAsync and setAsync.-->
- 该项目已经安装了[https://www.npmjs.com/package/redis](https://www.npmjs.com/package/redis)和两个 "承诺 "的函数--getAsync和setAsync。
+ 该项目已经安装了[https://www.npmjs.com/package/redis](https://www.npmjs.com/package/redis)和两个 " Promise  "的函数--getAsync和setAsync。
 
 <!-- - setAsync function takes in key and value, using the key to store the value.-->
  - setAsync函数接收键和值，用键来存储值。
 
 <!-- - getAsync function takes in key and returns the value in a promise.-->
- - getAsync函数接收键并在一个承诺中返回值。
+ - getAsync函数接收键并在一个 Promise 中返回值。
 
 <!-- Implement a todo counter that saves the number of created todos to Redis:-->
  实现一个todo计数器，将创建的todos的数量保存到Redis。

--- a/src/content/2/zh/part2c.md
+++ b/src/content/2/zh/part2c.md
@@ -164,7 +164,7 @@ setTimeout(() => {
  让我们回到从服务器获取数据的话题上来。
 
 <!-- We could use the previously mentioned promise based function [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) to pull the data from the server. Fetch is a great tool. It is standardized and supported by all modern browsers (excluding IE).-->
-我们可以使用之前提到的基于承诺的函数[fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)来从服务器获取数据。Fetch是一个伟大的工具。它是标准化的，被所有现代浏览器支持（不包括IE）。
+我们可以使用之前提到的基于 Promise 的函数[fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)来从服务器获取数据。Fetch是一个伟大的工具。它是标准化的，被所有现代浏览器支持（不包括IE）。
 
 <!-- That being said, we will be using the [axios](https://github.com/axios/axios) library instead for communication between the browser and server. It functions like fetch, but is somewhat more pleasant to use. Another good reason to use axios is our getting familiar with adding external libraries, so-called <i>npm packages</i>, to React projects.-->
  也就是说，我们将使用[axios](https://github.com/axios/axios)库来代替浏览器和服务器之间的通信。它的功能类似于fetch，但使用起来更顺手一些。使用axios的另一个很好的理由是我们要熟悉在React项目中添加外部库，即所谓的npm包</i>。
@@ -342,29 +342,29 @@ console.log(promise2)
  **注意：**当文件<i>index.js</i>的内容发生变化时，React并不总是自动注意到这一点，所以你可能需要刷新浏览器来看到你的变化!一个简单的解决方法是在项目的根目录下创建一个名为<i>.env</i>的文件，并添加这一行<i>FAST_REFRESH=false</i>，使React自动注意到变化。重新启动应用以使应用的变化生效。
 
 <!-- Axios' method _get_ returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises).-->
- 'Axios' 方法 _get_ 返回一个[承诺](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)。
+ 'Axios' 方法 _get_ 返回一个[ Promise ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)。
 
 <!-- The documentation on Mozilla's site states the following about promises:-->
- Mozilla网站上的文档对承诺有如下说明。
+ Mozilla网站上的文档对 Promise 有如下说明。
 
 <!-- > <i>A Promise is an object representing the eventual completion or failure of an asynchronous operation.</i>-->
  > <i>A Promise是一个代表异步操作最终完成或失败的对象。</i>
 
 <!-- In other words, a promise is an object that represents an asynchronous operation. A promise can have three distinct states:-->
- 换句话说，一个承诺是一个代表异步操作的对象。一个承诺可以有三种不同的状态。
+ 换句话说，一个 Promise 是一个代表异步操作的对象。一个 Promise 可以有三种不同的状态。
 
 <!-- 1. The promise is <i>pending</i>: It means that the final value (one of the following two) is not available yet.-->
  1.答应是<i>pending</i>：这意味着最终的值（以下两个中的一个）还不能用。
 <!-- 2. The promise is <i>fulfilled</i>: It means that the operation has been completed and the final value is available, which generally is a successful operation. This state is sometimes also called <i>resolved</i>.-->
- 2.承诺是<i>fulfilled</i>：它意味着操作已经完成，最终值可用，一般来说是一个成功的操作。这种状态有时也被称为<i>resolved</i>。
+ 2. Promise 是<i>fulfilled</i>：它意味着操作已经完成，最终值可用，一般来说是一个成功的操作。这种状态有时也被称为<i>resolved</i>。
 <!-- 3. The promise is <i>rejected</i>: It means that an error prevented the final value from being determined, which generally represents a failed operation.-->
- 3.承诺被<i>拒绝</i>：这意味着一个错误阻止了最终值的确定，这一般代表一个失败的操作。
+ 3. Promise 被<i>拒绝</i>：这意味着一个错误阻止了最终值的确定，这一般代表一个失败的操作。
 
 <!-- The first promise in our example is <i>fulfilled</i>, representing a successful _axios.get('http://localhost:3001/notes')_ request. The second one, however, is <i>rejected</i>, and the console tells us the reason. It looks like we were trying to make an HTTP GET request to a non-existent address.-->
- 我们例子中的第一个承诺是<i>fulfilled</i>，代表一个成功的_axios.get('http://localhost:3001/notes')_请求。然而，第二个承诺是<i>拒绝的</i>，并且控制台告诉我们原因。看起来我们试图向一个不存在的地址发出HTTP GET请求。
+ 我们例子中的第一个 Promise 是<i>fulfilled</i>，代表一个成功的_axios.get('http://localhost:3001/notes')_请求。然而，第二个 Promise 是<i>拒绝的</i>，并且控制台告诉我们原因。看起来我们试图向一个不存在的地址发出HTTP GET请求。
 
 <!-- If, and when, we want to access the result of the operation represented by the promise, we must register an event handler to the promise. This is achieved using the method <em>then</em>:-->
- 如果，以及何时，我们想访问承诺所代表的操作的结果，我们必须为承诺注册一个事件处理程序。这可以通过<em>then</em>方法实现。
+ 如果，以及何时，我们想访问 Promise 所代表的操作的结果，我们必须为 Promise 注册一个事件处理程序。这可以通过<em>then</em>方法实现。
 
 ```js
 const promise = axios.get('http://localhost:3001/notes')
@@ -382,7 +382,7 @@ promise.then(response => {
  JavaScript运行环境调用由<em>then</em>方法注册的回调函数，为其提供一个<em>response</em>对象作为参数。<em>response</em>对象包含与HTTP GET请求的响应相关的所有基本数据，其中包括返回的<i>数据</i>、<i>状态代码</i>和<i>头信息</i>。
 
 <!-- Storing the promise object in a variable is generally unnecessary, and it's instead common to chain the <em>then</em> method call to the axios method call, so that it follows it directly:-->
- 将承诺对象存储在一个变量中通常是不必要的，而通常是将<em>then</em>方法调用链到axios方法调用中，这样它就直接跟随它。
+ 将 Promise 对象存储在一个变量中通常是不必要的，而通常是将<em>then</em>方法调用链到axios方法调用中，这样它就直接跟随它。
 
 ```js
 axios.get('http://localhost:3001/notes').then(response => {
@@ -529,7 +529,7 @@ response => {
 ```
 
 <!-- When data arrives from the server, the JavaScript runtime calls the function registered as the event handler, which prints <i>promise fulfilled</i> to the console and stores the notes received from the server into the state using the function <em>setNotes(response.data)</em>.-->
-当数据从服务器到达时，JavaScript运行时调用注册为事件处理程序的函数，该函数将<i>承诺兑现</i>打印到控制台，并使用函数<em>setNotes(response.data)</em>将从服务器收到的注释存储到状态中。
+当数据从服务器到达时，JavaScript运行时调用注册为事件处理程序的函数，该函数将<i> Promise 兑现</i>打印到控制台，并使用函数<em>setNotes(response.data)</em>将从服务器收到的注释存储到状态中。
 
 <!-- As always, a call to a state-updating function triggers the re-rendering of the component. As a result, <i>render 3 notes</i> is printed to the console, and the notes fetched from the server are rendered to the screen.-->
  一如既往，对状态更新函数的调用会触发组件的重新渲染。结果，<i>render 3 notes</i>被打印到控制台，而从服务器上获取的笔记被渲染到屏幕上。
@@ -601,7 +601,7 @@ useEffect(() => {
 ```
 
 <!-- A reference to an event handler function is assigned to the variable <em>eventHandler</em>. The promise returned by the <em>get</em> method of Axios is stored in the variable <em>promise</em>. The registration of the callback happens by giving the <em>eventHandler</em> variable, referring to the event-handler function, as a parameter to the <em>then</em> method of the promise. It isn't usually necessary to assign functions and promises to variables, and a more compact way of representing things, as seen further above, is sufficient.-->
- 一个事件处理函数的引用被分配到变量<em>eventHandler</em>。由Axios的<em>get</em>方法返回的承诺被存储在变量<em>promise</em>中。回调的注册是通过给<em>eventHandler</em>变量，指的是事件处理函数，作为承诺的<em>then</em>方法的一个参数。通常没有必要把函数和承诺分配给变量，用更紧凑的方式来表示事情，如上面进一步看到的，就足够了。
+ 一个事件处理函数的引用被分配到变量<em>eventHandler</em>。由Axios的<em>get</em>方法返回的 Promise 被存储在变量<em>promise</em>中。回调的注册是通过给<em>eventHandler</em>变量，指的是事件处理函数，作为 Promise 的<em>then</em>方法的一个参数。通常没有必要把函数和 Promise 分配给变量，用更紧凑的方式来表示事情，如上面进一步看到的，就足够了。
 
 ```js
 useEffect(() => {

--- a/src/content/2/zh/part2d.md
+++ b/src/content/2/zh/part2d.md
@@ -336,7 +336,7 @@ export default {
 ```
 
 <!-- The module returns an object that has three functions (<i>getAll</i>, <i>create</i>, and <i>update</i>) as its properties that deal with notes. The functions directly return the promises returned by the axios methods.-->
- 该模块返回一个对象，该对象有三个函数（<i>getAll</i>、<i>create</i>和<i>update</i>）作为其属性，处理笔记。这些函数直接返回axios方法所返回的承诺。
+ 该模块返回一个对象，该对象有三个函数（<i>getAll</i>、<i>create</i>和<i>update</i>）作为其属性，处理笔记。这些函数直接返回axios方法所返回的 Promise 。
 
 <!-- The <i>App</i> component uses <em>import</em> to get access to the module:-->
  <i>App</i>组件使用<em>import</em>来获得对模块的访问。
@@ -457,7 +457,7 @@ export default {
 
 
 <!-- We no longer return the promise returned by axios directly. Instead, we assign the promise to the <em>request</em> variable and call its <em>then</em> method:-->
- 我们不再直接返回axios返回的承诺。相反，我们将承诺分配给<em>request</em>变量并调用其<em>then</em>方法。
+ 我们不再直接返回axios返回的 Promise 。相反，我们将 Promise 分配给<em>request</em>变量并调用其<em>then</em>方法。
 
 ```js
 const getAll = () => {
@@ -481,7 +481,7 @@ const getAll = () => {
 ```
 
 <!-- The modified <em>getAll</em> function still returns a promise, as the <em>then</em> method of a promise also [returns a promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then).-->
- 修改后的<em>getAll</em>函数仍然返回一个承诺，因为一个承诺的<em>then</em>方法也[返回一个承诺](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)。
+ 修改后的<em>getAll</em>函数仍然返回一个 Promise ，因为一个 Promise 的<em>then</em>方法也[返回一个 Promise ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)。
 
 <!-- After defining the parameter of the <em>then</em> method to directly return <i>response.data</i>, we have gotten the <em>getAll</em> function to work like we wanted it to. When the HTTP request is successful, the promise returns the data sent back in the response from the backend.-->
  在定义了<em>then</em>方法的参数以直接返回<i>response.data</i>之后，我们已经让<em>getAll</em>函数像我们希望的那样工作。当HTTP请求成功时，promise会返回从后端响应中发回的数据。
@@ -545,7 +545,7 @@ const App = () => {
 [你不懂JS](https://github.com/getify/You-Dont-Know-JS/tree/1st-ed)系列书籍中的 "异步和性能 "一书[很好地解释了这个话题](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/async%20%26%20performance/ch3.md)，但解释的篇幅很多。
 
 <!-- Promises are central to modern JavaScript development and it is highly recommended to invest a reasonable amount of time into understanding them.-->
- 承诺是现代JavaScript开发的核心，强烈建议投入合理的时间来理解它们。
+  Promise 是现代JavaScript开发的核心，强烈建议投入合理的时间来理解它们。
 
 ### Cleaner Syntax for Defining Object Literals
 
@@ -692,16 +692,16 @@ const getAll = () => {
  应用应该能够优雅地处理这些类型的错误情况。除非用户碰巧打开了他们的控制台，否则他们无法知道错误确实发生了。在应用中可以看到错误的唯一方法是，点击按钮对注释的重要性没有影响。
 
 <!-- We had [previously](/en/part2/getting_data_from_server#axios-and-promises) mentioned that a promise can be in one of three different states. When an HTTP request fails, the associated promise is <i>rejected</i>. Our current code does not handle this rejection in any way.-->
- 我们[之前](/en/part2/getting_data_from_server#axios-and-promises)提到，一个承诺可以处于三种不同的状态之一。当一个HTTP请求失败时，相关的承诺会被<i>拒绝</i>。我们目前的代码没有以任何方式处理这种拒绝。
+ 我们[之前](/en/part2/getting_data_from_server#axios-and-promises)提到，一个 Promise 可以处于三种不同的状态之一。当一个HTTP请求失败时，相关的 Promise 会被<i>拒绝</i>。我们目前的代码没有以任何方式处理这种拒绝。
 
 <!-- The rejection of a promise is [handled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) by providing the <em>then</em> method with a second callback function, which is called in the situation where the promise is rejected.-->
- 拒绝承诺是通过提供带有第二个回调函数的<em>then</em>方法来[处理](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)的，该函数在承诺被拒绝的情况下被调用。
+ 拒绝 Promise 是通过提供带有第二个回调函数的<em>then</em>方法来[处理](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)的，该函数在 Promise 被拒绝的情况下被调用。
 
 <!-- The more common way of adding a handler for rejected promises is to use the [catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) method.-->
- 为被拒绝的承诺添加处理程序的更常见方式是使用[catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch)方法。
+ 为被拒绝的 Promise 添加处理程序的更常见方式是使用[catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch)方法。
 
 <!-- In practice, the error handler for rejected promises is defined like this:-->
- 在实践中，被拒绝的承诺的错误处理程序是这样定义的。
+ 在实践中，被拒绝的 Promise 的错误处理程序是这样定义的。
 
 ```js
 axios
@@ -718,10 +718,10 @@ axios
  如果请求失败，与<em>catch</em>方法注册的事件处理程序被调用。
 
 <!-- The <em>catch</em> method is often utilized by placing it deeper within the promise chain.-->
- <em>catch</em>方法经常被利用，将其置于承诺链的更深处。
+ <em>catch</em>方法经常被利用，将其置于 Promise 链的更深处。
 
 <!-- When our application makes an HTTP request, we are in fact creating a [promise chain](https://javascript.info/promise-chaining):-->
- 当我们的应用发出一个HTTP请求时，我们实际上是在创建一个[承诺链](https://javascript.info/promise-chaining)。
+ 当我们的应用发出一个HTTP请求时，我们实际上是在创建一个[ Promise 链](https://javascript.info/promise-chaining)。
 
 ```js
 axios
@@ -733,7 +733,7 @@ axios
 ```
 
 <!-- The <em>catch</em> method can be used to define a handler function at the end of a promise chain, which is called once any promise in the chain throws an error and the promise becomes <i>rejected</i>.-->
- <em>catch</em>方法可以用来在承诺链的末端定义一个处理函数，一旦承诺链中的任何一个承诺抛出错误，承诺就会被调用，成为<i>拒绝</i>。
+ <em>catch</em>方法可以用来在 Promise 链的末端定义一个处理函数，一旦 Promise 链中的任何一个 Promise 抛出错误， Promise 就会被调用，成为<i>拒绝</i>。
 
 ```js
 axios

--- a/src/content/2/zh/part2e.md
+++ b/src/content/2/zh/part2e.md
@@ -356,7 +356,7 @@ const App = () => {
 ![](../../images/2/29b.png)
 
 <!-- Fix the issue according to the example shown in [promise and errors](/en/part2/altering_data_in_server#promises-and-errors) in part 2. Modify the example so that the user is shown a message when the operation does not succeed. The messages shown for successful and unsuccessful events should look different:-->
-按照第二章节中[承诺和错误](/en/part2/altering_data_in_server#promises-and-errors)所示的例子来解决这个问题。修改这个例子，使用户在操作不成功时显示一条信息。为成功和不成功的事件显示的信息应该是不同的。
+按照第二章节中[ Promise 和错误](/en/part2/altering_data_in_server#promises-and-errors)所示的例子来解决这个问题。修改这个例子，使用户在操作不成功时显示一条信息。为成功和不成功的事件显示的信息应该是不同的。
 
 ![](../../images/2/28e.png)
 

--- a/src/content/3/zh/part3c.md
+++ b/src/content/3/zh/part3c.md
@@ -307,7 +307,7 @@ note.save().then(result => {
  我们还可以通过修改代码中的数据和再次执行程序来保存一些注释。
 
 <!-- **NB:** Unfortunately the Mongoose documentation is not very consistent, with parts of it using callbacks in its examples and other parts, other styles, so it is not recommended to copy paste code directly from there. Mixing promises with old-school callbacks in the same code is not recommended.-->
- **NB:**不幸的是，Mongoose文档不是很一致，它的部分例子中使用了回调，而其他部分则是其他风格，所以不建议直接从那里复制粘贴代码。不建议在同一段代码中混合使用承诺和老式的回调。
+ **NB:**不幸的是，Mongoose文档不是很一致，它的部分例子中使用了回调，而其他部分则是其他风格，所以不建议直接从那里复制粘贴代码。不建议在同一段代码中混合使用 Promise 和老式的回调。
 
 ### Fetching objects from the database
 
@@ -765,7 +765,7 @@ app.get('/api/notes/:id', (request, response) => {
  如果我们试图访问一个ID不存在的笔记的URL，例如：<http://localhost:3001/api/notes/5c41c90e84d891c15dfa3431>，其中<i>5c41c90e84d891c15dfa3431</i>不是存储在数据库中的ID，那么响应将是_null_。
 
 <!-- Let's change this behavior so that if note with the given id doesn't exist, the server will respond to the request with the HTTP status code 404 not found. In addition let's implement a simple <em>catch</em> block to handle cases where the promise returned by the <em>findById</em> method is <i>rejected</i>:-->
- 让我们改变这个行为，如果给定id的注释不存在，服务器将以HTTP状态代码404未找到来响应请求。此外，让我们实现一个简单的<em>catch</em>块来处理由<em>findById</em>方法返回的承诺被<i>拒绝</i>的情况。
+ 让我们改变这个行为，如果给定id的注释不存在，服务器将以HTTP状态代码404未找到来响应请求。此外，让我们实现一个简单的<em>catch</em>块来处理由<em>findById</em>方法返回的 Promise 被<i>拒绝</i>的情况。
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -789,7 +789,7 @@ app.get('/api/notes/:id', (request, response) => {
 ```
 
 <!-- If no matching object is found in the database, the value of _note_ will be _null_ and the _else_ block is executed. This results in a response with the status code <i>404 not found</i>. If promise returned by the <em>findById</em> method is rejected, the response will have the status code <i>500 internal server error</i>. The console displays more detailed information about the error.-->
- 如果在数据库中没有找到匹配的对象，_note_的值将是_null_，_else_块被执行。这将导致一个状态代码为<i>404 not found</i>的响应。如果由<em>findById</em>方法返回的承诺被拒绝，那么响应的状态码将是<i>500 internal server error</i>。控制台会显示关于该错误的更详细的信息。
+ 如果在数据库中没有找到匹配的对象，_note_的值将是_null_，_else_块被执行。这将导致一个状态代码为<i>404 not found</i>的响应。如果由<em>findById</em>方法返回的 Promise 被拒绝，那么响应的状态码将是<i>500 internal server error</i>。控制台会显示关于该错误的更详细的信息。
 
 <!-- On top of the non-existing note, there's one more error situation needed to be handled. In this situation, we are trying to fetch a note with a wrong kind of _id_, meaning an _id_ that doesn't match the mongo identifier format.-->
  在不存在的注释之上，还有一个错误情况需要处理。在这种情况下，我们正试图获取一个带有错误的_id_的笔记，也就是说，一个不符合mongo标识符格式的_id_。

--- a/src/content/4/zh/part4b.md
+++ b/src/content/4/zh/part4b.md
@@ -292,7 +292,7 @@ test('the first note is about HTTP methods', async () => {
 
 
 <!-- The benefit of using the async/await syntax is starting to become evident. Normally we would have to use callback functions to access the data returned by promises, but with the new syntax things are a lot more comfortable:-->
- 使用async/await语法的好处开始变得明显了。通常情况下，我们必须使用回调函数来访问由承诺返回的数据，但有了新的语法，事情就好办多了。
+ 使用async/await语法的好处开始变得明显了。通常情况下，我们必须使用回调函数来访问由 Promise 返回的数据，但有了新的语法，事情就好办多了。
 
 ```js
 const response = await api.get('/api/notes')
@@ -445,10 +445,10 @@ npm test -- -t 'notes'
  在我们写更多的测试之前，让我们看一下_async_和_await_关键字。
 
 <!-- The async/await syntax that was introduced in ES7 makes it possible to use <i>asynchronous functions that return a promise</i> in a way that makes the code look synchronous.-->
- ES7中引入的async/await语法使得使用返回承诺的<i>异步函数</i>的方式可以使代码看起来是同步的。
+ ES7中引入的async/await语法使得使用返回 Promise 的<i>异步函数</i>的方式可以使代码看起来是同步的。
 
 <!-- As an example, the fetching of notes from the database with promises looks like this:-->
- 作为一个例子，用承诺从数据库中获取笔记的过程看起来是这样的。
+ 作为一个例子，用 Promise 从数据库中获取笔记的过程看起来是这样的。
 
 ```js
 Note.find({}).then(notes => {
@@ -457,13 +457,13 @@ Note.find({}).then(notes => {
 ```
 
 <!-- The _Note.find()_ method returns a promise and we can access the result of the operation by registering a callback function with the _then_ method.-->
- _Note.find()_方法返回一个承诺，我们可以通过用_then_方法注册一个回调函数来访问操作的结果。
+ _Note.find()_方法返回一个 Promise ，我们可以通过用_then_方法注册一个回调函数来访问操作的结果。
 
 <!-- All of the code we want to execute once the operation finishes is written in the callback function. If we wanted to make several asynchronous function calls in sequence, the situation would soon become painful. The asynchronous calls would have to be made in the callback. This would likely lead to complicated code and could potentially give birth to a so-called [callback hell](http://callbackhell.com/).-->
  一旦操作完成，我们想要执行的所有代码都写在回调函数中。如果我们想依次进行几个异步函数的调用，情况很快就会变得很痛苦。异步调用将不得不在回调中进行。这将可能导致复杂的代码，并有可能诞生所谓的[回调地狱](http://callbackhell.com/)。
 
 <!-- By [chaining promises](https://javascript.info/promise-chaining) we could keep the situation somewhat under control, and avoid callback hell by creating a fairly clean chain of _then_ method calls. We have seen a few of these during the course. To illustrate this, you can view an artificial example of a function that fetches all notes and then deletes the first one:-->
- 通过[链式承诺](https://javascript.info/promise-chaining)，我们可以在一定程度上控制局面，并通过创建一个相当干净的_then_方法调用链来避免回调地狱。我们在课程中已经看到了一些这样的情况。为了说明这一点，你可以查看一个人为的例子，这个函数获取了所有的笔记，然后删除了第一条。
+ 通过[链式 Promise ](https://javascript.info/promise-chaining)，我们可以在一定程度上控制局面，并通过创建一个相当干净的_then_方法调用链来避免回调地狱。我们在课程中已经看到了一些这样的情况。为了说明这一点，你可以查看一个人为的例子，这个函数获取了所有的笔记，然后删除了第一条。
 
 ```js
 Note.find({})
@@ -492,7 +492,7 @@ console.log('operation returned the following notes', notes)
 ```
 
 <!-- The code looks exactly like synchronous code. The execution of code pauses at <em>const notes = await Note.find({})</em> and waits until the related promise is <i>fulfilled</i>, and then continues its execution to the next line. When the execution continues, the result of the operation that returned a promise is assigned to the _notes_ variable.-->
- 这段代码看起来和同步代码完全一样。代码的执行在<em>const notes = await Note.find({})</em>处暂停，等待相关的承诺被<i>满足</i>，然后继续执行到下一行。当继续执行时，返回承诺的操作结果被分配给_notes_变量。
+ 这段代码看起来和同步代码完全一样。代码的执行在<em>const notes = await Note.find({})</em>处暂停，等待相关的 Promise 被<i>满足</i>，然后继续执行到下一行。当继续执行时，返回 Promise 的操作结果被分配给_notes_变量。
 
 <!-- The slightly complicated example presented above could be implemented by using await like this:-->
  上面介绍的稍微复杂的例子可以通过使用await这样来实现。
@@ -508,7 +508,7 @@ console.log('the first note is removed')
  由于新的语法，代码比以前的then-chain简单多了。
 
 <!-- There are a few important details to pay attention to when using async/await syntax. In order to use the await operator with asynchronous operations, they have to return a promise. This is not a problem as such, as regular asynchronous functions using callbacks are easy to wrap around promises.-->
- 使用async/await语法时，有几个重要的细节需要注意。为了在异步操作中使用await操作符，它们必须返回一个承诺。这并不是一个问题，因为使用回调的常规异步函数很容易被承诺所包裹。
+ 使用async/await语法时，有几个重要的细节需要注意。为了在异步操作中使用await操作符，它们必须返回一个 Promise 。这并不是一个问题，因为使用回调的常规异步函数很容易被 Promise 所包裹。
 
 <!-- The await keyword can't be used just anywhere in JavaScript code. Using await is possible only inside of an [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) function.-->
  await关键字不能在JavaScript代码中随便使用。只有在[async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)函数中才能使用await。
@@ -759,7 +759,7 @@ afterAll(() => {
 ```
 
 <!-- The code using promises works and the tests pass. We are ready to refactor our code to use the async/await syntax.-->
- 使用承诺的代码工作了，测试通过了。我们准备重构我们的代码以使用async/await语法。
+ 使用 Promise 的代码工作了，测试通过了。我们准备重构我们的代码以使用async/await语法。
 
 <!-- We make the following changes to the code that takes care of adding a new note(notice that the route handler definition is preceded by the _async_ keyword):-->
  我们对处理添加新注释的代码做如下修改（注意路由处理程序的定义前面有_async_关键字）。
@@ -790,7 +790,7 @@ notesRouter.post('/', async (request, response, next) => {
 ![](../../images/4/6.png)
 
 <!-- In other words we end up with an unhandled promise rejection, and the request never receives a response.-->
- 换句话说，我们最终会出现一个未处理的拒绝承诺，而且请求永远不会收到响应。
+ 换句话说，我们最终会出现一个未处理的拒绝 Promise ，而且请求永远不会收到响应。
 
 <!-- With async/await the recommended way of dealing with exceptions is the old and familiar _try/catch_ mechanism:-->
  在async/await中，处理异常的推荐方式是古老而熟悉的_try/catch_机制。
@@ -1095,16 +1095,16 @@ beforeEach(async () => {
 ```
 
 <!-- The solution is quite advanced despite its compact appearance. The _noteObjects_ variable is assigned to an array of Mongoose objects that are created with the _Note_ constructor for each of the notes in the _helper.initialNotes_ array. The next line of code creates a new array that <i>consists of promises</i>, that are created by calling the _save_ method of each item in the _noteObjects_ array. In other words, it is an array of promises for saving each of the items to the database.-->
- 这个解决方案尽管看起来很紧凑，但却相当先进。_noteObjects_变量被分配给一个Mongoose对象数组，这些对象是用_Note_构造函数为_helper.initialNotes_数组中的每个笔记创建的。下一行代码创建了一个新的数组，<i>由承诺组成</i>，这些承诺是通过调用_noteObjects_数组中每个项目的_save_方法创建的。换句话说，它是一个承诺数组，用于将每个项目保存到数据库中。
+ 这个解决方案尽管看起来很紧凑，但却相当先进。_noteObjects_变量被分配给一个Mongoose对象数组，这些对象是用_Note_构造函数为_helper.initialNotes_数组中的每个笔记创建的。下一行代码创建了一个新的数组，<i>由 Promise 组成</i>，这些 Promise 是通过调用_noteObjects_数组中每个项目的_save_方法创建的。换句话说，它是一个 Promise 数组，用于将每个项目保存到数据库中。
 
 <!-- The [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) method can be used for transforming an array of promises into a single promise, that will be <i>fulfilled</i> once every promise in the array passed to it as a parameter is resolved. The last line of code <em>await Promise.all(promiseArray)</em> waits that every promise for saving a note is finished, meaning that the database has been initialized.-->
- [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)方法可用于将一个承诺数组转化为一个承诺，一旦作为参数传递给它的数组中的每个承诺被解决，这个承诺就会被<i>履行</i>。最后一行代码<em>await Promise.all(promiseArray)</em>等待每个保存笔记的承诺完成，这意味着数据库已经被初始化了。
+ [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)方法可用于将一个 Promise 数组转化为一个 Promise ，一旦作为参数传递给它的数组中的每个 Promise 被解决，这个 Promise 就会被<i>履行</i>。最后一行代码<em>await Promise.all(promiseArray)</em>等待每个保存笔记的 Promise 完成，这意味着数据库已经被初始化了。
 
 <!-- > The returned values of each promise in the array can still be accessed when using the Promise.all method. If we wait for the promises to be resolved with the _await_ syntax <em>const results = await Promise.all(promiseArray)</em>, the operation will return an array that contains the resolved values for each promise in the _promiseArray_, and they appear in the same order as the promises in the array.-->
- > 使用Promise.all方法时，数组中每个承诺的返回值仍然可以被访问。如果我们用_await_语法<em>const results = await Promise.all(promiseArray)</em>来等待承诺的解析，该操作将返回一个数组，其中包含_promiseArray_中每个承诺的解析值，并且它们的出现顺序与数组中的承诺相同。
+ > 使用Promise.all方法时，数组中每个 Promise 的返回值仍然可以被访问。如果我们用_await_语法<em>const results = await Promise.all(promiseArray)</em>来等待 Promise 的解析，该操作将返回一个数组，其中包含_promiseArray_中每个 Promise 的解析值，并且它们的出现顺序与数组中的 Promise 相同。
 
 <!-- Promise.all executes the promises it receives in parallel. If the promises need to be executed in a particular order, this will be problematic. In situations like this, the operations can be executed inside of a [for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) block, that guarantees a specific execution order.-->
- Promise.all以并行方式执行它收到的承诺。如果这些承诺需要以特定的顺序执行，这将是有问题的。在这样的情况下，可以在[for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)块内执行操作，这样可以保证一个特定的执行顺序。
+ Promise.all以并行方式执行它收到的 Promise 。如果这些 Promise 需要以特定的顺序执行，这将是有问题的。在这样的情况下，可以在[for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)块内执行操作，这样可以保证一个特定的执行顺序。
 
 ```js
 beforeEach(async () => {
@@ -1118,7 +1118,7 @@ beforeEach(async () => {
 ```
 
 <!-- The asynchronous nature of JavaScript can lead to surprising behavior, and for this reason, it is important to pay careful attention when using the async/await syntax. Even though the syntax makes it easier to deal with promises, it is still necessary to understand how promises work!-->
- JavaScript的异步性可能会导致令人惊讶的行为，为此，在使用async/await语法时，一定要仔细注意。即使该语法使处理承诺变得更容易，但仍然有必要了解承诺是如何工作的!
+ JavaScript的异步性可能会导致令人惊讶的行为，为此，在使用async/await语法时，一定要仔细注意。即使该语法使处理 Promise 变得更容易，但仍然有必要了解 Promise 是如何工作的!
 
 <!-- The code for our application can be found from [github](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-5), branch <i>part4-5</i>.-->
  我们应用的代码可以从[github](https://github.com/fullstack-hy2020/part3-notes-backend/tree/part4-5)，分支<i>part4-5</i>找到。

--- a/src/content/5/zh/part5a.md
+++ b/src/content/5/zh/part5a.md
@@ -117,7 +117,7 @@ export default App
  登录是通过向服务器地址<i>api/login</i>发送一个HTTP POST请求来完成。让我们把负责这个请求的代码分离到自己的模块中，放到<i>services/login.js</i>文件中。
 
 <!-- We'll use <i>async/await</i> syntax instead of promises for the HTTP request:-->
- 我们将使用<i>async/await</i>语法而不是承诺来处理HTTP请求。
+ 我们将使用<i>async/await</i>语法而不是 Promise 来处理HTTP请求。
 
 ```js
 import axios from 'axios'

--- a/src/content/5/zh/part5c.md
+++ b/src/content/5/zh/part5c.md
@@ -760,7 +760,7 @@ const element = await screen.findByText('Does not work anymore :(')
 ```
 
 <!-- It is important to notice that unlike the other _ByText_ commands, _findByText_ returns a promise!-->
- 需要注意的是，与其他的_ByText_命令不同，_findByText_会返回一个承诺!
+ 需要注意的是，与其他的_ByText_命令不同，_findByText_会返回一个 Promise !
 
 <!-- There are situation where yet another form of the command _queryByText_ is useful. The command returns the element but <i>it does not cause an exception</i> if the element is not found.-->
  在有些情况下，另一种形式的命令_queryByText_是有用的。该命令返回元素，但如果没有找到该元素，它不会引起一个异常</i>。

--- a/src/content/5/zh/part5d.md
+++ b/src/content/5/zh/part5d.md
@@ -1145,7 +1145,7 @@ cy.contains('logout').click()
 Cypress命令总是返回_undefined_，所以上述代码中的_button.click()_会导致一个错误。试图启动调试器不会在执行命令之间停止代码，而是在任何命令被执行之前。
 
 <!-- Cypress commands are <i>like promises</i>, so if we want to access their return values, we have to do it using the [then](https://docs.cypress.io/api/commands/then.html) command.-->
-Cypress命令<i>类似于承诺</i>，所以如果我们想访问它们的返回值，我们必须使用[then](https://docs.cypress.io/api/commands/then.html)命令来完成。
+Cypress命令<i>类似于 Promise </i>，所以如果我们想访问它们的返回值，我们必须使用[then](https://docs.cypress.io/api/commands/then.html)命令来完成。
 <!-- For example, the following test would print the number of buttons in the application, and click the first button:-->
  例如，下面的测试将打印应用中的按钮数量，并点击第一个按钮。
 

--- a/src/content/6/zh/part6c.md
+++ b/src/content/6/zh/part6c.md
@@ -224,7 +224,7 @@ noteService.getAll().then(notes =>
 ```
 
 <!-- > **NB:** why didn't we use await in place of promises and event handlers (registered to _then_-methods)?-->
- > **NB:**我们为什么不用await来代替承诺和事件处理程序（注册到_then_-methods）？
+ > **NB:**我们为什么不用await来代替 Promise 和事件处理程序（注册到_then_-methods）？
 <!-- >-->
  >
 <!-- > Await only works inside <i>async</i> functions, and the code in <i>index.js</i> is not inside a function, so due to the simple nature of the operation, we'll abstain from using <i>async</i> this time.-->

--- a/src/content/7/zh/part7d.md
+++ b/src/content/7/zh/part7d.md
@@ -944,7 +944,7 @@ npx static-server
 ### Polyfill
 
 <!-- Our application is finished and works with all relatively recent versions of modern browsers, with the exception of Internet Explorer. The reason for this is that, because of _axios_, our code uses [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), and no existing version of IE supports them:-->
- 我们的应用已经完成，可以在所有相对较新版本的现代浏览器中使用，但Internet Explorer除外。原因是，由于_axios_，我们的代码使用了[承诺](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)，而现有版本的IE都不支持。
+ 我们的应用已经完成，可以在所有相对较新版本的现代浏览器中使用，但Internet Explorer除外。原因是，由于_axios_，我们的代码使用了[ Promise ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)，而现有版本的IE都不支持。
 
 ![](../../images/7/29.png)
 
@@ -954,7 +954,7 @@ npx static-server
 ![](../../images/7/30.png)
 
 <!-- In these situations it is not enough to transpile the code, as transpilation simply transforms the code from a newer version of JavaScript to an older one with wider browser support. IE understands Promises syntactically but it simply has not implemented their functionality. The _find_ property of arrays in IE is simply <i>undefined</i>.-->
- 在这些情况下，仅仅转译代码是不够的，因为转译只是把代码从较新的JavaScript版本转到较旧的浏览器支持的版本上。IE在语法上理解承诺，但它根本没有实现其功能。在IE中，数组的_find_属性是简单的<i>undefined</i>。
+ 在这些情况下，仅仅转译代码是不够的，因为转译只是把代码从较新的JavaScript版本转到较旧的浏览器支持的版本上。IE在语法上理解 Promise ，但它根本没有实现其功能。在IE中，数组的_find_属性是简单的<i>undefined</i>。
 
 <!-- If we want the application to be IE-compatible, we need to add a [polyfill](https://remysharp.com/2010/10/08/what-is-a-polyfill), which is code that adds the missing functionality to older browsers.-->
  如果我们想让应用与IE兼容，我们需要添加一个[polyfill](https://remysharp.com/2010/10/08/what-is-a-polyfill)，它是为旧版浏览器添加缺失功能的代码。

--- a/src/content/8/zh/part8c.md
+++ b/src/content/8/zh/part8c.md
@@ -116,7 +116,7 @@ const resolvers = {
  这些变化是非常直接的。然而，有几个值得注意的地方。我们记得，在Mongo中，一个对象的识别字段被称为<i>_id</i>，我们以前必须自己把字段的名称解析为<i>id</i>。现在GraphQL可以自动做到这一点。
 
 <!-- Another noteworthy thing is that the resolver functions now return a <i>promise</i>, when they previously returned normal objects. When a resolver returns a promise, Apollo server [sends back](https://www.apollographql.com/docs/apollo-server/data/data/#resolver-results) the value which the promise resolves to.-->
- 另一件值得注意的事情是，解析器函数现在会返回一个<i>承诺</i>，而以前它们会返回普通的对象。当一个解析器返回一个承诺时，Apollo服务器[送回](https://www.apollographql.com/docs/apollo-server/data/data/#resolver-results)承诺所解析的值。
+ 另一件值得注意的事情是，解析器函数现在会返回一个<i> Promise </i>，而以前它们会返回普通的对象。当一个解析器返回一个 Promise 时，Apollo服务器[送回](https://www.apollographql.com/docs/apollo-server/data/data/#resolver-results) Promise 所解析的值。
 
 <!-- For example, if the following resolver function is executed,-->
  例如，如果执行了下面的解析器函数。
@@ -128,7 +128,7 @@ allPersons: async (root, args) => {
 ```
 
 <!-- Apollo server waits for the promise to resolve, and returns the result. So Apollo works roughly like this:-->
- Apollo服务器等待承诺的解析，并返回结果。所以Apollo的工作原理大致是这样的。
+ Apollo服务器等待 Promise 的解析，并返回结果。所以Apollo的工作原理大致是这样的。
 
 ```js
 Person.find({}).then( result => {


### PR DESCRIPTION
In Chinese, the word "承诺" is commonly used to translate the English word "promise", which can lead to confusion when translating programming concepts like JavaScript's Promise. This is because "承诺" is often associated with making a commitment or a pledge, which is not an accurate description of the behavior of a Promise in programming.

Instead, the more accurate translation for "promise" in the context of JavaScript is "Promise" itself, as it is a commonly used programming term that has already been adopted in Chinese technical documentation and programming communities. This helps to avoid confusion and maintain consistency with the global programming community.

See also: 
- [Promise - MDN](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise)
- [Promise - JavaScript-info](https://zh.javascript.info/promise-basics)