### PR TITLE
Text fix for part1a (ptbr), part3b (en) and part4a (en)

### DIFF
--- a/src/content/1/pt/part1a.md
+++ b/src/content/1/pt/part1a.md
@@ -515,7 +515,7 @@ Também a idade:
 {amigos[0].idade}
 ```
 
-Após corrigir o erro, limpe as mensagens de erro do console clicando em Ø e, em seguida, recarregue o conteúdo da página e garanta que não haja mensagens de erro exibidas.
+Após corrigir o erro, limpe as mensagens de erro do console clicando em 🚫 e, em seguida, recarregue o conteúdo da página e garanta que não haja mensagens de erro exibidas.
 
 Uma adição ao lembrete anterior: React também permite que arrays sejam renderizados se conterem valores elegíveis para renderização (como números ou strings). Então, o seguinte programa funcionaria, embora o resultado não seja o que desejamos:
 

--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -210,31 +210,31 @@ The following assumes that the [sign in](https://dashboard.render.com/) has been
 
 After signing in, let us create a new "web service":
 
-![](../../images/3/r1.png)
+![Image showing the option to create a new Web Service](../../images/3/r1.png)
 
 The app repository is then connected to Render:
 
-![](../../images/3/r2.png)
+![Image showing the application repository on Render.](../../images/3/r2.png)
 
 The connecting seem to require that the app reopository is public.
 
 Next we will define the basic configurations. If the app is <i>not</i> at the root of the repository the <i>Root directory</i> needs to be given a proper value:
 
-![](../../images/3/r3.png)
+![image showing the Root Directory field as optional](../../images/3/r3.png)
 
 After this, the app starts up in the Render. The dashboard tells us the app state and the url where the app is running:
 
-![](../../images/3/r4.png)
+![The top left corner of the image shows the status of the application and its URL](../../images/3/r4.png)
 
 According to the [documentation](https://render.com/docs/deploys) every commit to GitHub should redeploy the app. For some reason this is not always working.
 
 Fortunately it is also possible to manually redeploy the app:
 
-![](../../images/3/r5.png)
+![Menu with the option to deploy latest commit highlighted](../../images/3/r5.png)
 
 Also the app logs can be seen in the dashboard:
 
-![](../../images/3/r7.png)
+![Image with the logs tab highlighted on the left corner. On the right side, the application logs](../../images/3/r7.png)
 
 We notice now from the logs that the app has been started in the port 10000. The app code gets the right port through the environment variable PORT so it is essential that the file <i>index.js</i> has been updated as follows:
 

--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -495,7 +495,7 @@ module.exports = {
 }
 ```
 
-> The _average_ function uses the array [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) method. If the method is not familiar to you yet, then now is a good time to watch the first three videos from the [Functional Javascript](https://www.youtube.com/watch?v=BMUiFMZr7vk&list=PL0zVEGEvSaeEd9hlmCXrk5yUyqUag-n84) series on Youtube.
+> The _average_ function uses the array [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) method. If the method is not familiar to you yet, then now is a good time to watch the first three videos from the [Functional Javascript](https://www.youtube.com/watch?v=BMUiFMZr7vk&list=PL0zVEGEvSaeEd9hlmCXrk5yUyqUag-n84) series on YouTube.
 
 There are many different testing libraries or <i>test runners</i> available for JavaScript. In this course we will be using a testing library developed and used internally by Facebook called [jest](https://jestjs.io/), which resembles the previous king of JavaScript testing libraries [Mocha](https://mochajs.org/).
 
@@ -665,7 +665,7 @@ describe('average', () => {
 
 Describe blocks can be used for grouping tests into logical collections. The test output of Jest also uses the name of the describe block:
 
-![screenshot of npm test shwoing describe blocks](../../images/4/4x.png)
+![screenshot of npm test showing describe blocks](../../images/4/4x.png)
 
 As we will see later on <i>describe</i> blocks are necessary when we want to run some shared setup or teardown operations for a group of tests.
 


### PR DESCRIPTION
## part1a (ptbr)
- [x] [fix clear symbol in part1a [ptbr]](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/pull/2695/commits/66781bdf9bb552986160a82be1022ae58d52384b)

## part3b (en)
- [x] [Alternative texts for images was missing, so I added it.](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/pull/2695/commits/37c2be1faf9122f0f17a3430926fc0d0b317b6b1)

## part4a (en)
- [x] [Fixed some text typos](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/pull/2695/commits/25bd6e5ab35d1c20c2ff59cd9da8b8bdb4afe2cd)
