### PR TITLE
Solution for error 404 when user tries to access parts not yet translated to ptbr

### DIFF
--- a/src/components/PartBanner/PartBanner.js
+++ b/src/components/PartBanner/PartBanner.js
@@ -74,16 +74,16 @@ const partNameTranslations = {
     'Introdução ao React',
     'Comunicação com o servidor',
     'Programando um servidor com NodeJS e Express',
-    'Teste de servidores Express e Administração de Usuários',
-    'Teste de aplicações React',
-    'Gerenciamento de Estado com Redux',
-    'React router, hooks personalizados, estilização de aplicações com CSS e Webpack',
-    'GraphQL',
-    'TypeScript',
-    'React Native',
-    'CI/CD',
-    'Containers',
-    'Utilizando bancos de dados relacionais',
+    'Teste de servidores Express e Administração de Usuários (tradução em andamento)',
+    'Teste de aplicações React (tradução em andamento)',
+    'Gerenciamento de Estado com Redux (tradução em andamento)',
+    'React router, hooks personalizados, estilização de aplicações com CSS e Webpack (tradução em andamento)',
+    'GraphQL (tradução em andamento)',
+    'TypeScript (tradução em andamento)',
+    'React Native (tradução em andamento)',
+    'CI/CD (tradução em andamento)',
+    'Containers (tradução em andamento)',
+    'Utilizando bancos de dados relacionais (tradução em andamento)',
   ],
 };
 
@@ -92,14 +92,8 @@ export const PartBanner = ({ lang }) => {
   const parts = Object.keys(navigation[lang]);
 
   function partName(lang) {
-    return lang === 'fi' ? 'Osa' : lang==='ptbr' ? 'Parte' : 'Part'
-    // if (lang === 'fi') {
-    //   return 'Osa'
-    // } else if (lang === 'ptbr') {
-    //   return 'Parte'
-    // } else {
-    //   return 'Part'
-    }
+    return lang === 'fi' ? 'Osa' : lang === 'ptbr' ? 'Parte' : 'Part';
+  }
 
   return (
     <Banner
@@ -120,7 +114,6 @@ export const PartBanner = ({ lang }) => {
                 alt: partNames[part],
               }}
               hoverImageSrc={require(`../../images/thumbnails/part-${part}_ovr.svg`)}
-              // name={`${lang === 'fi' ? 'Osa' : 'Part'} ${part}`}
               name={`${partName(lang)} ${part}`}
               summary={partNames[part]}
               path={getPartTranslationPath(lang, part)}

--- a/src/utils/getPartTranslationPath.js
+++ b/src/utils/getPartTranslationPath.js
@@ -1,4 +1,9 @@
 const getPartTranslationPath = (language, part, path = '') => {
+  // while the ptbr translation are not complete, return the URL for english version
+  if (language === 'ptbr' && part >= 4) {
+    // parts 0-3 are done. For part 4 onward, this will return the english version
+   return  `/en/part${part}${path}`
+  }
   return language === 'fi' ? `/osa${part}${path}` : `/${language}/part${part}${path}`;
 };
 


### PR DESCRIPTION
## Contextualizing the problem
The translation of the course into Brazilian Portuguese (ptbr) is a work in progress. We currently only have parts 0-3 in production. Because of this, when someone tries to access parts 4 onwards, they reach page 404.
![image](https://user-images.githubusercontent.com/614145/223299232-b54ae637-c67f-46dc-a2b9-ffdbd9911a61.png)

The solution: I could have made a placeholder page, but instead I chose to redirect the user to the English version of that page. When the ptbr translation of that part is ready, the user will be redirected to the correct version of the page.

## Files changed to reach this solution:
### PartBanner.js
- [x] I have included this information in each part that has not yet been translated into ptbr: ("tradução em andamento"), which means "translation in progress". This way, the user will know before clicking on the banner that the course material is not yet translated.
![image](https://user-images.githubusercontent.com/614145/223301562-a75ddb0e-545a-4ebb-ad47-279682d2b626.png)


### getPartTranslationPath.js
- [x] I implemented the logic to redirect the user to the English version of pages whose content has not yet been translated to ptbr.

### NB.: 
- **These changes only affect the Portuguese version of the course**.
- Some unnecessary comments were removed from the code.

