### PR TITLE
Fixing component tags in exercise 1.10

### DIFF
--- a/src/content/1/es/part1d.md
+++ b/src/content/1/es/part1d.md
@@ -1104,18 +1104,18 @@ Cambie su aplicación para mostrar estadísticas solo una vez que se hayan recop
 Continuemos refactorizando la aplicación. Extraiga los dos componentes siguientes:
 
 - <i>Button</i> para definir los botones utilizados para enviar comentarios
-- <i>Statistics</i> para mostrar una única estadística, por ejemplo, la puntuación media.
+- <i>StatisticLine</i> para mostrar una única estadística, por ejemplo, la puntuación media.
 
-Para ser claros: el componente <i>Statistics</i> siempre muestra una única estadística, lo que significa que la aplicación utiliza varios componentes para representar todas las estadísticas:
+Para ser claros: el componente <i>StatisticLine</i> siempre muestra una única estadística, lo que significa que la aplicación utiliza varios componentes para representar todas las estadísticas:
 
 ```js
 const Statistics = (props) => {
   /// ...
   return(
     <div>
-      <Statistic text="good" value ={...} />
-      <Statistic text="neutral" value ={...} />
-      <Statistic text="bad" value ={...} />
+      <StatisticLine text="good" value ={...} />
+      <StatisticLine text="neutral" value ={...} />
+      <StatisticLine text="bad" value ={...} />
       // ...
     </div>
   )


### PR DESCRIPTION
There is an error in the statement of exercise 1.10, which confuses the Statistic Component label with the Statistics component label, since they are different components. I propose the change to match the English version of the course, which does not have this error.