### PR TITLE
Missing highlight added

### DIFF
--- a/src/content/6/en/part6b.md
+++ b/src/content/6/en/part6b.md
@@ -151,7 +151,7 @@ const reducer = combineReducers({
 })
  // highlight-end
 
-const store = createStore(reducer)
+const store = createStore(reducer) // highlight-line
 
 console.log(store.getState())
 


### PR DESCRIPTION
Since the store is now created with combined reducer 'reducer' instead of noteReducer. Don't know if more highlights are needed, (console.log(// ...) is a new line too)