### PR TITLE
Update part7b.md

### DIFF
--- a/src/content/7/en/part7b.md
+++ b/src/content/7/en/part7b.md
@@ -19,7 +19,7 @@ In [part 5](/en/part5/props_children_and_proptypes#references-to-components-with
 
 Within the last couple of years, many React libraries have begun to offer hook-based APIs. [In part 6](/en/part6/flux_architecture_and_redux) we used the [useSelector](https://react-redux.js.org/api/hooks#useselector) and [useDispatch](https://react-redux.js.org/api/hooks#usedispatch) hooks from the react-redux library to share our redux-store and dispatch function to our components.
 
-The [React Router's](https://reactrouter.com/en/main/start/tutorial) API we introduced in the [previous part](/en/part7/react_router) is also partially [hook](https://reacttraining.com/react-router/web/api/Hooks)-based. Its hooks can be used to access URL parameters and the <i>navigation</i> object, which allows for manipulating the browser URL programmatically.
+The [React Router's](https://reactrouter.com/en/main/start/tutorial) API we introduced in the [previous part](/en/part7/react_router) is also partially hook-based. Its hooks can be used to access URL parameters and the <i>navigation</i> object, which allows for manipulating the browser URL programmatically.
 
 As mentioned in [part 1](/en/part1/a_more_complex_state_debugging_react_apps#rules-of-hooks), hooks are not normal functions, and when using those we have to adhere to certain [rules or limitations](https://reactjs.org/docs/hooks-rules.html). Let's recap the rules of using hooks, copied verbatim from the official React documentation:
 


### PR DESCRIPTION
Removed link to [old React Router page on hooks](https://reacttraining.com/react-router/web/api/Hooks) because the content no longer exists. The [new docs](https://reactrouter.com/en/main) do not have a route to an overview of hooks because documentation for each hook is directly accessible via the sidebar. Since the link to the new docs are already embedded earlier in the sentence, this link is no longer necessary.