### PR TITLE
Part 9b: fix bug in parseArguments function

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -390,7 +390,7 @@ const parseArguments = (args: string[]): MultiplyValues => {
   if (args.length < 4) throw new Error('Not enough arguments');
   if (args.length > 4) throw new Error('Too many arguments');
 
-  if (!isNaN(Number(args[2])) && !isNaN(Number(args[3]))) {
+  if (!isNaN(Number(args[2])) && !isNaN(Number(args[3])) && !(args[2] === "" || args[3] === "")) {
     return {
       value1: Number(args[2]),
       value2: Number(args[3])


### PR DESCRIPTION
Fix bug where passing an empty string '' as an argument would not throw an error.