### PR TITLE
Update osa1c.md

### DIFF
--- a/src/content/1/fi/osa1c.md
+++ b/src/content/1/fi/osa1c.md
@@ -629,7 +629,7 @@ Tapahtumankäsittelijä välitetään napeille propsin _handleClick_ välityksel
 
 Kerrataan vielä sovelluksen toiminnan pääperiaatteet.
 
-Kun sovellus käynnistyy, suoritetaan komponentin _App_-koodi, joka luo [useState](https://reactjs.org/docs/hooks-reference.html#usestate)-hookin avulla sovellukselle laskurin tilan _counter_. Komponentti renderöi laskimen alkuarvon 0 näyttävän komponentin _Display_ sekä kolme _Button_-komponenttia, joille se asettaa laskurin tilaa muuttavat tapahtumankäsittelijät.
+Kun sovellus käynnistyy, suoritetaan komponentin _App_-koodi, joka luo [useState](https://react.dev/reference/react/useState)-hookin avulla sovellukselle laskurin tilan _counter_. Komponentti renderöi laskimen alkuarvon 0 näyttävän komponentin _Display_ sekä kolme _Button_-komponenttia, joille se asettaa laskurin tilaa muuttavat tapahtumankäsittelijät.
 
 Kun jotain napeista painetaan, suoritetaan vastaava tapahtumankäsittelijä. Tapahtumankäsittelijä muuttaa komponentin _App_ tilaa funktion _setCounter_ avulla. **Tilaa muuttavan funktion kutsuminen aiheuttaa komponentin uudelleenrenderöitymisen.** 
 


### PR DESCRIPTION
useState doc linkki vie legacy sivulle https://legacy.reactjs.org/docs/hooks-reference.html#usestate Vaihto react.dev sivuun https://react.dev/reference/react/useState johon legacy sivullakin viitataan.