### PR TITLE
Import, not create  context

### DIFF
--- a/src/content/10/en/part10c.md
+++ b/src/content/10/en/part10c.md
@@ -757,10 +757,8 @@ Note that accessing a context's value using the <em>useContext</em> hook only wo
 Accessing the <em>AuthStorage</em> instance with <em>useContext(AuthStorageContext)</em> is quite verbose and reveals the details of the implementation. Let's improve this by implementing a <em>useAuthStorage</em> hook in a <i>useAuthStorage.js</i> file in the <i>hooks</i> directory:
 
 ```javascript
-import { createContext } from 'react';
 import { useContext } from 'react'; 
-
-const AuthStorageContext = createContext();
+import AuthStorageContext from "../contexts/AuthStorageContext";
 
 export const useAuthStorage = () => {
   return useContext(AuthStorageContext);


### PR DESCRIPTION
Before we put the context creation in the './src/contexts/AuthStorageContext.js' file. It makes sense to import this here and use it. Otherwise, it will throw an error since the context created in the useAuthStorage is not provided in the 'App.js'. 

(If it makes more sense, to create the context here, we should add explanation on why and delete the 'contexts' directory).