### PR TITLE
Update 'fetching a single resource' example code

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -469,7 +469,7 @@ We can define [parameters](http://expressjs.com/en/guide/routing.html#route-para
 ```js
 app.get('/api/notes/:id', (request, response) => {
   const id = request.params.id
-  const note = notes.find(note => note.id === id)
+  const note = notes.find(note => note.id == id)
   response.json(note)
 })
 ```


### PR DESCRIPTION
The id parameter from the request object is received as a string. So, when we run the array.find() method and do the '===' (equal value and equal type) it will return undefined because the id and the note.id do not match in 'type' (note.id is a number). 

This fix is to do '==' (equal to) and the array.find() will return the wanted value.