### PR TITLE
Update osa2e.md

### DIFF
--- a/src/content/2/fi/osa2e.md
+++ b/src/content/2/fi/osa2e.md
@@ -392,7 +392,7 @@ notesToShow.map(note => ...)
 
 ja tämä aiheuttaa ongelman, sillä arvolle _null_ ei voida kutsua metodia _map_. 
 
-Kun annoimme tilalle _notes_ alkuarvoksi tyhjän taulukon, ei samaa ongelmaa esiinny, tyhjälle taulukolle on luvallista kutsua metodia _filter_.
+Kun annoimme tilalle _notes_ alkuarvoksi tyhjän taulukon, ei samaa ongelmaa esiinny, tyhjälle taulukolle on luvallista kutsua metodia _map_.
 
 Sopiva tilan alustaminen siis "peitti" ongelman, joka johtuu siitä että muistiinpanoja ei ole vielä alustettu palvelimelta haettavalla datalla.
 


### PR DESCRIPTION
Filter is not included in the code preceding the paragraph.  Also when the code is first ran showAll is initialized to true so the filter part in the real definition of notesToShow is not reached. When notes == null the map causes an error.