### PR TITLE
Fix typo in part13a.md

### DIFF
--- a/src/content/13/en/part13a.md
+++ b/src/content/13/en/part13a.md
@@ -156,7 +156,7 @@ postgres=#
 ```
 
 Defined in this way, the data stored in the database is persisted only as long as the container exists. The data can be preserved by defining a
-[volume](/en/part12/building_and_configuring_environments#persisting-data-with-volumes) fort the data, see more
+[volume](/en/part12/building_and_configuring_environments#persisting-data-with-volumes) for the data, see more
 [here](https://github.com/docker-library/docs/blob/master/postgres/README.md#pgdata).
 
 #### Using the psql console


### PR DESCRIPTION
Fix typo in the sentence "defining a volume _fort_ the data", so the wrongly typed word "fort" is replaced with the word "for" as expected.