### PR TITLE
Part4d: token existence check is not reached

### DIFF
--- a/src/content/4/es/part4d.md
+++ b/src/content/4/es/part4d.md
@@ -166,8 +166,8 @@ notesRouter.post('/', async (request, response) => {
   const token = getTokenFrom(request)
 
   const decodedToken = jwt.verify(token, process.env.SECRET)
-  if (!token || !decodedToken.id) {
-    return response.status(401).json({ error: 'token missing or invalid' })
+  if (!decodedToken.id) {
+    return response.status(401).json({ error: 'invalid token' })
   }
 
   const user = await User.findById(decodedToken.id)


### PR DESCRIPTION
Apparently, this verification cannot be achieved, because if there is no token the jwt.verify() method will throw a JsonWebTokenError exception if token is equal to null.