### PR TITLE
Remove duplicate update of the note schema

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -436,19 +436,6 @@ notesRouter.post('/', async (request, response) => {
   response.json(savedNote)
 })
 ```
-The note scheme will also need to change as follows in our models/note.js file:
-
-```js
-const noteSchema = new mongoose.Schema({
-  content: {
-    type: String,
-    minLength: 5,
-    required: true,
-  },
-  important: Boolean,
-  user: String, //highlight-line
-})
-```
 
 It's worth noting that the <i>user</i> object also changes. The <i>id</i> of the note is stored in the <i>notes</i> field:
 


### PR DESCRIPTION
On line 177, the note schema is updated to include a field for user. Let's expand the schema of the note defined in the <i>models/note.js</i> file so that the note contains information about the user who created it:

```js
const noteSchema = new mongoose.Schema({
  content: {
    type: String,
    required: true,
    minlength: 5
  },
  important: Boolean,
  // highlight-start
  user: {
    type: mongoose.Schema.Types.ObjectId,
    ref: 'User'
  }
  // highlight-end
})
```

This is duplicated on line 439, but using string instead of the Mongoose ObjectId

```js
const noteSchema = new mongoose.Schema({
  content: {
    type: String,
    minLength: 5,
    required: true,
  },
  important: Boolean,
  user: String, //highlight-line
})
```

I nominate to keep the first update and remove the second because it maintains the flow of the article and is consistent with the last section on Populate. In fact, updating the code to match the second update (using string) breaks the app.