### PR TITLE
Fix display tags as text instead of rendering them

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -886,7 +886,7 @@ The page has to show the time that the request was received and how many entries
   
 Proposed Addition: There can only be one response.send() statement in an Express app route. Once you send a response to the client using response.send(), the request-response cycle is complete and no further response can be sent. 
   
-To include a line space in the output, use <br/> tag, or wrap the statements in <p> tags.
+To include a line space in the output, use the `<br/>` tag, or wrap the statements in `<p>` tags.
 
 #### 3.3: Phonebook backend step3
 


### PR DESCRIPTION
The `<br/>` and `<p>` tags are supposed to be displayed/formatted as text instead of being rendered as HTML content