### PR TITLE
The test works!

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -936,7 +936,7 @@ test('notes are returned as json', async () => {
 }
 ```
 
-We save the notes stored in the array into the database inside of a _forEach_ loop. The tests don't quite seem to work however, so we have added some console logs to help us find the problem.
+We save the notes stored in the array into the database inside of a _forEach_ loop. The tests seem to work however, so we have added some console logs to help us find the problem.
 
 The console displays the following output:
 


### PR DESCRIPTION
the logging appears in the stated order, but the tests works anyway even the first test with additional count check works! Maybe ```const response = await api.get(...)``` runs late enough or there is some internal ordering of post and get requests.

I removed some text only to mark the place, i have no idea how to improve this or construct a failing example.

This is the code of ```beforeEach``` and my first test in  tests/note_api.test.js:
```js
beforeEach(async () => {
  await Note.deleteMany()
  console.log('cleared')
  helper.initialNotes.forEach(async (note) => {
    let noteObject = new Note(note)
    await noteObject.save()
    console.log('saved')
  })
  console.log('done')
})

test('notes are returned as json', async () => {
  console.log('enter test')

  const response = await api
    .get('/api/notes')
    .expect(200)
    .expect('Content-Type', /application\/json/)
  
  console.log('check count')

  expect(response.body).toHaveLength(helper.initialNotes.length)
  console.log('leave test')
})
```

This is the output (leaving out the middle part)
```
console.log
    cleared

      at Object.log (tests/note_api.test.js:11:11)

  console.log
    done

      at Object.log (tests/note_api.test.js:17:11)

  console.log
    entered test

      at Object.log (tests/note_api.test.js:25:11)

  console.log
    saved

      at log (tests/note_api.test.js:15:13)

  console.log
    saved

      at log (tests/note_api.test.js:15:13)

  console.log
    check count

      at Object.log (tests/note_api.test.js:32:11)

  console.log
    leave test

      at Object.log (tests/note_api.test.js:35:11)

  console.log
    cleared
.
.
.
 PASS  tests/note_api.test.js
  ✓ notes are returned as json (946 ms)
  ✓ all notes are returned (109 ms)
  ✓ a specific note is within the returned notes (98 ms)
  ✓ a valid note can be added (187 ms)
  ✓ note without content is not added (133 ms)
  ✓ a specific note can be viewed (160 ms)
  ✓ a note can be deleted (150 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        4.57 s, estimated 5 s
Ran all test suites.
```
