### PR TITLE
Throwing an error if supposed friend is not in DB

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -459,6 +459,14 @@ And the mutation's resolver:
     }
 
     const person = await Person.findOne({ name: args.name })
+    if (!person) {
+        throw new GraphQLError("The name is not in the database", {
+          extensions: {
+            code: "BAD_USER_INPUT",
+            invalidArgs: args.name,
+          },
+        });
+      }
     if ( !isFriend(person) ) {
       currentUser.friends = currentUser.friends.concat(person)
     }


### PR DESCRIPTION
It would prevent future bugs by checking if the user wanted to be added as a friend to the current user.  If the user is not in the database, throw a GraphQL error stating that the user who wanted to be added is not in the database.

Thank you.