### PR TITLE
Fix typo in part9c.md

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -272,7 +272,7 @@ The [frontend](https://github.com/fullstack-hy2020/patientor) has already been b
 
 #### WARNING
 
-Quite often VS code looses track what is really happening in the code and it shows type or style related warnings despite the code has been fixed. If this happens (to me it has happened quite often), just restart the editor. It is also good to doublecheck that everything really works by running the compiler and the eslint from the command line with commands:
+Quite often VS code loses track what is really happening in the code and it shows type or style related warnings despite the code has been fixed. If this happens (to me it has happened quite often), just restart the editor. It is also good to doublecheck that everything really works by running the compiler and the eslint from the command line with commands:
 
 ```bash
 npm run tsc


### PR DESCRIPTION
Fix typo in the sentence "VS code looses track ", so the wrongly typed word "looses" is replaced with the word "loses" as expected.