### PR TITLE
Rename wtf step

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,7 @@ jobs:
           cd public 
           pwd
           ls -la
-      - name: wtf
+      - name: Gatsby Publish
         uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.SEKRED2 }}


### PR DESCRIPTION
Actions like https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/actions/runs/4902491308/jobs/8754368082 will now show a more descriptive title when failing