### PR TITLE
Fixed Grammar

### DIFF
--- a/src/content/3/en/part3d.md
+++ b/src/content/3/en/part3d.md
@@ -85,7 +85,7 @@ When validating an object fails, we return the following default error message f
 ![postman showing error message](../../images/3/50.png)
 
 We notice that the backend has now a problem: validations are not done when editing a note.
-The [documentation](https://github.com/blakehaswell/mongoose-unique-validator#find--updates) explains what is the problem, validations are not run by default when <i>findOneAndUpdate</i> is executed.
+The [documentation](https://github.com/blakehaswell/mongoose-unique-validator#find--updates) addresses the issue by explaining that validations are not run by default when <i>findOneAndUpdate</i> is executed.
 
 The fix is easy. Let us also reformulate the route code a bit:
 


### PR DESCRIPTION
On Part 3d, there is a statement that says: "The documentation explains what is the problem, validations are not run by default when findOneAndUpdate is executed."

I tried to re-word this statement in order to correct the grammar in this sentence.

This is also my first time trying to contribute to an open-source project. Please leave any helpful comments, thank you!