### PR TITLE
Update part4c.md

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -436,20 +436,6 @@ notesRouter.post('/', async (request, response) => {
   response.json(savedNote)
 })
 ```
-The note scheme will also need to change as follows in our models/note.js file:
-
-```js
-const noteSchema = new mongoose.Schema({
-  content: {
-    type: String,
-    minLength: 5,
-    required: true,
-  },
-  important: Boolean,
-  user: String, //highlight-line
-})
-```
-
 It's worth noting that the <i>user</i> object also changes. The <i>id</i> of the note is stored in the <i>notes</i> field:
 
 ```js


### PR DESCRIPTION
 In the creating a new note section, when saving the id of a user to a new note, it states that the note scheme will also need to change - {user: String}.  But in the sections of 'Mongoose schema for users' and at the end of populate, the note schema shown is different from the one stated above. Was there a reason to state them differently. I am seeing it as conflicting information with both being different. This is a proposal to remove the {user: String} and use the Object.id type.