### PR TITLE
Update part8c.md

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -285,7 +285,7 @@ Mutation: {
         throw new GraphQLError('Creating the user failed', {
           extensions: {
             code: 'BAD_USER_INPUT',
-            invalidArgs: args.name,
+            invalidArgs: args.username,
             error
           }
         })


### PR DESCRIPTION
The `createUser` mutation does not have the `name` property in the `args` parameter.