### PR TITLE
fix(common.scss): font weight and italic

### DIFF
--- a/src/components/common.scss
+++ b/src/components/common.scss
@@ -1,3 +1,5 @@
+// @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&display=swap');
+
 $white: #ffffff;
 $gray: #a0a0a0;
 $black: #33332d;

--- a/src/components/common.scss
+++ b/src/components/common.scss
@@ -1,4 +1,4 @@
-// @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&display=swap');
 
 $white: #ffffff;
 $gray: #a0a0a0;


### PR DESCRIPTION
## This fix closes #2073 
**BEFORE**
![before](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/614145/cb08ff06-f955-4ff3-b21b-eedb1ff79d55)

**AFTER**
![after](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/614145/0af5f7e6-f3b9-4a0b-97e1-7d7a02cf1ed6)

https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/614145/db57fd48-f996-4a62-893e-2dd3928d195f

