### PR TITLE
Update part4a.md

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -368,7 +368,7 @@ info('message')
 error('error message')
 ```
 
-The second way of of exporting may be preferable if only a small portion of the exported functions are used in a file.  E.g. in file <i>controller/notes.js</i> exporting happens as follows:
+The second way of exporting may be preferable if only a small portion of the exported functions are used in a file.  E.g. in file <i>controller/notes.js</i> exporting happens as follows:
 
 ```js
 const notesRouter = require('express').Router()


### PR DESCRIPTION
Changed the spelling in section "Note on exports" . One "of" instead of two