### PR TITLE
Update part11d.md

### DIFF
--- a/src/content/11/en/part11d.md
+++ b/src/content/11/en/part11d.md
@@ -42,9 +42,9 @@ on:
   push:
     branches:
       - master
-  pull_request: // highlight-line
-    branches: [master] // highlight-line
-    types: [opened, synchronize] // highlight-line
+  pull_request: # highlight-line
+    branches: [master] # highlight-line
+    types: [opened, synchronize] # highlight-line
     
 # note that your "main" branch might be called main instead of master
 ```


### PR DESCRIPTION
Fix highlight comment

YML code snippet does not seem to support `// highlight-line` comment syntax, instead `# highlight-comment` seems to be used elsewhere.

![Screenshot from 2023-06-03 11-26-17](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/525676/542833a4-77b2-495a-95e8-bb56d52b7b77)


Issue shown in screenshot is visible in https://fullstackopen.com/en/part11/keeping_green#working-with-pull-requests


Note: I've not tried this fix locally.
