### PR TITLE
Remove Railway from free hosting options

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -101,7 +101,6 @@ There are also some other free options hosting options that work well for this c
 
 Some course participants have also used the following
 
-- [Railway](https://railway.app/)
 - [Cyclic](https://www.cyclic.sh/)
 - [Replit](https://replit.com)
 - [CodeSandBox](https://codesandbox.io)


### PR DESCRIPTION
As seen in [this reddit post](https://www.reddit.com/r/webdev/comments/143tfc2/railway_the_heroku_alternative_shuts_down_their/?utm_source=share&utm_medium=android_app&utm_name=androidcss&utm_term=2&utm_content=share_button), Railway has discontinued their free hosting plan.

