### PR TITLE
Update part4c.md: removed a mistake

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -436,19 +436,6 @@ notesRouter.post('/', async (request, response) => {
   response.json(savedNote)
 })
 ```
-The note scheme will also need to change as follows in our models/note.js file:
-
-```js
-const noteSchema = new mongoose.Schema({
-  content: {
-    type: String,
-    minLength: 5,
-    required: true,
-  },
-  important: Boolean,
-  user: String, //highlight-line
-})
-```
 
 It's worth noting that the <i>user</i> object also changes. The <i>id</i> of the note is stored in the <i>notes</i> field:
 


### PR DESCRIPTION
I have removed the following section from this part:  The note scheme will also need to change as follows in our models/note.js file:

```js
const noteSchema = new mongoose.Schema({
  content: {
    type: String,
    minLength: 5,
    required: true,
  },
  important: Boolean,
  user: String, //highlight-line
})
```


Reason for removing: 
- Both Schema's in models/note.js and models/user.js are as follows: 
```js
const noteSchema = new mongoose.Schema({
  content: {
    type: String,
    minlength: 5,
    required: true
  },
  important: Boolean,
  user: {
    type: mongoose.Schema.Types.ObjectId,
    ref: 'User'
  }
})
```

```js
const userSchema = mongoose.Schema({
  username: {
    type: String,
    required: true,
    unique: true
  },
  name: String,
  passwordHash: String,
  notes: [
    {
      type: mongoose.Schema.Types.ObjectId,
      ref: 'Note'
    }
  ],
})
```

- Also, the Finnish version of the course doesn't include this link.

- Lastly, this inconsistency was acknowledged by thesob on discord as well: https://discord.com/channels/757581218085863474/878211601965137961/1106259100913897513


This is confusing for the people going through the course. 

Thank you!