### PR TITLE
Add Base Web (baseui) UI Framework

### DIFF
--- a/src/content/7/fi/osa7c.md
+++ b/src/content/7/fi/osa7c.md
@@ -502,6 +502,7 @@ Luetellaan tässä kaikesta huolimatta muitakin UI-frameworkeja:
 - <https://www.radix-ui.com/>
 - <https://react-spectrum.adobe.com/react-aria/index.html>
 - <https://master.co/>
+- <https://baseweb.design/>
 
 Jos oma suosikkisi ei ole mukana, tee pull request!
 


### PR DESCRIPTION
Add Base Web (baseui) UI Framework to the list of example frameworks. Made for React.