### PR TITLE
fix: update superseded link

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -76,7 +76,7 @@ Because the passwords themselves are not saved to the database, but <i>hashes</i
 await bcrypt.compare(body.password, user.passwordHash)
 ```
 
-If the user is not found, or the password is incorrect, the request is responded to with the status code [401 unauthorized](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2). The reason for the failure is explained in the response body.
+If the user is not found, or the password is incorrect, the request is responded to with the status code [401 unauthorized](https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized). The reason for the failure is explained in the response body.
 
 If the password is correct, a token is created with the method _jwt.sign_. The token contains the username and the user id in a digitally signed form.
 


### PR DESCRIPTION
# What?

Due to a pop-up warning upon visiting a link regarding the HTTP 401 status code, this PR updates the link to the redirected source material maintained by the [RFC Editor website](https://www.rfc-editor.org/).

My commit updates the superseded link to the updated link and automatically scrolls to the anchor of the HTTP 401 status code documentation, saving the student the hassle to fact-check for updates and a few clicks to find the study material.

# Why?

The [old link regarding the 401 HTTP Status code](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2) greets the student with the following warning: 

```
This document has been superseded. See IETF Documents for more information.
```

It provides an [updated link to the updated documentation in RFC Editor](https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized) with a better user interface if ever the student wants to delve deeper into the topic.