### PR TITLE
fix: correct broken link

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -11,7 +11,7 @@ So far, we have followed the state management conventions recommended by React. 
 
 ### Flux-architecture
 
-Already years ago Facebook developed the [Flux](https://facebook.github.io/flux/docs/in-depth-overview/)-architecture to make state management of React apps easier. In Flux, the state is separated from the React components and into its own <i>stores</i>.
+Already years ago Facebook developed the [Flux](https://facebookarchive.github.io/flux/docs/in-depth-overview)-architecture to make state management of React apps easier. In Flux, the state is separated from the React components and into its own <i>stores</i>.
 State in the store is not changed directly, but with different <i>actions</i>.
 
 When an action changes the state of the store, the views are rerendered:


### PR DESCRIPTION
# What?

Change the [old broken link](https://facebook.github.io/flux/docs/in-depth-overview/) found in Part 6-a, that incorrectly redirects to a redundant page, to the [new facebookarchive/flux overview docs](https://facebookarchive.github.io/flux/docs/in-depth-overview/) in order to meet the intended outcome of the lesson.

# Why?

Facebook archived the previous documentation on the Flux Architecture Overview, so the current link only redirects to [the homepage of opensource.fb.com](https://facebook.github.io/flux/docs/in-depth-overview/).

In an attempt to find the actual intended link, I came across the [facebookarchive/flux repository](https://github.com/facebookarchive/flux/blob/main/docs/In-Depth-Overview.md) which has the [lesson's intended documentation web page](https://facebookarchive.github.io/flux/docs/in-depth-overview) without any redirects.

Without correcting the broken link, students may not know where to find the study material and might raise unnecessary GitHub Issues. 