### PR TITLE
Update part3a.md (Math.max explanation moved to top)

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -741,6 +741,12 @@ app.post('/api/notes', (request, response) => {
 
 We need a unique id for the note. First, we find out the largest id number in the current list and assign it to the _maxId_ variable. The id of the new note is then defined as _maxId + 1_. This method is not recommended, but we will live with it for now as we will replace it soon enough.
 
+```js
+Math.max(...notes.map(n => n.id))
+```
+
+What exactly is happening in that line of code? <em>notes.map(n => n.id)</em> creates a new array that contains all the ids of the notes. [Math.max](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max) returns the maximum value of the numbers that are passed to it. However, <em>notes.map(n => n.id)</em> is an <i>array</i> so it can't directly be given as a parameter to _Math.max_. The array can be transformed into individual numbers by using the "three dot" [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) syntax <em>...</em>.
+
 The current version still has the problem that the HTTP POST request can be used to add objects with arbitrary properties. Let's improve the application by defining that the <i>content</i> property may not be empty. The <i>important</i> property will be given default value false. All other properties are discarded:
 
 ```js
@@ -804,25 +810,6 @@ The code for the current state of the application is specified in branch [part3-
 ![GitHub screenshot of branch 3-1](../../images/3/21.png)
 
 If you clone the project, run the _npm install_ command before starting the application with _npm start_ or _npm run dev_.
-
-One more thing before we move on to the exercises. The function for generating IDs looks currently like this:
-
-```js
-const generateId = () => {
-  const maxId = notes.length > 0
-    ? Math.max(...notes.map(n => n.id))
-    : 0
-  return maxId + 1
-}
-```
-
-The function body contains a row that looks a bit intriguing:
-
-```js
-Math.max(...notes.map(n => n.id))
-```
-
-What exactly is happening in that line of code? <em>notes.map(n => n.id)</em> creates a new array that contains all the ids of the notes. [Math.max](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max) returns the maximum value of the numbers that are passed to it. However, <em>notes.map(n => n.id)</em> is an <i>array</i> so it can't directly be given as a parameter to _Math.max_. The array can be transformed into individual numbers by using the "three dot" [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) syntax <em>...</em>.
 
 </div>
 


### PR DESCRIPTION
Problem Statement 
When we first see the piece of code ``` Math.max(...notes.map(n => n.id)) ```, it is a bit intriguing and I had to look for other resources to see how it works.  The explanation to the line of code was at the end of the notes.

Solution 

To move the explanation right after the piece of code was first introduced.