### PR TITLE
Update part4b: Clarify express-async-errors import order

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -832,7 +832,7 @@ npm install express-async-errors
 ```
 
 Using the library is <i>very</i> easy.
-You introduce the library in <i>app.js</i>:
+You introduce the library in <i>app.js</i>, _before_ you import your routes:
 
 ```js
 const config = require('./utils/config')


### PR DESCRIPTION
Clarify that express-async-errors must be imported before routes are defined, in order for the library to work correctly, as explained in the [docs](https://github.com/davidbanham/express-async-errors#usage).

When I was doing this exercise, I didn't realize that the order of imports mattered, and spent a while debugging the app until I realized why the errors were not being handled correctly!