### PR TITLE
Update part3b redundant fly deploy command

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -190,12 +190,6 @@ If all goes well, the app should now be up and running. You can open it in the b
 fly open
 ```
 
-After the initial setup, when the app code has been updated, it can be deployed to production with the command
-
-```bash
-fly deploy
-```
-
 A particularly important command is _fly logs_. This command can be used to view server logs. It is best to keep logs always visible!
 
 **Note:** In some cases (the cause is so far unknown) running Fly.io commands especially on Windows WSL has caused problems. If the following command just hangs

--- a/src/content/3/fi/osa3b.md
+++ b/src/content/3/fi/osa3b.md
@@ -143,12 +143,6 @@ Jos kaikki menee hyvin, sovellus käynnistyy ja saat sen avattua selaimeen komen
 fly open
 ```
 
-Tämän jälkeen aina kun teet muutoksia sovellukseen, saat vietyä uuden version tuotantoon komennolla 
-
-```bash
-fly deploy
-```
-
 Erittäin tärkeä komento on myös _fly logs_ jonka avulla voit seurata tuotantopalvelimen konsoliin tulostuvia logeja. Logit on viisainta pitää koko ajan näkyvillä.
 
 #### Render

--- a/src/content/3/ptbr/part3b.md
+++ b/src/content/3/ptbr/part3b.md
@@ -176,12 +176,6 @@ Se tudo correr bem, a aplicação deverá estar em funcionamento. Você pode abr
 fly open
 ```
 
-Depois da configuração inicial, quando o código da aplicação for atualizado, poderá ser implantada na produção com o comando:
-
-```bash
-fly deploy
-```
-
 Um comando particularmente importante é _fly logs_. Este comando pode ser usado para visualizar os logs do servidor. É melhor manter os logs sempre visíveis!
 
 **Atenção:** Em alguns casos (a causa é até agora desconhecida) executar comandos Fly.io, especialmente no Windows WSL, causou problemas. Se o seguinte comando simplesmente travar:


### PR DESCRIPTION
Under **Application to the Internet** - **Fly.io**, there is a redundant ```fly deploy``` command. 