### PR TITLE
incorrect property (args.name X . args.username ✔)

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -285,7 +285,7 @@ Mutation: {
         throw new GraphQLError('Creating the user failed', {
           extensions: {
             code: 'BAD_USER_INPUT',
-            invalidArgs: args.name,
+            invalidArgs: args.username,
             error
           }
         })


### PR DESCRIPTION
The args has no name field, 
The only field passed to it is username