### PR TITLE
fix: part11c broken link

### DIFF
--- a/src/content/11/en/part11c.md
+++ b/src/content/11/en/part11c.md
@@ -332,7 +332,7 @@ If you rather want to use other hosting options, there is an alternative set of 
 
 #### 11.10 Deploying your application to Render
 
-Set up your application in [Render](render.com). The setup is now not quite as straightforward as in [part 3](/en/part3/deploying_app_to_internet#application-to-the-internet). You have to carefully think about what should go to these settings:
+Set up your application in [Render](https://render.com/). The setup is now not quite as straightforward as in [part 3](/en/part3/deploying_app_to_internet#application-to-the-internet). You have to carefully think about what should go to these settings:
 
 ![](../../images/11/render1.png)
 


### PR DESCRIPTION
# What?

This pull request fixes the Render link in lesson to redirect to the intended website, from the previous [Render](https://fullstackopen.com/en/part11/render.com) link (which results in a `404 - Sivua ei löytynyt` error) to a new [Render](https://render.com/) link.

> Set up your application in [Render](https://fullstackopen.com/en/part11/render.com). The setup is now not quite as straightforward as in [part 3](https://fullstackopen.com/en/part3/deploying_app_to_internet#application-to-the-internet). You have to carefully think about what should go to these settings:

# Why?

Previously, the link was encoded as `[Render](render.com)` in the lesson's markdown file which redirects the user to `https://fullstackopen.com/en/part11/render.com` instead of `https://render.com` due to not including the protocol in the link.

By using `[Render](https://render.com)` instead, the user will be properly redirected to the Render.com website.