### PR TITLE
Update part4d.md to be consistent with rest of lesson

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -201,7 +201,7 @@ const errorHandler = (error, request, response, next) => {
   } else if (error.name === 'ValidationError') {
     return response.status(400).json({ error: error.message })
   } else if (error.name ===  'JsonWebTokenError') { // highlight-line
-    return response.status(400).json({ error: error.message }) // highlight-line
+    return response.status(401).json({ error: error.message }) // highlight-line
   }
 
   next(error)


### PR DESCRIPTION
The status code set in this block is 400 for some reason. Later down in the lesson, this same block is displayed sending a 401 without mention of changing it. 

Also, in exercise 4.23, the text states "write a new test to ensure adding a blog fails with the proper status code 401 Unauthorized if a token is not provided."

As the error refers to a missing authentication token, makes sense to send 401 instead, and agree with the rest of the lesson text.

fixes #3013 