### PR TITLE
Add [env] if [http_service] configuration

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -176,7 +176,12 @@ This will cause the following warning once deployed and result in your app being
 WARNING The app is not listening on the expected address and will not be reachable by fly-proxy
 ```
 
-Change internal_port to 8080 if your configuration is as mentioned above.
+Change internal_port to 8080 if your configuration is as mentioned above. Also add:
+
+```bash
+[env]
+  PORT = "8080"
+```
 
 We are now ready to deploy the app to the Fly.io servers. That is done with the following command:
 


### PR DESCRIPTION
Otherwise defaults to PORT 3001:
const PORT = process.env.PORT || 3001