### PR TITLE
Update part4c.md for test 'creation fails with proper statuscode and message if username already taken'

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -334,7 +334,7 @@ describe('when there is initially one user in db', () => {
       .expect(400)
       .expect('Content-Type', /application\/json/)
 
-    expect(result.body.error).toContain('expected `username` to be unique')
+    expect(result.body.error.message).toContain('expected `username` to be unique')
 
     const usersAtEnd = await helper.usersInDb()
     expect(usersAtEnd).toEqual(usersAtStart)


### PR DESCRIPTION
i received the whole error object, not just the message
![Screenshot (3725)](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/97498039/89725c01-6f24-4a9e-a24d-11c7cbc7dda1)
