### PR TITLE
Remove unnecessary "npm run dev" in part3c

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -504,7 +504,7 @@ The method for establishing the connection is now given functions for dealing wi
 There are many ways to define the value of an environment variable. One way would be to define it when the application is started:
 
 ```bash
-MONGODB_URI=address_here npm run dev
+MONGODB_URI=address_here
 ```
 
 A more sophisticated way is to use the [dotenv](https://github.com/motdotla/dotenv#readme) library. You can install the library with the command:

--- a/src/content/3/es/part3c.md
+++ b/src/content/3/es/part3c.md
@@ -519,7 +519,7 @@ El método para establecer la conexión ahora tiene funciones para lidiar con un
 Hay muchas formas de definir el valor de una variable de entorno. Una forma sería definirlo cuando se inicia la aplicación:
 
 ```bash
-MONGODB_URI=address_here npm run dev
+MONGODB_URI=address_here
 ```
 
 Una forma más sofisticada es utilizar la biblioteca [dotenv](https://github.com/motdotla/dotenv#readme). Puede instalar la librería con el comando:

--- a/src/content/3/fi/osa3c.md
+++ b/src/content/3/fi/osa3c.md
@@ -491,7 +491,7 @@ Yhteyden muodostavalle metodille on nyt rekisteröity onnistuneen ja epäonnistu
 On useita tapoja määritellä ympäristömuuttujan arvo. Voimme esim. antaa sen ohjelman käynnistyksen yhteydessä seuraavasti:
 
 ```bash
-MONGODB_URI=osoite_tahan npm run dev
+MONGODB_URI=osoite_tahan
 ```
 
 Eräs kehittyneempi tapa on käyttää [dotenv](https://github.com/motdotla/dotenv#readme)-kirjastoa. Asennetaan kirjasto komennolla

--- a/src/content/3/fr/part3c.md
+++ b/src/content/3/fr/part3c.md
@@ -507,7 +507,7 @@ La méthode d'établissement de la connexion est maintenant dotée de fonctions 
 Il existe de nombreuses façons de définir la valeur d'une variable d'environnement. L'une d'elles consiste à la définir au démarrage de l'application :
 
 ```bash
-MONGODB_URI=address_here npm run dev
+MONGODB_URI=address_here
 ```
 
 Une méthode plus sophistiquée consiste à utiliser la bibliothèque [dotenv](https://github.com/motdotla/dotenv#readme). Vous pouvez installer la bibliothèque avec la commande :

--- a/src/content/3/ptbr/part3c.md
+++ b/src/content/3/ptbr/part3c.md
@@ -505,7 +505,7 @@ Agora, o método para estabelecer a conexão recebe funções para lidar com uma
 Existem muitas maneiras de definir o valor de uma variável de ambiente. Uma maneira seria defini-la quando a aplicação é iniciada:
 
 ```bash
-MONGODB_URI=address_here npm run dev
+MONGODB_URI=address_here
 ```
 
 Uma maneira mais sofisticada é usar a biblioteca [dotenv](https://github.com/motdotla/dotenv#readme). É possível instalá-la com o comando:

--- a/src/content/3/zh/part3c.md
+++ b/src/content/3/zh/part3c.md
@@ -598,7 +598,7 @@ mongoose.connect(url)
  定义环境变量的值有很多方法。一种方法是在应用启动时定义它。
 
 ```bash
-MONGODB_URI=address_here npm run dev
+MONGODB_URI=address_here
 ```
 
 <!-- A more sophisticated way is to use the [dotenv](https://github.com/motdotla/dotenv#readme) library. You can install the library with the command:-->


### PR DESCRIPTION
There is an extra "npm run dev" in a code snippet which is not necessary for this part. 