### PR TITLE
part3b.md - warning with .dockerignore

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -369,6 +369,8 @@ fly deploy
 
 The application works perfectly, except we haven't added the functionality for changing the importance of a note to the backend yet.
 
+<i>**NOTE:** If you are using Fly.io, there could be a .dockerignore file that specifies the exclusion of the "./build" directory during deployment. To ensure it gets deployed, consider renaming the ./build directory to ./static_build or an equivalent name.</i>
+
 ![screenshot of notes application](../../images/3/30new.png)
 
 <i>**NOTE:** changing of the importance DOES NOT work yet since the backend has no implementation for it yet.</i>


### PR DESCRIPTION
Added a note/warning to check your .dockerignore file to make sure that the static web page at ./build directory is not being ingored by the deployment