### PR TITLE
part8e: Deleted declaration of const JWT_SECRET.

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -369,8 +369,6 @@ const http = require('http')
 
 const jwt = require('jsonwebtoken')
 
-const JWT_SECRET = 'NEED_HERE_A_SECRET_KEY'
-
 const mongoose = require('mongoose')
 
 const User = require('./models/user')


### PR DESCRIPTION
Deleted declaration of const JWT_SECRET. The declaration of JWT_SECRET is not needed as it is called from process.env. It also seems to contradict lessons from earlier on in the course.