### PR TITLE
fix: part5c clarify getByText matching under "About finding the elements"

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -665,7 +665,7 @@ test('renders content', () => {
 
   render(<Note note={note} />)
 
-  const element = screen.getByText('Does not work anymore :(')
+  const element = screen.getByText('Does not work')
 
   expect(element).toBeDefined()
 })
@@ -675,14 +675,14 @@ Command _getByText_ looks for an element that has the **same text** that it has 
 
 ```js
 const element = screen.getByText(
-  'Does not work anymore :(', { exact: false }
+  'Does not work', { exact: false }
 )
 ```
 
 or we could use the command _findByText_:
 
 ```js
-const element = await screen.findByText('Does not work anymore :(')
+const element = await screen.findByText('Does not work')
 ```
 
 It is important to notice that, unlike the other _ByText_ commands, _findByText_ returns a promise!

--- a/src/content/5/fi/osa5c.md
+++ b/src/content/5/fi/osa5c.md
@@ -653,7 +653,7 @@ test('renders content', () => {
 
   render(<Note note={note} />)
 
-  const element = screen.getByText('Does not work anymore :(')
+  const element = screen.getByText('Does not work')
 
   expect(element).toBeDefined()
 })
@@ -663,14 +663,14 @@ Komento _getByText_ nimittäin etsii elementtiä missä on <i>ainoastaan paramet
 
 ```js 
 const element = screen.getByText(
-  'Does not work anymore :(', { exact: false }
+  'Does not work', { exact: false }
 )
 ```
 
 tai käyttää komentoa _findByText_:
 
 ```js 
-const element = await screen.findByText('Does not work anymore :(')
+const element = await screen.findByText('Does not work')
 ```
 
 On tärkeä huomata, että toisin kuin muut _ByText_-komennoista, _findByText_ palauttaa promisen!

--- a/src/content/5/ptbr/part5c.md
+++ b/src/content/5/ptbr/part5c.md
@@ -666,7 +666,7 @@ test('renders content', () => {
 
   render(<Note note={note} />)
 
-  const element = screen.getByText('Does not work anymore :(')
+  const element = screen.getByText('Does not work')
 
   expect(element).toBeDefined()
 })
@@ -676,14 +676,14 @@ Command _getByText_ procura um elemento que tenha o **mesmo texto**  que possui 
 
 ```js
 const element = screen.getByText(
-  'Does not work anymore :(', { exact: false }
+  'Does not work', { exact: false }
 )
 ```
 
 ou poderíamos usar o comando _findByText_:
 
 ```js
-const element = await screen.findByText('Does not work anymore :(')
+const element = await screen.findByText('Does not work')
 ```
 
 É importante notar que, diferentemente dos outros comandos _ByText_, _findByText_ retorna uma promessa!

--- a/src/content/5/zh/part5c.md
+++ b/src/content/5/zh/part5c.md
@@ -737,7 +737,7 @@ test('renders content', () => {
 
   render(<Note note={note} />)
 
-  const element = screen.getByText('Does not work anymore :(')
+  const element = screen.getByText('Does not work')
 
   expect(element).toBeDefined()
 })
@@ -748,7 +748,7 @@ test('renders content', () => {
 
 ```js
 const element = screen.getByText(
-  'Does not work anymore :(', { exact: false }
+  'Does not work', { exact: false }
 )
 ```
 
@@ -756,7 +756,7 @@ const element = screen.getByText(
  或者我们可以使用_findByText_命令。
 
 ```js
-const element = await screen.findByText('Does not work anymore :(')
+const element = await screen.findByText('Does not work')
 ```
 
 <!-- It is important to notice that unlike the other _ByText_ commands, _findByText_ returns a promise!-->


### PR DESCRIPTION
In part5c, under "About finding the elements", it mentions about getByText matching. It is confusing since the line  ```const element = screen.getByText('Does not work anymore :(')``` is the **same text** as note.content, and should pass instead of fail. Changing this line to ```const element = screen.getByText('Does not work')``` should explain it better