### PR TITLE
naming convention for event props and handlers is misquoted from the react docs

### DIFF
--- a/src/content/1/en/part1c.md
+++ b/src/content/1/en/part1c.md
@@ -629,7 +629,10 @@ const App = () => {
 
 Since we now have an easily reusable <i>Button</i> component, we've also implemented new functionality into our application by adding a button that can be used to decrement the counter.
 
-The event handler is passed to the <i>Button</i> component through the _handleClick_ prop. The name of the prop itself is not that significant, but our naming choice wasn't completely random. React's own official [tutorial](https://react.dev/learn/tutorial-tic-tac-toe) suggests this convention.
+The event handler is passed to the <i>Button</i> component through the _handleClick_ prop. The name of the prop itself is not that significant, but our naming choice wasn't completely random. 
+
+React's own official [tutorial](https://react.dev/learn/tutorial-tic-tac-toe) suggests:
+"In React, it’s conventional to use onSomething names for props which represent events and handleSomething for the function definitions which handle those events."
 
 ### Changes in state cause rerendering
 


### PR DESCRIPTION
I have added a direct quote from react documentation about the naming convention for event handlers and props.  The course has mixed up the naming convention of the handlers and the props.

handlers should start with "handle", e.g. handleButtonClick props should start with "on", e.g. onButtonClick

the course has suggested calling a prop handleClick where as it should start with on and perhaps rather than just a plane onClick have something that indicates what is being clicked to differentiate it from html buttons onClick attribute

i havent changed the usage of this as it is spread throughout the whole section and i may make a more serious mistake than just getting a naming convention wrong.