### PR TITLE
Part 4c: Altered possibly misleading noteSchema `user` field type changes.

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -442,11 +442,16 @@ The note scheme will also need to change as follows in our models/note.js file:
 const noteSchema = new mongoose.Schema({
   content: {
     type: String,
-    minLength: 5,
     required: true,
+    minlength: 5
   },
   important: Boolean,
-  user: String, //highlight-line
+  // highlight-start
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }
+  //highlight-end
 })
 ```
 


### PR DESCRIPTION
This changes one of the latter code blocks in Part 4c, as I found this to be misleading when reading this document.

The current example shows that the `noteSchema`'s type should simply be a `String`. Soon after this, an example using mongoose's `populate` function is shown, which appears to depend on this being of type `mongoose.Schema.Types.ObjectId`.

The correct code is shown in the last code block of the page, but as I've been writing and running the code as I have followed along with the guide, it caused me some confusion at first.

The changes suggested in this commit are lifted from the last code block of the page, so they should be fully consistent with the following contents of the guide.