### PR TITLE
Update part0b.md

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -154,7 +154,7 @@ xhttp.onreadystatechange = function() {
       li.appendChild(document.createTextNode(note.content))
     })
 
-    document.getElementsByClassName('notes')[0].appendChild(ul)
+    document.getElementById('notes').appendChild(ul)
   }
 }
 
@@ -324,7 +324,7 @@ data.forEach(function(note) {
 Finally, the tree branch of the <em>ul</em> variable is connected to its proper place in the HTML tree of the whole page:
 
 ```js
-document.getElementsByClassName('notes').appendChild(ul)
+document.getElementById('notes').appendChild(ul)
 ```
 
 ### Manipulating the document object from console


### PR DESCRIPTION
Changed getElementByClassName('notes') and getElementsByClassName('notes')[0] to getElementById('notes') for correctness. The web page does not contain a tag with `class = "notes"` but contains a `<div>` with `id="notes"` where the `ul` should be added on the DOM