### PR TITLE
Update part7a.md command to run cloned app for exercise 7.1

### DIFF
--- a/src/content/7/en/part7a.md
+++ b/src/content/7/en/part7a.md
@@ -508,7 +508,7 @@ The application starts the usual way, but first, you need to install the depende
 
 ```bash
 npm install
-npm start
+npm run dev
 ```
 
 #### 7.1: routed anecdotes, step1


### PR DESCRIPTION
The command to run the routed-anecdotes app was changed, I assume during the move to Vite, from `npm start` to `npm run dev`. The given instructions will throw an error as written.