### PR TITLE
Update part10b.md

### DIFF
--- a/src/content/10/en/part10b.md
+++ b/src/content/10/en/part10b.md
@@ -575,7 +575,7 @@ const Main = () => {
       <AppBar />
       // highlight-start
       <Routes>
-        <Route path="/" element={<RepositoryList />} exact />
+        <Route path="/" element={<RepositoryList />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       // highlight-end


### PR DESCRIPTION
The attribute “exact” is no longer needed in React Router v6 https://reactrouter.com/en/main/upgrading/v5#relative-routes-and-links