### PR TITLE
Update part10c.md

### DIFF
--- a/src/content/10/en/part10c.md
+++ b/src/content/10/en/part10c.md
@@ -180,7 +180,7 @@ npm install @apollo/client graphql
 Before we can start using Apollo Client, we will need to slightly configure the Metro bundler so that it handles the <i>.cjs</i> file extensions used by the Apollo Client. First, let's install the <i>@expo/metro-config</i> package which has the default Metro configuration:
 
 ```shell
-npm install @expo/metro-config
+npm install @expo/metro-config@0.4.0
 ```
 
 Then, we can add the following configuration to a <i>metro.config.js</i> in the root directory of our project:


### PR DESCRIPTION
Explicitly specify a version for `@expo/metro-config` (example solutions use the constraint `"@expo/metro-config": "^0.3.9"`, the constraint `~0.4.0` worked for me). There might be issues with the metro peer dependency if the latest version of `@expo/metro-config` gets installed.