### PR TITLE
update start command to 'npm run dev'

### DIFF
--- a/src/content/2/en/part2c.md
+++ b/src/content/2/en/part2c.md
@@ -519,7 +519,7 @@ The configuration for the whole application has steadily grown more complex. Let
 
 ![diagram of composition of react app](../../images/2/18e.png)
 
-The JavaScript code making up our React application is run in the browser. The browser gets the JavaScript from the <i>React dev server</i>, which is the application that runs after running the command <em>npm start</em>. The dev-server transforms the JavaScript into a format understood by the browser. Among other things, it stitches together JavaScript from different files into one file. We'll discuss the dev-server in more detail in part 7 of the course.
+The JavaScript code making up our React application is run in the browser. The browser gets the JavaScript from the <i>React dev server</i>, which is the application that runs after running the command <em>npm run dev</em>. The dev-server transforms the JavaScript into a format understood by the browser. Among other things, it stitches together JavaScript from different files into one file. We'll discuss the dev-server in more detail in part 7 of the course.
 
 The React application running in the browser fetches the JSON formatted data from <i>json-server</i> running on port 3001 on the machine. The server we query the data from - <i>json-server</i> - gets its data from the file <i>db.json</i>.
 


### PR DESCRIPTION
In this commit, I've modified the start command in the project to transition from 'npm start' to 'npm run dev.' This change is to reflect the courses transition from Create React App to Vite as the underlying development tool.