### PR TITLE
Part5e: Resolve testcase failing.

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -534,7 +534,7 @@ describe('Note app', function() {
           .contains('make not important')
           .click()
 
-        cy.contains('show all').click() // by default 'show all' state is false
+        cy.contains('show all').click()  // by default 'show all' state is false
 
         cy.contains('another note cypress')
           .contains('make important')

--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -534,6 +534,8 @@ describe('Note app', function() {
           .contains('make not important')
           .click()
 
+        cy.contains('show all').click() // by default 'show all' state is false
+
         cy.contains('another note cypress')
           .contains('make important')
       })


### PR DESCRIPTION
Resolve failing test case issue.
if we skip the "show all" click step, line 540 fails because after making a note "not important", it filters out that note due to "show all" state.