### PR TITLE
Update part6d.md (FIN)

### DIFF
--- a/src/content/6/fi/osa6d.md
+++ b/src/content/6/fi/osa6d.md
@@ -48,6 +48,11 @@ export default App
 
 Alkuvaiheen koodi on GitHubissa repositorion [https://github.com/fullstack-hy2020/query-notes](https://github.com/fullstack-hy2020/query-notes/tree/part6-0) branchissa <i>part6-0</i>.
 
+**Huom:** Oletuksena repon kloonaus antaa sinulle ainoastaan main-branchin. Kloonaa siis yllä mainittu repo käyttämällä seuraavaa komentoa, jotta saat part6-0 branchin sisällön.
+```
+git clone --branch part6-0 https://github.com/fullstack-hy2020/query-notes.git
+```
+
 ### Palvelimella olevan datan hallinta React Query ‑kirjaston avulla
 
 Hyödynnämme nyt [React Query](https://tanstack.com/query/latest) ‑kirjastoa palvelimelta haettavan datan säilyttämiseen ja hallinnointiin. Kirjaston uusimmasta versiosta käytetään myös nimitystä TanStack Query mutta pitäydymme vanhassa tutussa nimessä.


### PR DESCRIPTION
Updates the part6 d to include specific git clone instructions for the `part6-0` branch. 

**Reason for Change:**
- Users cloning the repo may not be aware that they need to checkout a different branch to get the starter code for Part 6d. This should make that process clearer.