### PR TITLE
Fixed wrong default export declaration in part9b.md

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -587,7 +587,7 @@ and exporting
 export const isNotNumber = (argument: any): boolean =>
   isNaN(Number(argument));
 
-default export "this is the default..."
+export default "this is the default..."
 ```
 
 Another note: somehow surprisingly TypeScript does not allow to define the same variable in many files at a "block-scope", that is, outside functions (or classes):


### PR DESCRIPTION
Code snippet defines a default export as:

```js
default export "this is the default..."
```

Correct syntax is

```js
export default "this is the default..."
```

(A bit pedantic I know, but it got me confused when I was doing the TypeScript module ><)