### PR TITLE
fix typo and update start command to 'npm run dev'

### DIFF
--- a/src/content/2/en/part2e.md
+++ b/src/content/2/en/part2e.md
@@ -610,9 +610,9 @@ If you use Open weather map, [here](https://openweathermap.org/weather-condition
 Assuming the api-key is <i>54l41n3n4v41m34rv0</i>, when the application is started like so:
 
 ```bash
-VITE_SOME_KEY=54l41n3n4v41m34rv0 npm start3 npm start // For Linux/macOS Bash
-($env:VITE_SOME_KEY="54l41n3n4v41m34rv0") -and (npm start) // For Windows PowerShell
-set "VITE_SOME_KEY=54l41n3n4v41m34rv0" && npm start // For Windows cmd.exe
+VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev// For Linux/macOS Bash
+($env:VITE_SOME_KEY="54l41n3n4v41m34rv0") -and (npm run dev) // For Windows PowerShell
+set "VITE_SOME_KEY=54l41n3n4v41m34rv0" && npm run dev // For Windows cmd.exe
 ```
 
 you can access the value of the key from the _process.env_ object:


### PR DESCRIPTION
In this commit, 

I fixed a typo in the command for the linux/macOS Bash

I have also modified the start command in the project to transition from 'npm start' to 'npm run dev.' This change is to reflect the courses transition from Create React App to Vite as the underlying development tool.