### PR TITLE
Update osa7a.md

### DIFF
--- a/src/content/7/fi/osa7a.md
+++ b/src/content/7/fi/osa7a.md
@@ -506,7 +506,7 @@ Sovellus käynnistyy normaaliin tapaan, mutta joudut ensin asentamaan sovellukse
 
 ```bash
 npm install
-npm start
+npm run dev
 ```
 
 #### 7.1: routed anecdotes, step1


### PR DESCRIPTION
Updates the part7 a Documentation with correct npm command

**Reason for Change:**
The documentation currently instructs to use `npm start` to launch the application. However, as the repository is bootstrapped with Vite, the accurate command is `npm run dev`. 