### PR TITLE
Update part6d.md: Fix a syntax error

### DIFF
--- a/src/content/6/en/part6d.md
+++ b/src/content/6/en/part6d.md
@@ -304,8 +304,8 @@ const App = () => {
 
   const newNoteMutation = useMutation(createNote, {
     onSuccess: (newNote) => {
-      const notes = queryClient.getQueryData('notes') // highlight-line
-      queryClient.setQueryData('notes', notes.concat(newNote)) // highlight-line
+      const notes = queryClient.getQueryData(['notes']) // highlight-line
+      queryClient.setQueryData(['notes'], notes.concat(newNote)) // highlight-line
     }
   })
   // ...


### PR DESCRIPTION
The given code for `queryClient.getQueryData()` and `queryClient.setQueryData()` was causing errors.

I identified and fixed the syntax error present there.

<img width="410" alt="image" src="https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/93025341/f58cc8c7-fe51-4f68-9134-e556aabd49ac">
