### PR TITLE
update static file serving to use 'dist' directory instead of 'build'

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -789,7 +789,7 @@ The execution order of middleware is the same as the order that they are loaded 
 The correct order is the following:
 
 ```js
-app.use(express.static('build'))
+app.use(express.static('dist'))
 app.use(express.json())
 app.use(requestLogger)
 


### PR DESCRIPTION
Updated the configuration to serve static files from the 'dist' directory instead of 'build'. This aligns with the curriculum's current build setup and ensures that the code is consistent with previous lessons.