### PR TITLE
Update part7f.md: Fix a typo

### DIFF
--- a/src/content/7/en/part7f.md
+++ b/src/content/7/en/part7f.md
@@ -7,7 +7,7 @@ lang: en
 
 <div class="content">
 
-In addition to the eight exercises in the [React router](/en/part7/react_router) and [custom hooks](/en/part7/custom_hooks) sections of this seventh part of the course material, 13 exercises continue our work on the Bloglist application that we worked on in parts four and five of the course material. Some of the following exercises are "features" that are independent of one another, meaning that there is no need to finish the exercises in any particular order. You are free to skip over a part of the exercises if you wish to do so. Quite many of the exercises are applying the advanced state management technique (Redux, React Query and context) covered in part [part 6](/en/part6).
+In addition to the eight exercises in the [React router](/en/part7/react_router) and [custom hooks](/en/part7/custom_hooks) sections of this seventh part of the course material, 13 exercises continue our work on the Bloglist application that we worked on in parts four and five of the course material. Some of the following exercises are "features" that are independent of one another, meaning that there is no need to finish the exercises in any particular order. You are free to skip over a part of the exercises if you wish to do so. Quite many of the exercises are applying the advanced state management technique (Redux, React Query and context) covered in [part 6](/en/part6).
 
 If you do not want to use your Bloglist application, you are free to use the code from the model solution as a starting point for these exercises.
 


### PR DESCRIPTION
Fixed a typo in the introductory paragraph of the exercises chapter.

Before: `part part 6`
After: `part 6`

<img width="837" alt="image" src="https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/93025341/7a705f2f-cf10-463f-8487-5851a5dff118">
