### PR TITLE
fix: Correct startup command in part9d.md

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -25,7 +25,7 @@ We can use [Vite](https://vitejs.dev/) to create a TypeScript app specifying a t
 npm create vite@latest my-app-name -- --template react-ts
 ```
 
-After running the command, you should have a complete basic React app that uses TypeScript. You can start the app by running *npm start* in the application's root.
+After running the command, you should have a complete basic React app that uses TypeScript. You can start the app by running *npm run dev* in the application's root.
 
 If you take a look at the files and folders, you'll notice that the app is not that different from one using pure JavaScript. The only differences are that the *.jsx* files are now *.tsx* files, they contain some type annotations, and the root directory contains a *tsconfig.json* file.
 


### PR DESCRIPTION
The original text mistakenly stated that the React app should be started with `npm start` in the `part9d.md` file. However, the application was created using Vite, and the correct command to start the app is `npm run dev`.