### PR TITLE
Adopt .eslintrc.* in part10a.md

### DIFF
--- a/src/content/10/en/part10a.md
+++ b/src/content/10/en/part10a.md
@@ -138,7 +138,7 @@ Now that we are somewhat familiar with the development environment let's enhance
 npm install --save-dev eslint @babel/eslint-parser eslint-plugin-react eslint-plugin-react-native
 ```
 
-Next, let's add the ESLint configuration into a <i>.eslintrc</i> file in the <i>rate-repository-app</i> directory with the following content:
+Next, let's add the ESLint configuration into a <i>.eslintrc.json</i> file in the <i>rate-repository-app</i> directory with the following content:
 
 ```javascript
 {


### PR DESCRIPTION
While they still work, .eslintrc files without an extension are technically deprecated. Updated the text to use .eslintrc.json .