### PR TITLE
Update part6d.md - unnecessary prop passing in example

### DIFF
--- a/src/content/6/en/part6d.md
+++ b/src/content/6/en/part6d.md
@@ -568,7 +568,7 @@ const App = () => {
 
   return (
     <CounterContext.Provider value={[counter, counterDispatch]}>  // highlight-line
-      <Display counter={counter}/>
+      <Display />
       <div>
         <Button type='INC' label='+' />
         <Button type='DEC' label='-' />


### PR DESCRIPTION
The value of counter for the Display component is grabbed via context, and does not need to be passed as a prop in this example.