### PR TITLE
Add links to React UI libraries in part7c.md en

### DIFF
--- a/src/content/7/en/part7c.md
+++ b/src/content/7/en/part7c.md
@@ -508,6 +508,9 @@ Here are some other UI frameworks for your consideration. If you do not see your
 - <https://www.radix-ui.com/>
 - <https://nextui.org/>
 - <https://daisyui.com/>
+- <https://ui.shadcn.com/>
+- <https://www.tremor.so/>
+- <https://headlessui.com/>
 
 ### Styled components
 


### PR DESCRIPTION
In this commit I've added links to some useful React UI libraries.

Libraries added:
- [shadcn/ui](https://ui.shadcn.com/): Re-usable components built using Radix UI and Tailwind CSS.
- [headless ui](https://headlessui.com/): Completely unstyled, fully accessible UI components, designed to integrate beautifully with Tailwind CSS.
- [tremor](https://www.tremor.so/): The React library to build dashboards fast.