### PR TITLE
Update part4b.md

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -798,7 +798,7 @@ notesRouter.get('/:id', async (request, response, next) => {
 
 notesRouter.delete('/:id', async (request, response, next) => {
   try {
-    await Note.findByIdAndRemove(request.params.id)
+    await Note.findByIdAndDelete(request.params.id)
     response.status(204).end()
   } catch(exception) {
     next(exception)


### PR DESCRIPTION
I got this error ("TypeError: Note.findByIdAndRemove is not a function," ) while deleteing a note with mongoose v 8. I think this is because the "findByIdAndRemove" function has been deprecated and "findByIdAndDelete" is the alternative.