### PR TITLE
Update part3c.md Use findOneAndDelete instead of findByIdAndRemove in docs

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -852,11 +852,11 @@ Now the handling of unknown endpoints is ordered <i>before the HTTP request hand
 
 Let's add some missing functionality to our application, including deleting and updating an individual note.
 
-The easiest way to delete a note from the database is with the [findByIdAndRemove](https://mongoosejs.com/docs/api/model.html#model_Model-findByIdAndRemove) method:
+The easiest way to delete a note from the database is with the [findByIdAndDelete](https://mongoosejs.com/docs/api/model.html#Model.findByIdAndDelete()) method:
 
 ```js
 app.delete('/api/notes/:id', (request, response, next) => {
-  Note.findByIdAndRemove(request.params.id)
+  Note.findByIdAndDelete(request.params.id)
     .then(result => {
       response.status(204).end()
     })


### PR DESCRIPTION
This PR updates the documentation to use the `findOneAndDelete` function instead of the `findByIdAndRemove` function in the `app.delete` route handler in the part3 lesson c of the FullStackOpen 2023 course.

The `findByIdAndRemove` function is deprecated. 

### Changes :

Updated the documentation to use the `findOneAndDelete` function instead of the `findByIdAndRemove` function in the `app.delete` route handler in the part3 lesson c of the FullStackOpen 2023 course.


### Issue :
Fixes #3255 