### PR TITLE
Deleted some extra parentheses, part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -456,7 +456,7 @@ mongoose.connect(url)
   .then(result => {
     console.log('connected to MongoDB')
   })
-  .catch((error) => {
+  .catch(error => {
     console.log('error connecting to MongoDB:', error.message)
   })
 // highlight-end
@@ -500,7 +500,7 @@ mongoose.connect(url)
   .then(result => {
     console.log('connected to MongoDB')
   })
-  .catch((error) => {
+  .catch(error => {
     console.log('error connecting to MongoDB:', error.message)
   })
 ```


### PR DESCRIPTION
In the entire chapter, there were 8 examples where `.catch(error => {})` were used. Those two examples that I have updated contained parentheses around the error statement that looked like `.catch((error) => {}`. This made the code feels a little different than usual, so I updated it.

Incase the changes should have been on the other examples, I will be happy to update this pull request!