### PR TITLE
Update part2e.md

### DIFF
--- a/src/content/2/en/part2e.md
+++ b/src/content/2/en/part2e.md
@@ -610,7 +610,7 @@ If you use Open weather map, [here](https://openweathermap.org/weather-condition
 Assuming the api-key is <i>54l41n3n4v41m34rv0</i>, when the application is started like so:
 
 ```bash
-VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev// For Linux/macOS Bash
+export VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // For Linux/macOS Bash
 ($env:VITE_SOME_KEY="54l41n3n4v41m34rv0") -and (npm run dev) // For Windows PowerShell
 set "VITE_SOME_KEY=54l41n3n4v41m34rv0" && npm run dev // For Windows cmd.exe
 ```


### PR DESCRIPTION
The command in line 613, "VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // For Linux/macOS Bash", does not work in Linux. It is necessary to use the command "export" to set the environment variable. So, line 613 should be "export VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // For Linux/macOS Bash".