### PR TITLE
Update osa2e.md

### DIFF
--- a/src/content/2/fi/osa2e.md
+++ b/src/content/2/fi/osa2e.md
@@ -609,7 +609,7 @@ Jos käytät Open weather mapia, [täällä](https://openweathermap.org/weather-
 Oletetaan että API-avaimen arvo on <i>54l41n3n4v41m34rv0</i>. Kun ohjelma käynnistetään seuraavasti
 
 ```bash
-VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // Linux/macOS Bash
+export VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // Linux/macOS Bash
 ($env:VITE_SOME_KEY="54l41n3n4v41m34rv0") -and (npm run dev) // Windows PowerShell
 set "VITE_SOME_KEY=54l41n3n4v41m34rv0" && npm run dev // Windows cmd.exe
 ```


### PR DESCRIPTION

The command in line 612, "VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // For Linux/macOS Bash", does not work in Linux. It is necessary to use the command "export" to set the environment variable. So, line 612 should be "export VITE_SOME_KEY=54l41n3n4v41m34rv0 && npm run dev // For Linux/macOS Bash".