### PR TITLE
Fix highlighting issues in part6a that affects the build

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -79,9 +79,7 @@ Let's change the code a bit. We have used if-else statements to respond to an ac
 Let's also define a [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) of 0 for the parameter <i>state</i>. Now the reducer works even if the store state has not been primed yet.
 
 ```js
-// highlight-start
-const counterReducer = (state = 0, action) => {
-  // highlight-end
+const counterReducer = (state = 0, action) => { // highlight-line
   switch (action.type) {
     case 'INCREMENT':
       return state + 1
@@ -98,9 +96,7 @@ const counterReducer = (state = 0, action) => {
 Reducer is never supposed to be called directly from the application's code. Reducer is only given as a parameter to the _createStore_-function which creates the store:
 
 ```js
-// highlight-start
-import { createStore } from 'redux'
-// highlight-end
+import { createStore } from 'redux' // highlight-line
 
 const counterReducer = (state = 0, action) => {
   // ...
@@ -753,10 +749,8 @@ Your application can have a modest appearance, nothing else is needed but button
 Let's add the functionality for adding new notes and changing their importance:
 
 ```js
-// highlight-start
-const generateId = () =>
-  Number((Math.random() * 1000000).toFixed(0))
-// highlight-stop
+const generateId = () => // highlight-line
+  Number((Math.random() * 1000000).toFixed(0)) // highlight-line
 
 const App = () => {
   // highlight-start

--- a/src/content/6/es/part6a.md
+++ b/src/content/6/es/part6a.md
@@ -90,9 +90,7 @@ Cambiemos un poco el código. Es habitual usar el comando [switch](https://devel
 Definamos también un [valor predeterminado](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) de 0 para el <i>estado</i> del parámetro . Ahora el reducer funciona incluso si el estado del store aún no se ha indicado.
 
 ```js
-// highlight-start
-const counterReducer = (state = 0, action) => {
-  // highlight-end
+const counterReducer = (state = 0, action) => { // highlight-line
   switch (action.type) {
     case 'INCREMENT':
       return state + 1
@@ -110,9 +108,7 @@ const counterReducer = (state = 0, action) => {
 No se supone que Reducer se llame directamente desde el código de la aplicación. Reducer solo se proporciona como parámetro a la función _createStore_ que crea el store:
 
 ```js
-// highlight-start
-import { createStore } from 'redux'
-// highlight-end
+import { createStore } from 'redux' // highlight-line
 
 const counterReducer = (state = 0, action) => {
   // ...
@@ -764,10 +760,8 @@ Tu aplicación puede tener una apariencia modesta, nada más se necesitan 3 boto
 Agreguemos la funcionalidad para agregar nuevas notas y cambiar su importancia:
 
 ```js
-// highlight-start
-const generateId = () =>
-  Number((Math.random() * 1000000).toFixed(0))
-// highlight-stop
+const generateId = () => // highlight-line
+  Number((Math.random() * 1000000).toFixed(0)) // highlight-line
 
 const App = () => {
   // highlight-start


### PR DESCRIPTION
Fix highlighting issues in part6a that affects the build. A previous contribution added highlighting to some lines just at the beginning of code blocks and just for by one line in some cases, that generates conflicts when the ContentTemplate.js tries to get the part content from graphql.

Ex. (part6a.md, line 82)

```
```js
// highlight-start
const counterReducer = (state = 0, action) => {
// highlight-end
```

Instead of, we can use `// highlight-line` to highlight the needed line and prevent build problems.

```
```js
const counterReducer = (state = 0, action) => { // highlight-line
```
