### PR TITLE
Update part3a.md: add boolean conversion to body.important

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -762,7 +762,7 @@ app.post('/api/notes', (request, response) => {
 
   const note = {
     content: body.content,
-    important: body.important || false,
+    important: Boolean(body.important) || false,
     id: generateId(),
   }
 
@@ -790,10 +790,10 @@ If the content property has a value, the note will be based on the received data
 If the <i>important</i> property is missing, we will default the value to <i>false</i>. The default value is currently generated in a rather odd-looking way:
 
 ```js
-important: body.important || false,
+important: Boolean(body.important) || false,
 ```
 
-If the data saved in the _body_ variable has the <i>important</i> property, the expression will evaluate to its value. If the property does not exist, then the expression will evaluate to false which is defined on the right-hand side of the vertical lines.
+If the data saved in the _body_ variable has the <i>important</i> property, the expression will evaluate its value and convert it to a boolean value. If the property does not exist, then the expression will evaluate to false which is defined on the right-hand side of the vertical lines.
 
 > To be exact, when the <i>important</i> property is <i>false</i>, then the <em>body.important || false</em> expression will in fact return the <i>false</i> from the right-hand side...
 


### PR DESCRIPTION
body.important needs to be converted to a boolean value, otherwise, it will be saved to the note as it is if it's a truthy value.