### PR TITLE
Add a note to lesson part1-c

### DIFF
--- a/src/content/1/en/part1c.md
+++ b/src/content/1/en/part1c.md
@@ -752,6 +752,19 @@ const Button = ({ onSmash, text }) => (
 )
 ```
 
+Don't forget that you would need to change the prop name also in the App component:
+
+```js
+return (
+    <div>
+      <Display counter={counter} />
+      <Button onSmash={increaseByOne} text="plus" />
+      <Button onSmash={setToZero} text="zero" />
+      <Button onSmash={decreaseByOne} text="minus" />
+    </div>
+);
+```
+
 We can simplify the Button component once more by declaring the return statement in just one line:
 
 ```js


### PR DESCRIPTION
Students are told that prop name `onClick` can be changed to `onSmash` but this change on its own creates an error because the prop name passed from App to Button doesn't match the one used inside Button. This note can be added to avoid confusion.