### PR TITLE
Update osa1a.md: Set rule 'react/prop-types' to 0 instead of false

### DIFF
--- a/src/content/1/fi/osa1a.md
+++ b/src/content/1/fi/osa1a.md
@@ -391,7 +391,7 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
-    'react/prop-types': false // highlight-line
+    'react/prop-types': 0 // highlight-line
   },
 }
 ```


### PR DESCRIPTION
The rule `'react/prop-types': false` is invalid.
![image](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/42709836/6da9a37d-82ad-4e38-9ec4-86bd42279cb5)

According to https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md, set `'react/prop-types': 0` to disable it.