### PR TITLE
fix: added docs folder for broken links for react bootstrap in 7c

### DIFF
--- a/src/content/7/en/part7c.md
+++ b/src/content/7/en/part7c.md
@@ -197,7 +197,7 @@ We will render the message as a Bootstrap [Alert](https://getbootstrap.com/docs/
 
 #### Navigation structure
 
-Lastly, let's alter the application's navigation menu to use Bootstrap's [Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) component. The React Bootstrap library provides us with [matching built-in components](https://react-bootstrap.github.io/docs/components/navbar/#navbars-mobile-friendly). Through trial and error, we end up with a working solution despite the cryptic documentation:
+Lastly, let's alter the application's navigation menu to use Bootstrap's [Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) component. The React Bootstrap library provides us with [matching built-in components](https://react-bootstrap.github.io/docs/components/navbar/#responsive-behaviors). Through trial and error, we end up with a working solution despite the cryptic documentation:
 
 ```js
 <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">

--- a/src/content/7/es/part7c.md
+++ b/src/content/7/es/part7c.md
@@ -31,7 +31,7 @@ Instalemos el paquete con el comando:
 npm install react-bootstrap
 ```
 
-Luego agreguemos un [link para cargar la hoja de estilo CSS](https://react-bootstrap.github.io/getting-started/introduction#stylesheets) para Bootstrap dentro de la etiqueta <i>head</i> en el archivo <i>public/index.html</i> de la aplicación:
+Luego agreguemos un [link para cargar la hoja de estilo CSS](https://react-bootstrap.github.io/docs/getting-started/introduction#stylesheets) para Bootstrap dentro de la etiqueta <i>head</i> en el archivo <i>public/index.html</i> de la aplicación:
 
 ```js
 <head>
@@ -70,7 +70,7 @@ Notamos que esto ya tiene un efecto en la apariencia de la aplicación. El conte
 
 #### Tablas
 
-A continuación, hagamos algunos cambios en el componente <i>Notes</i>, para que muestre la lista de notas como una [tabla](https://getbootstrap.com/docs/4.1/content/tables/). React Bootstrap proporciona un componente [Table](https://react-bootstrap.github.io/components/table/) integrado para este propósito, por lo que no es necesario definir clases CSS por separado.
+A continuación, hagamos algunos cambios en el componente <i>Notes</i>, para que muestre la lista de notas como una [tabla](https://getbootstrap.com/docs/4.1/content/tables/). React Bootstrap proporciona un componente [Table](https://react-bootstrap.github.io/docs/components/table/) integrado para este propósito, por lo que no es necesario definir clases CSS por separado.
 
 ```js
 const Notes = (props) => (
@@ -110,7 +110,7 @@ import { Table } from 'react-bootstrap'
 
 Mejoremos el formulario en la vista de inicio de sesión con la ayuda de [formularios](https://getbootstrap.com/docs/4.1/components/forms/) Bootstrap.
 
-React Bootstrap proporciona [componentes](https://react-bootstrap.github.io/forms/overview/) integrados para crear formularios (aunque falta un poco la documentación para ellos):
+React Bootstrap proporciona [componentes](https://react-bootstrap.github.io/docs/forms/overview/) integrados para crear formularios (aunque falta un poco la documentación para ellos):
 
 ```js
 let Login = (props) => {
@@ -180,7 +180,7 @@ const App = () => {
 }
 ```
 
-Representaremos el mensaje como un componente [Alert](https://getbootstrap.com/docs/4.1/components/alerts/) de Bootstrap . Una vez más, la librería React Bootstrap nos proporciona un [componente React](https://react-bootstrap.github.io/components/alerts/) correspondiente:
+Representaremos el mensaje como un componente [Alert](https://getbootstrap.com/docs/4.1/components/alerts/) de Bootstrap . Una vez más, la librería React Bootstrap nos proporciona un [componente React](https://react-bootstrap.github.io/docs/components/alerts/) correspondiente:
 
 ```js
 <div className="container">
@@ -197,7 +197,7 @@ Representaremos el mensaje como un componente [Alert](https://getbootstrap.com/d
 
 #### Estructura de navegación
 
-Por último, modifiquemos el menú de navegación de la aplicación para usar el componente [Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) de Bootstrap. La librería React Bootstrap nos proporciona [componentes incorporados coincidentes](https://react-bootstrap.github.io/components/navbar/#navbars-mobile-friendly). A través de prueba y error, terminamos con una solución que funciona a pesar de la documentación críptica:
+Por último, modifiquemos el menú de navegación de la aplicación para usar el componente [Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) de Bootstrap. La librería React Bootstrap nos proporciona [componentes incorporados coincidentes](https://react-bootstrap.github.io/docs/components/navbar/#responsive-behaviors). A través de prueba y error, terminamos con una solución que funciona a pesar de la documentación críptica:
 
 ```js
 <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">

--- a/src/content/7/fi/osa7c.md
+++ b/src/content/7/fi/osa7c.md
@@ -31,7 +31,7 @@ Asennetaan kirjasto:
 npm install react-bootstrap
 ```
 
-Lisätään sitten sovelluksen tiedostoon <i>public/index.html</i> tagin <i>head</i> sisään [Bootstrapin CSS-määrittelyt](https://react-bootstrap.github.io/getting-started/introduction#stylesheets) lataava rivi:
+Lisätään sitten sovelluksen tiedostoon <i>public/index.html</i> tagin <i>head</i> sisään [Bootstrapin CSS-määrittelyt](https://react-bootstrap.github.io/docs/getting-started/introduction#stylesheets) lataava rivi:
 
 ```js
 <head>
@@ -69,7 +69,7 @@ Sovelluksen ulkoasu muuttuu siten, että sisältö ei ole enää yhtä kiinni se
 
 #### Taulukko
 
-Muutetaan seuraavaksi komponenttia <i>Notes</i> siten, että se renderöi muistiinpanojen listan [taulukkona](https://getbootstrap.com/docs/4.1/content/tables/). React-Bootstrap tarjoaa valmiin komponentin [Table](https://react-bootstrap.github.io/components/table/), joten CSS-luokan käyttöön ei ole tarvetta.
+Muutetaan seuraavaksi komponenttia <i>Notes</i> siten, että se renderöi muistiinpanojen listan [taulukkona](https://getbootstrap.com/docs/4.1/content/tables/). React-Bootstrap tarjoaa valmiin komponentin [Table](https://react-bootstrap.github.io/docs/components/table/), joten CSS-luokan käyttöön ei ole tarvetta.
 
 ```js
 const Notes = ({ notes }) => (
@@ -109,7 +109,7 @@ import { Table } from 'react-bootstrap'
 
 Parannellaan seuraavaksi näkymän <i>Login</i> kirjautumislomaketta Bootstrapin [lomakkeiden](https://getbootstrap.com/docs/4.1/components/forms/) avulla.
 
-React-Bootstrap tarjoaa valmiit [komponentit](https://react-bootstrap.github.io/forms/overview/) myös lomakkeiden muodostamiseen (dokumentaatio tosin ei ole paras mahdollinen):
+React-Bootstrap tarjoaa valmiit [komponentit](https://react-bootstrap.github.io/docs/forms/overview/) myös lomakkeiden muodostamiseen (dokumentaatio tosin ei ole paras mahdollinen):
 
 ```js
 let Login = (props) => {
@@ -180,7 +180,7 @@ const App = () => {
 }
 ```
 
-ja renderöidään viesti Bootstrapin [Alert](https://getbootstrap.com/docs/4.1/components/alerts/)-komponentin avulla. React-Bootstrap tarjoaa tähän jälleen valmiin [React-komponentin](https://react-bootstrap.github.io/components/alerts/):
+ja renderöidään viesti Bootstrapin [Alert](https://getbootstrap.com/docs/4.1/components/alerts/)-komponentin avulla. React-Bootstrap tarjoaa tähän jälleen valmiin [React-komponentin](https://react-bootstrap.github.io/docs/components/alerts/):
 
 ```js
 <div className="container">
@@ -197,7 +197,7 @@ ja renderöidään viesti Bootstrapin [Alert](https://getbootstrap.com/docs/4.1/
 
 #### Navigaatiomenu
 
-Muutetaan vielä lopuksi sovelluksen navigaatiomenu käyttämään Bootstrapin [Navbaria](https://getbootstrap.com/docs/4.1/components/navbar/). Tähänkin React-Bootstrap tarjoaa [valmiit komponentit](https://react-bootstrap.github.io/components/navbar/#navbars-mobile-friendly). Dokumentaatio on hieman kryptistä, mutta trial and error johtaa lopulta toimivaan ratkaisuun:
+Muutetaan vielä lopuksi sovelluksen navigaatiomenu käyttämään Bootstrapin [Navbaria](https://getbootstrap.com/docs/4.1/components/navbar/). Tähänkin React-Bootstrap tarjoaa [valmiit komponentit](https://react-bootstrap.github.io/docs/components/navbar/#responsive-behaviors). Dokumentaatio on hieman kryptistä, mutta trial and error johtaa lopulta toimivaan ratkaisuun:
 
 ```js
 <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">

--- a/src/content/7/zh/part7c.md
+++ b/src/content/7/zh/part7c.md
@@ -78,8 +78,8 @@ const App = () => {
 
 ![](../../images/7/6ea.png)
 
-<!-- Next, let's make some changes to the <i>Notes</i> component, so that it renders the list of notes as a [table](https://getbootstrap.com/docs/4.1/content/tables/). React Bootstrap provides a built-in [Table](https://react-bootstrap.github.io/components/table/) component for this purpose, so there is no need to define CSS classes separately.-->
- 接下来，让我们对<i>Notes</i>组件做一些修改，使其将笔记列表渲染成一个[表格](https://getbootstrap.com/docs/4.1/content/tables/)。React Bootstrap为此提供了一个内置的[Table](https://react-bootstrap.github.io/components/table/)组件，所以不需要再单独定义CSS类。
+<!-- Next, let's make some changes to the <i>Notes</i> component, so that it renders the list of notes as a [table](https://getbootstrap.com/docs/4.1/content/tables/). React Bootstrap provides a built-in [Table](https://react-bootstrap.github.io/docs/components/table/) component for this purpose, so there is no need to define CSS classes separately.-->
+ 接下来，让我们对<i>Notes</i>组件做一些修改，使其将笔记列表渲染成一个[表格](https://getbootstrap.com/docs/4.1/content/tables/)。React Bootstrap为此提供了一个内置的[Table](https://react-bootstrap.github.io/docs/components/table/)组件，所以不需要再单独定义CSS类。
 
 ```js
 const Notes = ({ notes }) => (
@@ -122,8 +122,8 @@ import { Table } from 'react-bootstrap'
 <!-- Let's improve the form in the <i>Login</i> view with the help of Bootstrap [forms](https://getbootstrap.com/docs/4.1/components/forms/).-->
  让我们在Bootstrap[表单](https://getbootstrap.com/docs/4.1/components/forms/)的帮助下改进<i>Login</i>视图中的表单。
 
-<!-- React Bootstrap provides built-in [components](https://react-bootstrap.github.io/forms/overview/) for creating forms (although the documentation for them is slightly lacking):-->
- React Bootstrap为创建表单提供了内置的[组件](https://react-bootstrap.github.io/forms/overview/)(尽管它们的文档略显不足)。
+<!-- React Bootstrap provides built-in [components](https://react-bootstrap.github.io/docs/forms/overview/) for creating forms (although the documentation for them is slightly lacking):-->
+ React Bootstrap为创建表单提供了内置的[组件](https://react-bootstrap.github.io/docs/forms/overview/)(尽管它们的文档略显不足)。
 
 ```js
 let Login = (props) => {
@@ -198,8 +198,8 @@ const App = () => {
 ```
 
 
-<!-- We will render the message as a Bootstrap [Alert](https://getbootstrap.com/docs/4.1/components/alerts/) component. Once again, the React Bootstrap library provides us with a matching [React component](https://react-bootstrap.github.io/components/alerts/):-->
- 我们将把消息渲染成一个Bootstrap [Alert](https://getbootstrap.com/docs/4.1/components/alerts/)组件。再一次，React Bootstrap库为我们提供了一个匹配的[React组件](https://react-bootstrap.github.io/components/alerts/)。
+<!-- We will render the message as a Bootstrap [Alert](https://getbootstrap.com/docs/4.1/components/alerts/) component. Once again, the React Bootstrap library provides us with a matching [React component](https://react-bootstrap.github.io/docs/components/alerts/):-->
+ 我们将把消息渲染成一个Bootstrap [Alert](https://getbootstrap.com/docs/4.1/components/alerts/)组件。再一次，React Bootstrap库为我们提供了一个匹配的[React组件](https://react-bootstrap.github.io/docs/components/alerts/)。
 
 ```js
 <div className="container">
@@ -216,8 +216,8 @@ const App = () => {
 
 #### Navigation structure
 
-<!-- Lastly, let's alter the application's navigation menu to use Bootstrap's [Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) component. The React Bootstrap library provides us with [matching built-in components](https://react-bootstrap.github.io/components/navbar/#navbars-mobile-friendly). Through trial and error, we end up with a working solution in spite of the cryptic documentation:-->
- 最后，让我们改变应用的导航菜单，使用Bootstrap的[Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) 组件。React Bootstrap库为我们提供了[匹配的内置组件](https://react-bootstrap.github.io/components/navbar/#navbars-mobile-friendly)。通过试验和错误，我们最终得到了一个可行的解决方案，尽管文档中的内容很隐晦。
+<!-- Lastly, let's alter the application's navigation menu to use Bootstrap's [Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) component. The React Bootstrap library provides us with [matching built-in components](https://react-bootstrap.github.io/docs/components/navbar/#responsive-behaviors). Through trial and error, we end up with a working solution in spite of the cryptic documentation:-->
+ 最后，让我们改变应用的导航菜单，使用Bootstrap的[Navbar](https://getbootstrap.com/docs/4.1/components/navbar/) 组件。React Bootstrap库为我们提供了[匹配的内置组件](https://react-bootstrap.github.io/docs/components/navbar/#responsive-behaviors)。通过试验和错误，我们最终得到了一个可行的解决方案，尽管文档中的内容很隐晦。
 
 ```js
 <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">


### PR DESCRIPTION
Similar to:
- #3353
- #3354 
- #3355 

except here we added the docs folder to the path as well as change the navbar-mobile-friendly anchor to "responsive-behaviors", since the navbar mobile friendly is no longer an anchor in the bootstrap docs.