### PR TITLE
Fix typos

### DIFF
--- a/src/content/3/fi/osa3a.md
+++ b/src/content/3/fi/osa3a.md
@@ -284,11 +284,11 @@ let notes = [
   ...
 ]
 
-app.get('/', (req, res) => {
+app.get('/', (request, response) => {
   res.send('<h1>Hello World!</h1>')
 })
 
-app.get('/api/notes', (req, res) => {
+app.get('/api/notes', (request, response) => {
   res.json(notes)
 })
 

--- a/src/content/3/fi/osa3b.md
+++ b/src/content/3/fi/osa3b.md
@@ -367,7 +367,7 @@ Renderin tapauksessa skriptit näyttävät seuraavalta:
 
 Skripteistä _npm run build:ui_ kääntää ui:n tuotantoversioksi ja kopioi sen.
 
-_npm run deploy:full_ sisältää edellisen lisää vaadittavat <i>git</i>-komennot versionhallinnan päivittämistä varten.
+_npm run deploy:full_ sisältää edellisen lisäksi vaadittavat <i>git</i>-komennot versionhallinnan päivittämistä varten.
 
 Huomaa, että skriptissä <i>build:ui</i> olevat polut riippuvat repositorioiden sijainnista.
 

--- a/src/content/3/fi/osa3c.md
+++ b/src/content/3/fi/osa3c.md
@@ -359,7 +359,7 @@ const mongoose = require('mongoose')
 
 // ÄLÄ KOSKAAN TALLETA SALASANOJA GitHubiin!
 const url =
-  `mongodb+srv://fullstack:${fullstack@cluster0.o1opl.mongodb.net/?retryWrites=true&w=majority`
+  `mongodb+srv://fullstack:${password}@cluster0.o1opl.mongodb.net/?retryWrites=true&w=majority`
 
 mongoose.set('strictQuery',false)
 mongoose.connect(url)


### PR DESCRIPTION
`(req, res)` -> `(request, response)`, this was used in rest of the text
edellisen lisää -> edellisen lisäksi
`mongodb+srv://fullstack:${fullstack@cluster0.o1opl.mongodb.net/?retryWrites=true&w=majority`
-> `mongodb+srv://fullstack:${password}@cluster0.o1opl.mongodb.net/?retryWrites=true&w=majority`, this was used earlier in the text