### PR TITLE
Fix Markdown parser issue

### DIFF
--- a/src/content/0/fi/osa0b.md
+++ b/src/content/0/fi/osa0b.md
@@ -506,7 +506,7 @@ Avaa nyt <i>Network</i>-välilehti ja tyhjennä se &#x29B8;-symbolilla. Kun luot
 
 ![](../../images/0/26e.png)
 
-Pyyntö kohdistuu osoitteeseen <i>new_note_spa</i>, on tyypiltään POST ja se sisältää JSON-muodossa olevan uuden muistiinpanon, johon kuuluu sekä sisältö (<i>content</i>) että aikaleima (<i>date</i>):
+Pyyntö kohdistuu osoitteeseen <i>new\_note\_spa</i>, on tyypiltään POST ja se sisältää JSON-muodossa olevan uuden muistiinpanon, johon kuuluu sekä sisältö (<i>content</i>) että aikaleima (<i>date</i>):
 
 ```js
 {

--- a/src/content/0/ptbr/part0b.md
+++ b/src/content/0/ptbr/part0b.md
@@ -511,7 +511,7 @@ Abra a guia <i>Rede (Network)</i> e esvazie-a. Quando você criar uma nova nota,
 
 ![Guia Rede nas Ferramentas do Desenvolvedor](../../images/0/26e.png)
 
-A requisição POST para o endereço <i>new_note_spa</i> contém a nova nota como dados JSON, contendo tanto o conteúdo da nota (<i>content</i>) quanto o timestamp (<i>date</i>):
+A requisição POST para o endereço <i>new\_note\_spa</i> contém a nova nota como dados JSON, contendo tanto o conteúdo da nota (<i>content</i>) quanto o timestamp (<i>date</i>):
 
 ```js
 {


### PR DESCRIPTION
For Finnish and Portuguese translations Markdown parser changed underscores in the middle of the word `new_note_spa` to `<em>` HTML elements.
Other languages are already fixed.

<img width="807" alt="Screenshot 2024-01-04 at 10 38 33" src="https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/867808/a881efec-befb-4ef2-a880-daa8b95dfd9a">
