### PR TITLE
Use response.json instead of response.send when handling id CastError

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -719,7 +719,7 @@ app.get('/api/notes/:id', (request, response) => {
     })
     .catch(error => {
       console.log(error)
-      response.status(400).send({ error: 'malformatted id' }) // highlight-line
+      response.status(400).json({ error: 'malformatted id' }) // highlight-line
     })
 })
 ```
@@ -737,7 +737,7 @@ It's never a bad idea to print the object that caused the exception to the conso
 ```js
 .catch(error => {
   console.log(error)  // highlight-line
-  response.status(400).send({ error: 'malformatted id' })
+  response.status(400).json({ error: 'malformatted id' })
 })
 ```
 


### PR DESCRIPTION
Otherwise Node.js complains that the send method is receiving an object instead of a string as argument.