### PR TITLE
Update part5b.md

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -781,7 +781,7 @@ Now the directories <em>dist</em> and <em>node_modules</em> will be skipped when
 As usual, you can perform the linting either from the command line with the command
 
 ```bash
-npm run Lint
+npm run lint
 ```
 
 or using the editor's Eslint plugin.


### PR DESCRIPTION
On the ESlint part, the command to start the linting from the command line should be `npm run lint` instead of `npm run Lint` because in the package.json scripts it's defined "lint"