### PR TITLE
Update part7a.md - clarifying text which introduces a new example

### DIFF
--- a/src/content/7/en/part7a.md
+++ b/src/content/7/en/part7a.md
@@ -190,7 +190,7 @@ The Routes works by rendering the first component whose <i>path</i> matches the 
 
 ### Parameterized route
 
-Let's examine the slightly modified version from the previous example. The complete code for the example can be found [here](https://github.com/fullstack-hy2020/misc/blob/master/router-app-v1.js).
+Let's examine a slightly modified version from the previous example. The complete code for the updated example can be found [here](https://github.com/fullstack-hy2020/misc/blob/master/router-app-v1.js).
 
 The application now contains five different views whose display is controlled by the router. In addition to the components from the previous example (<i>Home</i>, <i>Notes</i> and <i>Users</i>), we have <i>Login</i> representing the login view and <i>Note</i> representing the view of a single note.
 


### PR DESCRIPTION
Replacing the article "the", which implies an already existing example, with "a", to indicate the text is introducing a new version of the code which has not been shown previously. Emphasizing that the code being referenced is new by adding the modifier "updated".