### PR TITLE
Fixed broken SCSS layout

### DIFF
--- a/src/content/3/fr/part3c.md
+++ b/src/content/3/fr/part3c.md
@@ -286,7 +286,7 @@ Note.find({ important: true }).then(result => {
 
 </div>
 
-<div class="tâches">
+<div class="tasks">
 
 ### Exercice 3.12.
 


### PR DESCRIPTION
### Fix for Broken SCSS Layout for the French part

**Problem:**
The layout was completely broken on the 3.12 exercises due to an incorrect SCSS class

**Solution:**
This PR fixes the issue by correcting the SCSS class responsible for the layout. The changes ensure that the layout now aligns correctly and the exercise fits within the page as expected

**Test:**
To verify the fix, navigate to the 3.12 exercises page on the french translation and confirm that the layout appears as expected