### PR TITLE
Notes "user" field changed to "userId"

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -457,7 +457,7 @@ const noteSchema = new mongoose.Schema({
   },
   important: Boolean,
   // highlight-start
-  user: {
+  userId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User'
   }


### PR DESCRIPTION
I was getting an error when I was creating new notes referencing the user id and tracked it down to the note schema not referencing the id properly, changing the "user" field to "userId" fixed it.