### PR TITLE
part 3b - `fly open` to `fly apps open`

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -174,7 +174,7 @@ fly deploy
 If all goes well, the app should now be up and running. You can open it in the browser with the command
 
 ```bash
-fly open
+fly apps open
 ```
 
 A particularly important command is _fly logs_. This command can be used to view server logs. It is best to keep logs always visible!

--- a/src/content/3/fi/osa3b.md
+++ b/src/content/3/fi/osa3b.md
@@ -142,7 +142,7 @@ fly deploy
 Jos kaikki menee hyvin, sovellus käynnistyy ja saat sen avattua selaimeen komennolla 
 
 ```bash
-fly open
+fly apps open
 ```
 
 Tämän jälkeen aina kun teet muutoksia sovellukseen, saat vietyä uuden version tuotantoon komennolla 

--- a/src/content/3/ptbr/part3b.md
+++ b/src/content/3/ptbr/part3b.md
@@ -173,7 +173,7 @@ fly deploy
 Se tudo correr bem, a aplicação deverá estar em funcionamento. Você pode abri-la no navegador com o comando
 
 ```bash
-fly open
+fly apps open
 ```
 
 Depois da configuração inicial, quando o código da aplicação for atualizado, poderá ser implantada na produção com o comando:


### PR DESCRIPTION
When `fly open` is run fly gives the following response:

```
Command "open" is deprecated, use `fly apps open` instead
```