### PR TITLE
Replaced in code example deprecated remove() by deleteOne()

### DIFF
--- a/src/content/4/es/part4b.md
+++ b/src/content/4/es/part4b.md
@@ -563,7 +563,7 @@ const initialNotes = [
 const nonExistingId = async () => {
   const note = new Note({ content: 'willremovethissoon', date: new Date() })
   await note.save()
-  await note.remove()
+  await note.deleteOne()
 
   return note._id.toString()
 }

--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -556,7 +556,7 @@ const initialNotes = [
 const nonExistingId = async () => {
   const note = new Note({ content: 'willremovethissoon' })
   await note.save()
-  await note.remove()
+  await note.deleteOne()
 
   return note._id.toString()
 }

--- a/src/content/4/ptbr/part4b.md
+++ b/src/content/4/ptbr/part4b.md
@@ -580,7 +580,7 @@ const initialNotes = [
 const nonExistingId = async () => {
   const note = new Note({ content: 'willremovethissoon' })
   await note.save()
-  await note.remove()
+  await note.deleteOne()
 
   return note._id.toString()
 }

--- a/src/content/4/zh/part4b.md
+++ b/src/content/4/zh/part4b.md
@@ -654,7 +654,7 @@ const initialNotes = [
 const nonExistingId = async () => {
   const note = new Note({ content: 'willremovethissoon', date: new Date() })
   await note.save()
-  await note.remove()
+  await note.deleteOne()
 
   return note._id.toString()
 }


### PR DESCRIPTION
Some translations already have this change in place. This commit extends the change to cover all the translations.