### PR TITLE
Update osa4c.md

### DIFF
--- a/src/content/4/fi/osa4c.md
+++ b/src/content/4/fi/osa4c.md
@@ -380,16 +380,6 @@ userSchema.plugin(uniqueValidator) // highlight-line
 // ...
 ```
 
-Huom: asentaessasi kirjastoa _mongoose-unique-validator_ saatat törmätä seuraavaan virheilmoitukseen:
-
-![](../../images/4/uniq.png)
-
-Syynä tälle on se, että kirjasto ei ole kirjoitushetkellä (10.11.2023) vielä yhteensopiva Mongoosen version 8 kanssa. Jos törmäät virheeseen, voit ottaa käyttöösi Mongoosen vanhemman version suorittamalla komennon
-
-```
-npm install mongoose@7.6.5
-```
-
 Voisimme toteuttaa käyttäjien luomisen yhteyteen myös muita tarkistuksia, esim. onko käyttäjätunnus tarpeeksi pitkä, koostuuko se sallituista merkeistä ja onko salasana tarpeeksi hyvä. Jätämme ne kuitenkin vapaaehtoiseksi harjoitustehtäväksi.
 
 Ennen kuin menemme eteenpäin, lisätään sovellukseen alustava versio kaikki käyttäjät palauttavasta käsittelijäfunktiosta:


### PR DESCRIPTION
Poistin ohjeet koskien mongoose-unique-validator kirjaston asennuksessa tapahtuvaa virheilmoitusta, joka on vanhentunut. Nykyään (07.02.2024) vaadittu mongoose versio m-u-v kirjaston asentamiseen  on mongoose@^8.0.0, joten ohjeet vanhemman version asentamisesta voivat aiheuttaa sekaannuksia ja päänvaivaa. Kirjaston asennuksen pitäisi siis onnistua, kunhan mongoose on asennettu oletusasetuksilla (uusin versio tällä hetkellä 8.1.1).