### PR TITLE
Update part2b.md

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -235,7 +235,7 @@ const addNote = (event) => {
   const noteObject = {
     content: newNote,
     important: Math.random() < 0.5,
-    id: notes.length + 1,
+    id: "${notes.length + 1}"
   }
 
   setNotes(notes.concat(noteObject))


### PR DESCRIPTION
I experienced a bug which might be hard to track down for a novice.  Console.log message is "'Uncaught (in promise)' + promise obj". It seems to originate from json-server behavior. Somehow hardcoded data ids get converted to strings, while newly added do not. It happens when I try to toggle importance on added notes. I think I was following the instructions precisely, but here is the code just in case [](https://github.com/Margulis162/fullstack_exercises-/tree/main/part2)
  "dependencies": 
    "axios": "^1.6.7",
    "react": "^18.2.0",
    "react-dom": "^18.2.0"
 
  "devDependencies": 
    "@types/react": "^18.2.43",
    "@types/react-dom": "^18.2.17",
    "@vitejs/plugin-react": "^4.2.1",
    "eslint": "^8.55.0",
    "eslint-plugin-react": "^7.33.2",
    "eslint-plugin-react-hooks": "^4.6.0",
    "eslint-plugin-react-refresh": "^0.4.5",
    "json-server": "^1.0.0-alpha.23",
    "vite": "^5.0.8"
![json-server](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/134349936/a95f9aaf-9ef0-472f-878f-ecd02191cc51)

