### PR TITLE
Add object comparision method 'deepStrictEqual' in node test module o…

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -748,6 +748,8 @@ The value returned by the function could be in the following format:
 }
 ```
 
+**NB** when you are comparing objects, the [deepStrictEqual](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) method is probably what you want to use, since the [strictEqual](https://nodejs.org/api/assert.html#assertstrictequalactual-expected-message) tries to verify that the two values are the same value, and not just that they contain the same properties. For differences between various assert module functions, you can refer to [this Stack Overflow answer](https://stackoverflow.com/a/73937068/15291501).
+
 Write the tests for this exercise inside of a new <i>describe</i> block. Do the same for the remaining exercises as well.
 
 #### 4.6*: Helper Functions and Unit Tests, step 4


### PR DESCRIPTION
## Updated part 4.5 exercise description

Currently used method `strictEqual` does not work for object comparison when asserting using node test. 

`deepStrictEqual` is to be used for object comparisons.

Thus updated the section 4.5 with note describing the use-case of both these methods and attached stack overflow answer comparing various assert module function.