### PR TITLE
Update deprecated --only

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -205,7 +205,7 @@ RUN npm ci # highlight-line
 CMD DEBUG=playground:* npm start
 ```
 
-Even better, we can use _npm ci --only=production_ to not waste time installing development dependencies.
+Even better, we can use _npm ci --omit=dev_ to not waste time installing development dependencies.
 
 > As you noticed in the comparison list; npm ci will delete the node_modules folder so creating the .dockerignore did not matter. However, .dockerignore is an amazing tool when you want to optimize your build process. We will talk briefly about these optimizations later.
 


### PR DESCRIPTION
The --only is a deprecated option and now replaced with the --omit counterpart. 
This causes a warning when running and there is no more references to --only option in npm ci [manual. ](https://docs.npmjs.com/cli/v10/commands/npm-ci#omit)
