### PR TITLE
Update part4b.md - move after inside `describe`

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -124,22 +124,23 @@ npm install --save-dev supertest
 Let's write our first test in the <i>tests/note_api.test.js</i> file:
 
 ```js
-const { test, after } = require('node:test')
+const {describe, test, after } = require('node:test')
 const mongoose = require('mongoose')
 const supertest = require('supertest')
 const app = require('../app')
 
 const api = supertest(app)
 
-test('notes are returned as json', async () => {
-  await api
-    .get('/api/notes')
-    .expect(200)
-    .expect('Content-Type', /application\/json/)
-})
-
-after(async () => {
-  await mongoose.connection.close()
+describe('notes API testing', () => {
+    test('notes are returned as json', async () => {
+      await api
+        .get('/api/notes')
+        .expect(200)
+        .expect('Content-Type', /application\/json/)
+    })
+    after(async () => {
+      await mongoose.connection.close()
+    })  
 })
 ```
 


### PR DESCRIPTION
`after` hook runs correctly only inside a test suite. Using it as standalone outside the suite i.e outside the `describe` block causes the test to hang indefinitely .