### PR TITLE
Update part4c.md - remove mongoose-unique-validator

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -348,7 +348,6 @@ Mongoose validations do not provide a direct way to check the uniqueness of a fi
 
 ```js
 const mongoose = require('mongoose')
-const uniqueValidator = require('mongoose-unique-validator') // highlight-line
 
 const userSchema = mongoose.Schema({
   // highlight-start


### PR DESCRIPTION
Removed const uniqueValidator = require('mongoose-unique-validator') from the code example snippet as it doesn't add or change anything to the code. 

If this is supposed to be used then it should be stated to npm install and as per mongoose-unique-validator documents the code would also need to use userSchema.plugin(uniqueValidator);