### PR TITLE
Updated `npm start` to `npm run dev` in part2a, all languages

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -460,7 +460,7 @@ Note that the <i>main</i> branch of the repository contains the code for a later
 
 ![GitHub branch screenshot](../../images/2/2e.png)
 
-If you clone the project, run the command _npm install_ before starting the application with _npm start_.
+If you clone the project, run the command _npm install_ before starting the application with _npm run dev_.
 
 ### When the Application Breaks
 

--- a/src/content/2/es/part2a.md
+++ b/src/content/2/es/part2a.md
@@ -460,7 +460,7 @@ Ten en cuenta que la rama _main_ del repositorio contiene el código de una vers
 
 ![Captura de pantalla de la rama de GitHub](../../images/2/2e.png)
 
-Si clonas el proyecto, ejecuta el comando _npm install_ antes de iniciar la aplicación con _npm start_.
+Si clonas el proyecto, ejecuta el comando _npm install_ antes de iniciar la aplicación con _npm run dev_.
 
 ### Cuando la aplicación se rompe
 

--- a/src/content/2/fr/part2a.md
+++ b/src/content/2/fr/part2a.md
@@ -469,7 +469,7 @@ Notez que la branche <i>main</i> du référentiel contient le code d'une version
 
 ![](../../images/2/2e.png)
 
-Si vous clonez le projet, exécutez la commande _npm install_ avant de démarrer l'application avec _npm start_.
+Si vous clonez le projet, exécutez la commande _npm install_ avant de démarrer l'application avec _npm run dev_.
 
 ### Lorsque l'application crashe
 

--- a/src/content/2/ptbr/part2a.md
+++ b/src/content/2/ptbr/part2a.md
@@ -464,7 +464,7 @@ Note que a branch <i>main</i> do repositório contém o código para uma versão
 
 ![captura de tela da branch do GitHub](../../images/2/2e.png)
 
-Caso deseje clonar o projeto, execute o comando _npm install_ antes de iniciar a aplicação com _npm start_.
+Caso deseje clonar o projeto, execute o comando _npm install_ antes de iniciar a aplicação com _npm run dev_.
 
 ### Quando a Aplicação Quebra
 

--- a/src/content/2/zh/part2a.md
+++ b/src/content/2/zh/part2a.md
@@ -551,8 +551,8 @@ const App = ({ notes }) => {
 
 ![](../../images/2/2e.png)
 
-<!-- If you clone the project, run the command _npm install_ before starting the application with _npm start_.-->
- 如果你克隆了这个项目，在用_npm start_启动应用之前，运行_npm install_命令。
+<!-- If you clone the project, run the command _npm install_ before starting the application with _npm run dev_.-->
+ 如果你克隆了这个项目，在用_npm run dev_启动应用之前，运行_npm install_命令。
 
 ### When the Application Breaks
 


### PR DESCRIPTION
Changed `npm start` command to `npm run dev` to reflect the change to using Vite.

The context of this command is in reference to this repo: https://github.com/fullstack-hy2020/part2-notes-frontend/tree/part2-1, which you can see from the `package.json` that it's now `npm run dev`

I noticed it in the English translation, and then applied it to all other translations, although it was already done for Finnish.