### PR TITLE
Update part4d.md

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -199,7 +199,7 @@ notesRouter.post('/', async (request, response) => {
   const note = new Note({
     content: body.content,
     important: body.important === undefined ? false : body.important,
-    user: user._id
+    user: user.id
   })
 
   const savedNote = await note.save()


### PR DESCRIPTION
User ids are referred through user.id and not through user._id since we've deleted _id through the transform option in the note model