### PR TITLE
Update Chinese translation of part2c.md

### DIFF
--- a/src/content/2/zh/part2c.md
+++ b/src/content/2/zh/part2c.md
@@ -442,10 +442,10 @@ axios.get('http://localhost:3001/notes').then(response => {
 <!-- We have already used [state hooks](https://reactjs.org/docs/hooks-state.html) that were introduced along with React version [16.8.0](https://www.npmjs.com/package/react/v/16.8.0), which provide state to React components defined as functions - the so-called <i>functional components</i>. Version 16.8.0 also introduces [effect hooks](https://reactjs.org/docs/hooks-effect.html) as a new feature. As per the official docs:-->
  我们已经使用了与React版本[16.8.0](https://www.npmjs.com/package/react/v/16.8.0)一起引入的[状态钩子](https://reactjs.org/docs/hooks-state.html)，它为定义为函数的React组件--所谓的<i>功能组件</i>提供状态。16.8.0版本还引入了[效果钩子](https://reactjs.org/docs/hooks-effect.html)这个新功能。按照官方文档的说法。
 
-<!-- > <i>The Effect Hook lets you perform side effects on function components.</i>-->
- > <i>效果钩可以让你对函数组件执行副作用。</i>。
-<!-- > <i>Data fetching, setting up a subscription, and manually changing the DOM in React components are all examples of side effects.</i>-->
- > <i>获取数据、设置订阅、以及手动改变React组件中的DOM都是副作用的例子。</i>
+<!-- > <i>Effects let a component connect to and synchronize with external systems.</i>-->
+ > <i>Effect 允许组件连接到外部系统并与之同步。</i>
+<!-- > <i>This includes dealing with network, browser DOM, animations, widgets written using a different UI library, and other non-React code.</i>-->
+ > <i>这包括处理网络、浏览器、DOM、动画、使用不同 UI 库编写的小部件以及其他非 React 代码。</i>
 
 <!-- As such, effect hooks are precisely the right tool to use when fetching data from a server.-->
  因此，当从服务器获取数据时，效果钩子正是正确的工具。

--- a/src/content/2/zh/part2c.md
+++ b/src/content/2/zh/part2c.md
@@ -440,7 +440,7 @@ axios.get('http://localhost:3001/notes').then(response => {
 ### Effect-hooks
 
 <!-- We have already used [state hooks](https://reactjs.org/docs/hooks-state.html) that were introduced along with React version [16.8.0](https://www.npmjs.com/package/react/v/16.8.0), which provide state to React components defined as functions - the so-called <i>functional components</i>. Version 16.8.0 also introduces [effect hooks](https://reactjs.org/docs/hooks-effect.html) as a new feature. As per the official docs:-->
- 我们已经使用了与React版本[16.8.0](https://www.npmjs.com/package/react/v/16.8.0)一起引入的[状态钩子](https://reactjs.org/docs/hooks-state.html)，它为定义为函数的React组件--所谓的<i>功能组件</i>提供状态。16.8.0版本还引入了[效果钩子](https://reactjs.org/docs/hooks-effect.html)这个新功能。按照官方文档的说法。
+ 我们已经使用了与React版本[16.8.0](https://www.npmjs.com/package/react/v/16.8.0)一起引入的[状态钩子](https://zh-hans.react.dev/reference/react/hooks#state-hooks)，它为定义为函数的React组件--所谓的<i>功能组件</i>提供状态。16.8.0版本还引入了[效果钩子](https://zh-hans.react.dev/reference/react/hooks#effect-hooks)这个新功能。按照官方文档的说法。
 
 <!-- > <i>Effects let a component connect to and synchronize with external systems.</i>-->
  > <i>Effect 允许组件连接到外部系统并与之同步。</i>
@@ -565,8 +565,8 @@ const hook = () => {
 useEffect(hook, [])
 ```
 
-<!-- Now we can see more clearly that the function [useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect) actually takes <i>two parameters</i>. The first is a function, the <i>effect</i> itself. According to the documentation:-->
- 现在我们可以更清楚地看到，函数[useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect)实际上需要<i>两个参数</i>。第一个是一个函数，即<i>effect</i>本身。根据文档的内容。
+<!-- Now we can see more clearly that the function [useEffect](https://react.dev/reference/react/useEffect) actually takes <i>two parameters</i>. The first is a function, the <i>effect</i> itself. According to the documentation:-->
+ 现在我们可以更清楚地看到，函数[useEffect](https://zh-hans.react.dev/reference/react/useEffect)实际上需要<i>两个参数</i>。第一个是一个函数，即<i>effect</i>本身。根据文档的内容。
 
 <!-- > <i>By default, effects run after every completed render, but you can choose to fire it only when certain values have changed.</i>-->
  > <i>默认情况下，效果会在每次完成渲染后运行，但你可以选择只在某些值发生变化时启动它。</i>
@@ -575,7 +575,7 @@ useEffect(hook, [])
  所以默认情况下，效果是<i>总是</i>在组件被渲染后运行。然而，在我们的例子中，我们只想在第一次渲染时执行效果。
 
 <!-- The second parameter of <em>useEffect</em> is used to [specify how often the effect is run](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect). If the second parameter is an empty array <em>[]</em>, then the effect is only run along with the first render of the component.-->
- <em>useEffect</em>的第二个参数用于[指定效果的运行频率](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)。如果第二个参数是一个空的数组<em>[]</em>，那么效果就只在组件的第一次渲染时运行。
+ <em>useEffect</em>的第二个参数用于[指定效果的运行频率](https://zh-hans.react.dev/reference/react/useEffect#parameters)。如果第二个参数是一个空的数组<em>[]</em>，那么效果就只在组件的第一次渲染时运行。
 
 <!-- There are many possible use cases for an effect hook other than fetching data from the server. However, this use is sufficient for us, for now.-->
  除了从服务器上获取数据之外，效果钩子还有许多可能的使用情况。然而，目前这个用途对我们来说已经足够了。
@@ -695,8 +695,8 @@ Error: listen EADDRINUSE 0.0.0.0:3001
 <!-- it means that port 3001 is already in use by another application, e.g. in use by an already running json-server. Close the other application, or change the port in case that doesn't work.-->
  这意味着3001端口已经被另一个应用使用，例如，被一个已经运行的json-server使用。关闭另一个应用，或者改变端口，如果这不起作用的话。
 
-<!-- Modify the application such that the initial state of the data is fetched from the server using the <i>axios</i>-library. Complete the fetching with an [Effect hook](https://reactjs.org/docs/hooks-effect.html). -->
- 修改应用，使数据的初始状态是使用<i>axios</i>-library从服务器获取的。用一个[效果钩子](https://reactjs.org/docs/hooks-effect.html)来完成获取。
+<!-- Modify the application such that the initial state of the data is fetched from the server using the <i>axios</i>-library. Complete the fetching with an [Effect hook](https://react.dev/reference/react/hooks#effect-hooks). -->
+ 修改应用，使数据的初始状态是使用<i>axios</i>-library从服务器获取的。用一个[效果钩子](https://zh-hans.react.dev/reference/react/hooks#effect-hooks)来完成获取。
 
 <h4>2.12* Data for countries, step1</h4>
 


### PR DESCRIPTION
The expression about Effect books in the previous reference was unclear, so I searched for the [latest description](https://react.dev/reference/react/hooks#effect-hooks) from the official document and updated it. Also, the original document has two periods here. It can also be seen that the [English version of the document](https://github.com/Dilettante258/fullstackopen/blob/source/src/content/2/en/part2c.md#effect-hooks) has already been updated, while the Chinese version has not followed up.

之前的引用的关于Effect-hooks的表达不清楚，所以从 [官方文档](https://zh-hans.react.dev/reference/react/hooks#effect-hooks) 那里查询了最新的描述并更新。另，原来的文档在这里有两个句号。同时也可以看到，[英文版的文档](https://github.com/Dilettante258/fullstackopen/blob/source/src/content/2/en/part2c.md#effect-hooks)早就已经更新了，而中文版没有跟进。

