### PR TITLE
Update part12c.md

### DIFF
--- a/src/content/12/en/part12c.md
+++ b/src/content/12/en/part12c.md
@@ -235,6 +235,8 @@ You can now view hello-frontend in the browser.
 
 > <i>**Editor's note:** hot reload might work in your computer, but it is currently known to have some [issues](https://github.com/facebook/create-react-app/issues/11879). So if it does not work for you, just continue without the hot reload support, and reload the browser when you change the frontend code. You may also use use [The Visual Studio Code Containers extension](https://code.visualstudio.com/docs/remote/containers).</i>
 
+If changes made to the mounted files are not visible even after manually reloading the app in the browser, you might be able to fix this with [Watchpack API](https://github.com/webpack/watchpack) by enabling Watchpack Polling with environment variable "WATCHPACK_POLLING=true" either directly in the React project, or on the docker-compose file.
+
 Next, let's move the config to a <i>docker-compose.yml</i>. That file should be at the root of the project as well:
 
 ```yml


### PR DESCRIPTION
In the material, it is stated that hot reload might not work when running a React development server inside a docker container and making changes to bind mounted files on host machine. At least *on my computer*, even manually reloading the app on the browser did not make the changes visible. Apparently there is an issue related to the WSL2. https://github.com/microsoft/WSL/issues/6255#issuecomment-730701001

However the problem can be solved, at least *on my computer*, by adding environment-variable "WATCHPACK_POLLING=true" on the docker-compose.yml. After adding this to the compose-configuration, even hot reload started to work as expected.

This information should be added to the material so that each student does not have to spend hours figuring it out individually.