### PR TITLE
Update part12c.md

### DIFF
--- a/src/content/12/en/part12c.md
+++ b/src/content/12/en/part12c.md
@@ -659,7 +659,7 @@ services:
   nginx:
     image: nginx:1.20.1
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.dev.conf:/etc/nginx/nginx.conf:ro
     ports:
       - 8080:80 # this is needed
     container_name: reverse-proxy


### PR DESCRIPTION
The filename doesn't match the naming stated prior in the same section. This causes unnecessary confusion, since the same filename is used in exercise 12.20 in the production environment.