### PR TITLE
Correct highlight spelling in md syntex for playright part in en and fi

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -1146,7 +1146,7 @@ const createNote = async (page, content) => {
   await page.getByRole('button', { name: 'new note' }).click()
   await page.getByRole('textbox').fill(content)
   await page.getByRole('button', { name: 'save' }).click()
-  await page.getByText(content).waitFor() // hightlight-line
+  await page.getByText(content).waitFor() // highlight-line
 }
 ```
 

--- a/src/content/5/fi/osa5d.md
+++ b/src/content/5/fi/osa5d.md
@@ -1138,7 +1138,7 @@ const createNote = async (page, content) => {
   await page.getByRole('button', { name: 'new note' }).click()
   await page.getByRole('textbox').fill(content)
   await page.getByRole('button', { name: 'save' }).click()
-  await page.getByText(content).waitFor() // hightlight-line
+  await page.getByText(content).waitFor() // highlight-line
 }
 ```
 


### PR DESCRIPTION
Correct a misspelling of highlight-line (previously hightlight-line) in en and fi content directories, which are the only ones containing the playright testing section.