### PR TITLE
Update part11b.md

### DIFF
--- a/src/content/11/en/part11b.md
+++ b/src/content/11/en/part11b.md
@@ -359,7 +359,6 @@ Once the end to end test works in your machine, include it in the GitHub Action 
 - name: e2e tests
   uses: cypress-io/github-action@v5
   with:
-    command: npm run test:e2e
     start: npm run start-prod
     wait-on: http://localhost:5000
 ```


### PR DESCRIPTION
Remove 'command: npm run test:e2e' from the last exercise workflow. This command causes the workflow to stall because it starts Cypress in interactive mode, requiring manual interaction.