### PR TITLE
Update osa2e.md

### DIFF
--- a/src/content/2/fi/osa2e.md
+++ b/src/content/2/fi/osa2e.md
@@ -621,7 +621,7 @@ const api_key = import.meta.env.VITE_SOME_KEY
 // muuttujassa api_key on nyt käynnistyksessä annettu API-avaimen arvo
 ```
 
-Huomaa, että ympäristömuuttujan nimen täytyy alkaa merkkijonolla _VITE\__.
+Huomaa, että ympäristömuuttujan nimen täytyy alkaa merkkijonolla <i>VITE_</i>.
 
 Tämä oli osan viimeinen tehtävä ja on aika sekä puskea koodi GitHubiin että merkitä tehdyt tehtävät [palautussovellukseen](https://studies.cs.helsinki.fi/stats/courses/fullstackopen).
 


### PR DESCRIPTION
VITE_ merkkijono renderöityy kurssimateriaalissa väärin.

<img width="757" alt="vite-issue" src="https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/525676/cd792c51-5e6c-4957-8fb1-84fc41d36fee">
