### PR TITLE
part12b: Remove broken hyperlink on content

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -763,7 +763,7 @@ Ensure that you see the new todo both in the Express app and when querying from 
 
 By default, Redis works <i>in-memory</i>, which means that it does not store data persistently. 
 
-An excellent use case for Redis is to use it as a [cache](![alt text](image.png)). Caches are often used to store data that is otherwise slow to fetch and save the data until it's no longer valid. After the cache becomes invalid, you would then fetch the data again and store it in the cache.
+An excellent use case for Redis is to use it as a cache. Caches are often used to store data that is otherwise slow to fetch and save the data until it's no longer valid. After the cache becomes invalid, you would then fetch the data again and store it in the cache.
 
 Redis has nothing to do with containers. But since we are already able to add <i>any</i> 3rd party service to your applications, why not learn about a new one?
 


### PR DESCRIPTION
On the Redis subpart the word cache has an hyperlink to an image, when one clicks the link you get error 404. Inspecting the repository more carefully, I noticed there isn't such a file on `/src/content/12/en/` nor on `/src/images/`, therefore I proceeded to remove that broken link.

![link](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/89616355/db0cdb18-07cc-427b-84b3-bbfa66c9cfc5)
![error](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/89616355/a520ed21-00b9-4634-98b3-77bd6e28c217)