### PR TITLE
Add import for 'assert'

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -605,6 +605,7 @@ Let output from the npm test with _average_ function, into a new file <i>tests/a
 
 ```js
 const { test, describe } = require('node:test')
+const assert = require("node:assert");
 
 // ...
 


### PR DESCRIPTION
The code example for grouping tests with `describe` uses `node:assert`, but the line to import it is missing. Without it, there is an error when running the test.