### PR TITLE
fix(test): `.forEach` expects a synchronous function

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -913,11 +913,12 @@ beforeEach(async () => {
   await Note.deleteMany({})
   console.log('cleared')
 
-  helper.initialNotes.forEach(async (note) => {
+  for (const note of helper.initialNotes) {
     let noteObject = new Note(note)
     await noteObject.save()
     console.log('saved')
-  })
+  }
+
   console.log('done')
 })
 


### PR DESCRIPTION
Some tests related to database operation over API could fail erratically. In my case, `a specific note can be viewed` test failed. This happened because `.forEach` expects a synchronous function. 

Reference: https://betterprogramming.pub/javascript-async-await-pitfalls-with-foreach-d55dddc42d0