### PR TITLE
Update link to Mozilla JavaScript Overview on part1b.md

### DIFF
--- a/src/content/1/en/part1b.md
+++ b/src/content/1/en/part1b.md
@@ -524,7 +524,7 @@ The ES6 class syntax is used a lot in "old" React and also in Node.js, hence an 
 
 There exist both good and poor guides for JavaScript on the Internet. Most of the links on this page relating to JavaScript features reference [Mozilla's JavaScript Guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript).
 
-It is highly recommended to immediately read [A re-introduction to JavaScript (JS tutorial)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript) on Mozilla's website.
+It is highly recommended to immediately read [JavaScript language overview](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Language_overview) on Mozilla's website.
 
 If you wish to get to know JavaScript deeply there is a great free book series on the Internet called [You-Dont-Know-JS](https://github.com/getify/You-Dont-Know-JS).
 


### PR DESCRIPTION
old link redirects to this page that contains the same content with a different title and url