### PR TITLE
Part5d: Fix description in exercise 5.20 with Playwright E2E

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -1299,7 +1299,7 @@ The test should ensure that the created blog is visible in the list of blogs.
 
 #### 5.20: Blog List End To End Testing, step 4
 
-Do a test that makes sure the blog can be edited.
+Do a test that makes sure that users can like a blog.
 
 #### 5.21: Blog List End To End Testing, step 5
 


### PR DESCRIPTION
I think that the description in exercise 5.20 with Playwright E2E is currently wrong.

The description tells us to make a sure a blog can be edited, although this functionality was not required in previous exercises. In addition, the description for the corresponding exercise in the Cypress E2E chapter tells us to ensure users can **like** a blog.