### PR TITLE
Scopes example usage jamiUsers add 'await' statement

### DIFF
--- a/src/content/13/en/part13c.md
+++ b/src/content/13/en/part13c.md
@@ -1335,14 +1335,14 @@ const adminUsers = await User.scope('admin').findAll()
 const disabledUsers = await User.scope('disabled').findAll()
 
 // users with the string jami in their name
-const jamiUsers = User.scope({ method: ['name', '%jami%'] }).findAll()
+const jamiUsers = await User.scope({ method: ['name', '%jami%'] }).findAll()
 ```
 
 It is also possible to chain scopes:
 
 ```js
 // admins with the string jami in their name
-const jamiUsers = User.scope('admin', { method: ['name', '%jami%'] }).findAll()
+const jamiUsers = await User.scope('admin', { method: ['name', '%jami%'] }).findAll()
 ```
 
 Since Sequelize models are normal [JavaScript classes](https://sequelize.org/master/manual/model-basics.html#taking-advantage-of-models-being-classes), it is possible to add new methods to them.


### PR DESCRIPTION
Current examples don't have the 'await' statement, which causes the JSON response returned by the .findAll() method to be empty. I believe these examples need 'await' statement to be added.