### PR TITLE
Correct 5.20: Test blog can be 'liked', instead of 'edited'

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -1299,7 +1299,7 @@ The test should ensure that the created blog is visible in the list of blogs.
 
 #### 5.20: Blog List End To End Testing, step 4
 
-Do a test that makes sure the blog can be edited.
+Do a test that makes sure the blog can be liked.
 
 #### 5.21: Blog List End To End Testing, step 5
 


### PR DESCRIPTION
I think there's a mistake in exercise 5.20. The Cypress version of this exercise is to test that a blog can be "liked". The Playwright version says "edited". The coursework up to this point has not implemented "editing" a blog post.