### PR TITLE
' radix-ui ' listed twice in Part-7c: Other UI frameworks

### DIFF
--- a/src/content/7/en/part7c.md
+++ b/src/content/7/en/part7c.md
@@ -507,7 +507,6 @@ Here are some other UI frameworks for your consideration. If you do not see your
 - <https://www.radix-ui.com/>
 - <https://react-spectrum.adobe.com/react-aria/index.html>
 - <https://master.co/>
-- <https://www.radix-ui.com/>
 - <https://nextui.org/>
 - <https://daisyui.com/>
 - <https://ui.shadcn.com/>


### PR DESCRIPTION
In [Part 7-c: Other UI frameworks](https://fullstackopen.com/en/part7/more_about_styles#other-ui-frameworks),
`https://www.radix-ui.com/`
is listed twice.

![Screenshot (256)](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/114846457/8f37d400-3126-4341-a78e-1e91cca33a9b)
