### PR TITLE
correct use of word is "argument" not "parameter" in Part6-d

### DIFF
--- a/src/content/6/en/part6d.md
+++ b/src/content/6/en/part6d.md
@@ -206,7 +206,7 @@ const newNoteMutation = useMutation({ mutationFn: createNote })
 
 The parameter is the function we added to the file <i>requests.js</i>, which uses Axios to send a new note to the server.
 
-The event handler <i>addNote</i> performs the mutation by calling the mutation object's function <i>mutate</i> and passing the new note as a parameter:
+The event handler <i>addNote</i> performs the mutation by calling the mutation object's function <i>mutate</i> and passing the new note as an argument:
 
 ```js
 newNoteMutation.mutate({ content, important: true })


### PR DESCRIPTION
In Part6-d:  [React Query, useReducer and the context](https://fullstackopen.com/en/part6/react_query_use_reducer_and_the_context#synchronizing-data-to-the-server-using-react-query)

The correct use of word is **argument** not **parameter**.

![Screenshot (258)](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/114846457/5feb8dfe-4366-4a13-8ed3-98665028d759)
