### PR TITLE
change word from Jest to Vitest in Part-5c.md

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -863,6 +863,6 @@ Vitest offers a completely different alternative to "traditional" testing called
 
 The fundamental principle is to compare the HTML code defined by the component after it has changed to the HTML code that existed before it was changed.
 
-If the snapshot notices some change in the HTML defined by the component, then either it is new functionality or a "bug" caused by accident. Snapshot tests notify the developer if the HTML code of the component changes. The developer has to tell Jest if the change was desired or undesired. If the change to the HTML code is unexpected, it strongly implies a bug, and the developer can become aware of these potential issues easily thanks to snapshot testing.
+If the snapshot notices some change in the HTML defined by the component, then either it is new functionality or a "bug" caused by accident. Snapshot tests notify the developer if the HTML code of the component changes. The developer has to tell Vitest if the change was desired or undesired. If the change to the HTML code is unexpected, it strongly implies a bug, and the developer can become aware of these potential issues easily thanks to snapshot testing.
 
 </div>


### PR DESCRIPTION
Updated word used in Part-5c.md  [Snapshot testing](https://fullstackopen.com/en/part5/testing_react_apps#snapshot-testing) from **Jest** to **Vitest**

![Screenshot (260)](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/assets/114846457/de68a540-52a6-4cf7-a821-9ae2442003fd)
