### PR TITLE
Update part5c.md

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -778,7 +778,7 @@ const element = screen.getByText(
 or we could use the _findByText_ method:
 
 ```js
-const element = await screen.findByText('Does not work anymore :(')
+const element = await screen.findByText('Does not work anymore :(', { exact: false })
 ```
 
 It is important to notice that, unlike the other _ByText_ methods, _findByText_ returns a promise!


### PR DESCRIPTION
The code does not work without { exact: false } for the `findByText` method. So, I added it and the test passes.