### PR TITLE
move instruction to a logical place

### DIFF
--- a/src/content/2/fi/osa2c.md
+++ b/src/content/2/fi/osa2c.md
@@ -168,13 +168,11 @@ Nykyään lähes kaikki JavaScript-projektit määritellään node "pakkausmanag
 
 Tässä vaiheessa meitä kiinnostaa osa <i>dependencies</i>, joka määrittelee mitä <i>riippuvuuksia</i> eli ulkoisia kirjastoja projektilla on.
 
-Voisimme määritellä Axios-kirjaston suoraan tiedostoon <i>package.json</i>, mutta on parempi asentaa se komentoriviltä:
+Voisimme määritellä Axios-kirjaston suoraan tiedostoon <i>package.json</i>, mutta on parempi asentaa se komentoriviltä. **Huomaa, että _npm_-komennot tulee antaa aina projektin juurihakemistossa** eli siinä, jossa tiedosto <i>package.json</i> on.
 
 ```bash
 npm install axios
 ```
-
-**Huomaa, että _npm_-komennot tulee antaa aina projektin juurihakemistossa** eli siinä, jossa tiedosto <i>package.json</i> on.
 
 Nyt Axios on mukana riippuvuuksien joukossa:
 


### PR DESCRIPTION
Instruction to a command should be placed before the command. Otherwise, reader will read it too late.