### PR TITLE
Update part5d.md

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -1022,7 +1022,7 @@ const Note = ({ note, toggleImportance }) => {
 }
 ```
 
-Tests break! The reason for the problem is that the command _await page.getByText('second note')_ now returns a _span_ element containing only text, and the button is outside of it.
+Tests break! The reason for the problem is that the command _await page.getByText('first note')_ now returns a _span_ element containing only text, and the button is outside of it.
 
 One way to fix the problem is as follows:
 


### PR DESCRIPTION
- After including the {note.content} in a span, the tests break because the command await page.getByText('first note') now returns a span which does not contain the button. The test did not call the getByText method on the 'second note'