### PR TITLE
fix: make password length validation work

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -138,7 +138,7 @@ Let's not add any code dealing with Mongo to our backend just yet. Instead, let'
 ```js
 const mongoose = require('mongoose')
 
-if (process.argv.length<3) {
+if (process.argv[2].length<3) {
   console.log('give password as argument')
   process.exit(1)
 }


### PR DESCRIPTION
The password length validation was not being executed as it was not accessing the corresponding position in the array of process.argv