### PR TITLE
Update part4c.md to prevent unexpected test failures

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -448,6 +448,7 @@ notesRouter.post('/', async (request, response) => {
   response.status(201).json(savedNote)
 })
 ```
+NOTE: From this point on posting a note will require a <i>userId</i> field in the request body since Mongoose needs it to return the corresponding user object. A 500 "Internal Server Error" will pop up whenever we try to post a new note without it, which includes tests. So we need to add a <i>userId</i> field to the <i>newNote</i> objects inside <i>note_api.test.js</i> for tests to work as expected.
 
 It's worth noting that the <i>user</i> object also changes. The <i>id</i> of the note is stored in the <i>notes</i> field of the <i>user</i> object:
 


### PR DESCRIPTION
Tests concerning POSTing new notes failed with an enexpected 500 "Internal Server Error" after adding the update-user functionality to controllers/notes.js router since userId is now required for Mongoose to return the corresponding user object. I added a warning that this the exact reason for test failures so that other students don't spend too much time debugging the code.

P.S. For my tests to pass I also rewrote the beforeEach method since, if the userbase is cleared completely everytime, there will never be a stable userId that can be securely passed inside newNote objects to test the POST functionality.