### PR TITLE
Update fly launch instruction

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -141,13 +141,11 @@ Note if the command _fly_ does not work on your machine, you can try the longer 
 Initializing an app happens by running the following command in the root directory of the app
 
 ```bash
-fly launch
+fly launch --no-deploy
 ```
 
 Give the app a name or let Fly.io auto-generate one. Pick a region where the app will be run. Do not create a Postgres database for the app and do not create an Upstash Redis database, since these are not needed.
   
-The last question is "Would you like to deploy now?". We should answer "no" since we are not quite ready yet.
-
 Fly.io creates a file <i>fly.toml</i> in the root of your app where we can configure it. To get the app up and running we <i>might</i> need to do a small addition to the configuration:
 
 ```bash


### PR DESCRIPTION
The newest version of the fly CLI will deploy by default. --no-deploy flag is needed to bypass this behavior.