### PR TITLE
Fix code snippet in part3a.md so delete request example works as intended

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -530,7 +530,7 @@ Next, let's implement a route for deleting resources. Deletion happens by making
 
 ```js
 app.delete('/api/notes/:id', (request, response) => {
-  const id = request.params.id
+  const id = Number(request.params.id)
   notes = notes.filter(note => note.id !== id)
 
   response.status(204).end()


### PR DESCRIPTION
The 'deleting resources' section has a code snippet which compares a string to an integer (e.g., node.id !== id) that causes the example to not work as intended. Therefore, change the definition of the id variable to be an integer so the comparison and code works as intended.