### PR TITLE
Update array ids to be strings in part3a.md so code snippets work

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -187,17 +187,17 @@ const http = require('http')
 // highlight-start
 let notes = [
   {
-    id: 1,
+    id: "1",
     content: "HTML is easy",
     important: true
   },
   {
-    id: 2,
+    id: "2",
     content: "Browser can execute only JavaScript",
     important: false
   },
   {
-    id: 3,
+    id: "3",
     content: "GET and POST are the most important methods of HTTP protocol",
     important: true
   }


### PR DESCRIPTION
Notes array contains *integer* ids when subsequent images and code snippets show/assume they are strings. Therefore, update array to use *string* ids instead of integer ids. 

In section "Simple web server", ../../images/3/2new.png displays ids as strings (very end of the section). 

In section "Deleting resources", code snippet comparing request.params.id !== note.id compares a string with an integer, causing the code example to not work as intended.

In section "Receiving data", (e.g., grep "note.id = String(maxId + 1)", the post request code snippets write ids as strings and not integers.