### PR TITLE
change `note` ids into strings

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -187,17 +187,17 @@ const http = require('http')
 // highlight-start
 let notes = [
   {
-    id: 1,
+    id: '1',
     content: "HTML is easy",
     important: true
   },
   {
-    id: 2,
+    id: '2',
     content: "Browser can execute only JavaScript",
     important: false
   },
   {
-    id: 3,
+    id: '3',
     content: "GET and POST are the most important methods of HTTP protocol",
     important: true
   }


### PR DESCRIPTION
Our `/api/notes/:id` route assumes that the ids are string and do not convert them with `parseInt` or anything else to match with `request.params.id`.