### PR TITLE
update: part3a.md (GET /api/notes/:id and DELETE /api/notes/:id Endpoints Not Working)

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -503,7 +503,7 @@ Let's make the following change to our code:
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
-  const id = request.params.id
+  const id = Number(request.params.id)
   const note = notes.find(note => note.id === id)
   
   // highlight-start
@@ -530,7 +530,7 @@ Next, let's implement a route for deleting resources. Deletion happens by making
 
 ```js
 app.delete('/api/notes/:id', (request, response) => {
-  const id = request.params.id
+  const id = Number(request.params.id)
   notes = notes.filter(note => note.id !== id)
 
   response.status(204).end()


### PR DESCRIPTION
The GET /api/notes/:id and DELETE /api/notes/:id endpoints are not functioning as expected. The endpoints should return or delete the note corresponding to the given ID, but they currently do not. This issue is caused by the req.params.id being a string, while the id in the notes array is a number. As a result, the find and findIndex methods fail to match the note.

Steps to Reproduce:
Start the server using node server.js.
Navigate to http://localhost:3000/api/notes/1 or use a tool like curl or Postman to make a GET request. Observe that the endpoint does not return the expected note. Make a DELETE request to http://localhost:3000/api/notes/1. Observe that the note is not deleted.

Solution:
Convert req.params.id to a number before using it to find or delete the note.

Ref: https://prnt.sc/ohggpLOupB_H