### PR TITLE
Removed the third argument from createNote helper function calls

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -900,13 +900,13 @@ describe('Note app', () => {
     })
 
     test('a new note can be created', async ({ page }) => {
-      await createNote(page, 'a note created by playwright', true) // highlight-line
+      await createNote(page, 'a note created by playwright') // highlight-line
       await expect(page.getByText('a note created by playwright')).toBeVisible()
     })
 
     describe('and a note exists', () => {
       beforeEach(async ({ page }) => {
-        await createNote(page, 'another note by playwright', true) // highlight-line
+        await createNote(page, 'another note by playwright') // highlight-line
       })
   
       test('importance can be changed', async ({ page }) => {


### PR DESCRIPTION
- The createNote helper function has only two parameters - page and content. But the code is calling the function with three arguments - createNote(page, 'note content', true)
- I fixed the code by calling the createNote function by calling it with only first two arguments
- I assume the last boolean argument is for the "important" property of a note, but it isn't used here correctly