### PR TITLE
eslint config file errors

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -963,7 +963,7 @@ export default tseslint.config({
   rules: {
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/semi': 'error',
+    '@/semi': 'error',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/restrict-template-expressions': 'off',

--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -898,6 +898,7 @@ npm install --save-dev eslint @eslint/js @types/eslint__js typescript typescript
 We will configure ESlint to [disallow explicit any]( https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-explicit-any.md). Write the following rules to *eslint.config.mjs*:
 
 ```js
+import eslint from "@eslint/js";
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config({
@@ -944,6 +945,7 @@ On top of the recommended settings, we should try to get familiar with the codin
 So we will use the following *eslint.config.mjs*
 
 ```js
+import eslint from "@eslint/js";
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config({


### PR DESCRIPTION
Is currently the standard as in docs https://typescript-eslint.io/getting-started/

Not explicitly importing causes an absolute seizure of crash fit as eslint crumbles in on itself and the text editor becomes unusable (at least in neovim (found out the hard way)).
![image](https://github.com/user-attachments/assets/3e5a34f1-9874-4616-8b3e-947704d22a70)

semi is defined at @/semi and not @typescript-eslint/semi

This is some witchcraft caused by the following two reasons: 
The rule for semi has been deprecated - https://typescript-eslint.io/rules/semi/
and moved - https://eslint.style/rules/ts/semi#ts-semi

tested with vs code just to be sure:
![image](https://github.com/user-attachments/assets/16621f8b-cf5f-41f3-8760-ac12fa758c77)
![image](https://github.com/user-attachments/assets/3a1f4f38-2f5a-4fc2-9bce-51530586ed67)

