### PR TITLE
Removed String() frrom addNote function

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -235,7 +235,7 @@ const addNote = (event) => {
   const noteObject = {
     content: newNote,
     important: Math.random() < 0.5,
-    id: String(notes.length + 1),
+    id: notes.length + 1,
   }
 
   setNotes(notes.concat(noteObject))


### PR DESCRIPTION
Removed String() function from creating id for noteObject. The current result is having an id of type string for newly created notes. This is different from the initial data of notes having data type number for id  on each note.