### PR TITLE
Update part1a.md - note about StrictMode

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -52,6 +52,8 @@ import App from './App'
 ReactDOM.createRoot(document.getElementById('root')).render(<App />)
 ```
 
+> <i>By default, there will be React.StrictMode tags around the <App />. We have chosen to remove them from this tutorial.</i>
+
 and file <i>App.jsx</i> looks like this
 
 ```js


### PR DESCRIPTION
By default, when using npm create vite@latest part1 -- --template react

main.jsx will look like this

ReactDOM.createRoot(document.getElementById('root')).render(
  <React.StrictMode>
    <App />
  </React.StrictMode>
);

Your example on the page doesn't have the <React.StrictMode> tags. I added a note saying this. I asked on Discord and heartsmagic suggested it was probably removed to not confuse learners with strict mode. This note hopefully clarifies that. I am unsure of the exact reason so am happy with any other reason being given.