### PR TITLE
Update part9e.md

### DIFF
--- a/src/content/9/en/part9e.md
+++ b/src/content/9/en/part9e.md
@@ -168,7 +168,7 @@ Before going into this, let us do some preparatory work.
 Create an endpoint */api/patients/:id* to the backend that returns all of the patient information for one patient, including the array of patient entries that is still empty for all the patients. For the time being, expand the backend types as follows:
 
 ```js
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Entry {
 }
 


### PR DESCRIPTION
Use new rule `@typescript-eslint/no-empty-object-type` for eslint-disable-next-line instead of the [deprecated `@typescript-eslint/no-empty-interface`](https://typescript-eslint.io/rules/no-empty-interface/)
