### PR TITLE
Add missing underscore escapes in part 0b (all presently included languages)

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -440,7 +440,7 @@ The Form Data dropdown is within the new Payload tab, located to the right of th
 
 ![form data dropdown in developer tools](../../images/0/23e.png)
 
-The Form tag has attributes <i>action</i> and <i>method</i>, which define that submitting the form is done as an HTTP POST request to the address <i>new_note</i>.
+The Form tag has attributes <i>action</i> and <i>method</i>, which define that submitting the form is done as an HTTP POST request to the address <i>new\_note</i>.
 
 ![action and method highlight](../../images/0/24e.png)
 
@@ -549,7 +549,7 @@ form.onsubmit = function(e) {
 }
 ```
 
-The command <em>document.getElementById('notes_form')</em> instructs the code to fetch a reference to the HTML form element on the page that has the ID "notes_form" and to register an <i>event handler</i> to handle the form's submit event. The event handler immediately calls the method <em>e.preventDefault()</em> to prevent the default handling of form's submit. The default method would send the data to the server and cause a new GET request, which we don't want to happen.
+The command <em>document.getElementById('notes\_form')</em> instructs the code to fetch a reference to the HTML form element on the page that has the ID "notes\_form" and to register an <i>event handler</i> to handle the form's submit event. The event handler immediately calls the method <em>e.preventDefault()</em> to prevent the default handling of form's submit. The default method would send the data to the server and cause a new GET request, which we don't want to happen.
 
 Then the event handler creates a new note, adds it to the notes list with the command <em>notes.push(note)</em>, rerenders the note list on the page and sends the new note to the server.
 

--- a/src/content/0/es/part0b.md
+++ b/src/content/0/es/part0b.md
@@ -550,7 +550,7 @@ form.onsubmit = function(e) {
 }
 ```
 
-El comando <em>document.getElementById('notes_form')</em> le indica al código que obtenga el elemento form de la página y que registre un <i>event handler</i> para manejar el evento de envío del formulario. El controlador de eventos llama inmediatamente al método <em>e.preventDefault()</em> para evitar el manejo por defecto del envío de formularios. El método por defecto enviaría los datos al servidor y causaría una nueva solicitud GET, lo cual no queremos que suceda.
+El comando <em>document.getElementById('notes\_form')</em> le indica al código que obtenga el elemento form de la página y que registre un <i>event handler</i> para manejar el evento de envío del formulario. El controlador de eventos llama inmediatamente al método <em>e.preventDefault()</em> para evitar el manejo por defecto del envío de formularios. El método por defecto enviaría los datos al servidor y causaría una nueva solicitud GET, lo cual no queremos que suceda.
 
 Luego el controlador de eventos crea una nueva nota, la agrega a la lista de notas con el comando <em>notes.push(note)</em>, vuelve a renderizar la lista de notas en la página y envía la nueva nota al servidor.
 

--- a/src/content/0/fi/osa0b.md
+++ b/src/content/0/fi/osa0b.md
@@ -435,7 +435,7 @@ Network-välilehti näyttää myös lomakkeen mukana lähetetyn datan:
 
 ![](../../images/0/23e.png)
 
-Lomakkeen lähettäminen tapahtuu HTTP POST ‑pyyntönä ja osoitteeseen <i>new_note</i> form-tagiin määriteltyjen attribuuttien <i>action</i> ja <i>method</i> ansiosta:
+Lomakkeen lähettäminen tapahtuu HTTP POST ‑pyyntönä ja osoitteeseen <i>new\_note</i> form-tagiin määriteltyjen attribuuttien <i>action</i> ja <i>method</i> ansiosta:
 
 ![](../../images/0/24e.png)
 
@@ -542,7 +542,7 @@ form.onsubmit = function(e) {
 }
 ```
 
-Komennolla <em>document.getElementById('notes_form')</em> koodi hakee sivulta lomake-elementin ja rekisteröi sille <i>tapahtumankäsittelijän</i> hoitamaan tilanteen, jossa lomake "submitoidaan" eli lähetetään. Tapahtumankäsittelijä kutsuu heti metodia <em>e.preventDefault()</em>, jolla se estää lomakkeen lähetyksen oletusarvoisen toiminnan. Oletusarvoinen toiminta aiheuttaisi lomakkeen lähettämisen ja sivun uudelleen lataamisen, joita emme single page ‑sovelluksissa halua tapahtuvan.
+Komennolla <em>document.getElementById('notes\_form')</em> koodi hakee sivulta lomake-elementin ja rekisteröi sille <i>tapahtumankäsittelijän</i> hoitamaan tilanteen, jossa lomake "submitoidaan" eli lähetetään. Tapahtumankäsittelijä kutsuu heti metodia <em>e.preventDefault()</em>, jolla se estää lomakkeen lähetyksen oletusarvoisen toiminnan. Oletusarvoinen toiminta aiheuttaisi lomakkeen lähettämisen ja sivun uudelleen lataamisen, joita emme single page ‑sovelluksissa halua tapahtuvan.
 
 Tämän jälkeen koodi luo muistiinpanon, lisää sen muistiinpanojen listalle komennolla <em>notes.push(note)</em>, piirtää ruudun sisällön eli muistiinpanojen listan uudelleen ja lähettää uuden muistiinpanon palvelimelle.
 

--- a/src/content/0/fr/part0b.md
+++ b/src/content/0/fr/part0b.md
@@ -433,7 +433,7 @@ NB: Dans les dernières versions de Chrome, les informations sur les données de
 
 ![informations sur les données de formulaire](../../images/0/23e.png)
 
-La balise Form a les attributs <i>action</i> et <i>method</i>, qui définissent que la soumission du formulaire se fait sous la forme d'une requête HTTP POST à ​​l'adresse <i>new_note</i>.
+La balise Form a les attributs <i>action</i> et <i>method</i>, qui définissent que la soumission du formulaire se fait sous la forme d'une requête HTTP POST à ​​l'adresse <i>new\_note</i>.
 
 ![mise en évidence de l'action et la méthode du formulaire](../../images/0/24e.png)
 

--- a/src/content/0/ptbr/part0b.md
+++ b/src/content/0/ptbr/part0b.md
@@ -441,7 +441,7 @@ Obs.: Na versão mais recente do Chrome, o menu drop-down (lista suspensa) "Form
 
 ![Menu drop-down do Form Data das Ferramentas do Desenvolvedor](../../images/0/23e.png)
 
-A tag Form tem os atributos <i>action</i> e <i>method</i>, que definem que o envio do formulário é feito como uma requisição HTTP POST para o endereço <i>new_note</i>.
+A tag Form tem os atributos <i>action</i> e <i>method</i>, que definem que o envio do formulário é feito como uma requisição HTTP POST para o endereço <i>new\_note</i>.
 
 ![Destaque dos atributos action e method](../../images/0/24e.png)
 
@@ -547,7 +547,7 @@ form.onsubmit = function(e) {
 }
 ```
 
-O comando <em>document.getElementById('notes_form')</em> instrui o código a buscar o elemento de formulário da página e a registrar um <i>gerenciador de evento</i> para lidar com o evento de envio do formulário. O gerenciador de evento chama imediatamente o método <em>e.preventDefault()</em> para evitar o tratamento padrão do envio do formulário. O método padrão enviaria os dados para o servidor e causaria uma nova requisição GET, o que não queremos que aconteça.
+O comando <em>document.getElementById('notes\_form')</em> instrui o código a buscar o elemento de formulário da página e a registrar um <i>gerenciador de evento</i> para lidar com o evento de envio do formulário. O gerenciador de evento chama imediatamente o método <em>e.preventDefault()</em> para evitar o tratamento padrão do envio do formulário. O método padrão enviaria os dados para o servidor e causaria uma nova requisição GET, o que não queremos que aconteça.
 
 Em seguida, o gerenciador de evento cria uma nova nota, adiciona-a à lista de notas com o comando <em>notes.push(note)</em>, redesenha a lista de notas na página e envia a nova nota ao servidor.
 
@@ -567,7 +567,7 @@ var sendToServer = function(note) {
 O código determina que os dados devem ser enviados com uma requisição HTTP POST e o tipo de dados deve ser JSON. O tipo de dados é determinado com um cabeçalho <i>Content-type</i>. Em seguida, os dados são enviados como uma string JSON.
 
 O código da aplicação está disponível em <https://github.com/mluukkai/example_app>.
-Vale ressaltar que a aplicação serve apenas para demonstrar os conceitos do curso. O código segue um estilo ruim de desenvolvimento em algumas partes e não deve ser usado como exemplo ao criar suas próprias aplicações. O mesmo se aplica às URLs usadas. A URL <i>new_note_spa</i> para a qual as novas notas são enviadas, não segue as melhores práticas usadas atualmente.
+Vale ressaltar que a aplicação serve apenas para demonstrar os conceitos do curso. O código segue um estilo ruim de desenvolvimento em algumas partes e não deve ser usado como exemplo ao criar suas próprias aplicações. O mesmo se aplica às URLs usadas. A URL <i>new\_note\_spa</i> para a qual as novas notas são enviadas, não segue as melhores práticas usadas atualmente.
 
 ### Bibliotecas JavaScript
 

--- a/src/content/0/zh/part0b.md
+++ b/src/content/0/zh/part0b.md
@@ -524,7 +524,7 @@ list.appendChild(newElement)
 ![Detail view of the first request](../../images/0/22e.png)
 
 <!-- It is an [HTTP POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) request to the server address <i>new\_note</i>. The server responds with HTTP status code 302. This is a [URL redirect](https://en.wikipedia.org/wiki/URL_redirection), with which the server asks the browser to do a new HTTP GET request to the address defined in the header's <i>Location</i> - the address <i>notes</i>.-->
-这是一个[HTTP POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST)请求，指向服务器地址<i>new_note</i>。服务器回应的是HTTP状态代码302。这是一个[URL重定向](https://en.wikipedia.org/wiki/URL_redirection)，服务器要求浏览器对头信息<i>Location</i>中定义的地址--即地址<i>notes</i>做一个新的HTTP GET请求。
+这是一个[HTTP POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST)请求，指向服务器地址<i>new\_note</i>。服务器回应的是HTTP状态代码302。这是一个[URL重定向](https://en.wikipedia.org/wiki/URL_redirection)，服务器要求浏览器对头信息<i>Location</i>中定义的地址--即地址<i>notes</i>做一个新的HTTP GET请求。
 
 <!-- So, the browser reloads the Notes page. The reload causes three more HTTP requests: fetching the style sheet (main.css), the JavaScript code (main.js), and the raw data of the notes (data.json).-->
  于是，浏览器重新加载了笔记页面。重载又引起了三个HTTP请求：获取样式表（main.css）、JavaScript代码（main.js）和笔记的原始数据（data.json）。
@@ -538,7 +538,7 @@ list.appendChild(newElement)
 ![](../../images/0/23e.png)
 
 <!-- The Form tag has attributes <i>action</i> and <i>method</i>, which define that submitting the form is done as an HTTP POST request to the address <i>new_note</i>.-->
- 表单标签有属性<i>action</i>和<i>method</i>，它们定义了提交表单是以HTTP POST请求的方式完成的，地址为<i>new_note</i>。
+ 表单标签有属性<i>action</i>和<i>method</i>，它们定义了提交表单是以HTTP POST请求的方式完成的，地址为<i>new\_note</i>。
 
 ![](../../images/0/24e.png)
 
@@ -635,7 +635,7 @@ HTML代码几乎相同，但JavaScript文件不同（<i>spa.js</i>），而且�
 ![](../../images/0/26e.png)
 
 <!-- The POST request to the address <i>new\_note\_spa</i> contains the new note as JSON-data containing both the content of the note (<i>content</i>) and the timestamp (<i>date</i>):-->
- 发送到地址<i>new_note/spa</i>的POST请求包含了新笔记的JSON数据，包含了笔记的内容（<i>content</i>）和时间戳（<i>date</i>）。
+ 发送到地址<i>new\_note\_spa</i>的POST请求包含了新笔记的JSON数据，包含了笔记的内容（<i>content</i>）和时间戳（<i>date</i>）。
 
 ```js
 {
@@ -705,7 +705,7 @@ var sendToServer = function(note) {
 <!-- The application code is available at <https://github.com/mluukkai/example_app>.-->
  应用代码可在<https://github.com/mluukkai/example_app>中找到。
 <!-- It's worth remembering that the application is only meant to demonstrate the concepts of the course. The code follows a poor style of development in some measure, and should not be used as an example when creating your own applications. The same is true for the URLs used. The URL <i>new\_note\_spa</i>, which new notes are sent to, does not adhere to current best practices.-->
- 值得记住的是，这个应用只是为了演示课程的概念。代码在某种程度上遵循了不良的开发风格，在创建你自己的应用时，不应作为一个例子来使用。所用的URL也是如此。发送新笔记的URL <i>new_note\_spa</i>并不符合当前的最佳实践。
+ 值得记住的是，这个应用只是为了演示课程的概念。代码在某种程度上遵循了不良的开发风格，在创建你自己的应用时，不应作为一个例子来使用。所用的URL也是如此。发送新笔记的URL <i>new\_note\_spa</i>并不符合当前的最佳实践。
 
 ### JavaScript-libraries
 


### PR DESCRIPTION
Escaped all underscores ("_") in part 0b, fixing issues like

![issue](https://github.com/user-attachments/assets/31372274-8b00-4fd4-a87e-1fbbf1ce446c)

to 

![fixed](https://github.com/user-attachments/assets/31c80a1e-802f-4c60-8f2a-16dbecd2fe08)

And also fixed a typo

![issue2](https://github.com/user-attachments/assets/d725b355-5f28-4206-b7e5-b3007e6a2a41)

to

![fixed2](https://github.com/user-attachments/assets/d29b39b7-0102-4520-bac5-7e4359b87519)

<br>

In some cases, not escaping the underscore didn't result in any unwanted result, but it is still good practice to escape them.

Also, I have followed the [contributing guidelines](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io/blob/d1a1cfd96169f49a3dfdfdf9df6a9cbc60e8bc57/CONTRIBUTING.md) (though slight deviation: I already made my changes in the source branch, so I didn't create a new one).