### PR TITLE
Update part13c.md

### DIFF
--- a/src/content/13/en/part13c.md
+++ b/src/content/13/en/part13c.md
@@ -995,8 +995,8 @@ In the context of the include, we must now use the alias name <i>marked\_notes</
 In order to test the feature, let's create some test data in the database:
 
 ```sql
-insert into user_notes (user_id, note_id) values (1, 4);
-insert into user_notes (user_id, note_id) values (1, 5);
+insert into user_notes (user_id, note_id) values (2, 1);
+insert into user_notes (user_id, note_id) values (2, 2); 
 ```
 
 The end result is functional:


### PR DESCRIPTION
I found this inconsistency between the screenshot and the SQL operations we perform in the material:

- we insert notes 4 and 5 for user 1
<img width="792" alt="Screenshot 2024-08-27 at 16 59 21" src="https://github.com/user-attachments/assets/d9644a94-78dd-4bf2-8e11-e02e42666d6b">

- but on the screenshot we make a call for user 2 that has 2 marked notes: 1 and 2.
<img width="782" alt="Screenshot 2024-08-27 at 16 59 57" src="https://github.com/user-attachments/assets/c032df17-4548-4c73-96b6-6f298fd9568c">

So in order to match the screenshot I propose to change the two INSERT commands.

(Also, as a side note: on the screenshot we already include the author of the marked notes but the code is only updated later in the course, so it might be beneficial to change the screenshot).