### PR TITLE
Update part9c.md

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -838,9 +838,15 @@ The first type parameter is the most interesting for us, it corresponds <i>the r
 We could and propably should give a proper type as the type variable. In our case it is an array of diary entries:
 
 ```js
-router.get('/', (_req, res: Response<DiaryEntry[]>) => { //
-  res.send(res.send(diaryService.getNonSensitiveEntries());
+import { Response } from 'express'
+
+// ...
+
+router.get('/', (_req, res: Response<DiaryEntry[]>) => {
+  res.send(diaryService.getNonSensitiveEntries());
 });
+
+// ...
 ```
 
 If we now try to respond with wrong type of data, the code does not compile


### PR DESCRIPTION
Fix the code from the part **typing the request response**,  the `res.send` is duplicated and also the 
`import { Response } from 'express'` is missing, I don't know if it's intended but I'm dumb so I thought that I just missed something and decided to re-read everything from the start.   I'm not sure if this is the correct way but if it's not please change it so people like me can save time. Thanks.