### PR TITLE
Update part2a.md

### DIFF
--- a/src/content/2/en/part2a.md
+++ b/src/content/2/en/part2a.md
@@ -300,7 +300,7 @@ Changing the command to:
 const result = notes.map(note => note.content)
 ```
 
-results in an array containing the contents of the notes.
+will give you an array containing the contents of the notes.
 
 This is already pretty close to the React code we used:
 


### PR DESCRIPTION
Original text "results in an array containing the contents of the notes." is confusing because the variable is "result". When I saw "results in an array containing the contents of the notes.", I thought that the "results" was the variable "result" mis-spelled. This way of phrasing won't confuse the reader.