### PR TITLE
Fix frontend startup command

### DIFF
--- a/src/content/5/en/part5a.md
+++ b/src/content/5/en/part5a.md
@@ -88,7 +88,7 @@ export default App
 
 The current application code can be found on [GitHub](https://github.com/fullstack-hy2020/part2-notes-frontend/tree/part5-1), in the branch <i>part5-1</i>. If you clone the repo, don't forget to run _npm install_ before attempting to run the frontend.
 
-The frontend will not display any notes if it's not connected to the backend. You can start the backend with _npm run dev_ in its folder from Part 4. This will run the backend on port 3001. While that is active, in a separate terminal window you can start the frontend with _npm start_, and now you can see the notes that are saved in your MongoDB database from Part 4.
+The frontend will not display any notes if it's not connected to the backend. You can start the backend with _npm run dev_ in its folder from Part 4. This will run the backend on port 3001. While that is active, in a separate terminal window you can start the frontend with _npm run dev_, and now you can see the notes that are saved in your MongoDB database from Part 4.
 
 Keep this in mind from now on.
 


### PR DESCRIPTION
Update document to specify npm run dev instead of npm start in frontend setup instructions.