### PR TITLE
fix: contentBase is deprecated in Webpack v5

### DIFF
--- a/src/content/7/es/part7d.md
+++ b/src/content/7/es/part7d.md
@@ -515,7 +515,9 @@ const config = {
   },
   // highlight-start
   devServer: {
-    contentBase: path.resolve(__dirname, 'build'),
+    static: {
+        directory: path.resolve(__dirname, 'build'),
+    },
     compress: true,
     port: 3000,
   },


### PR DESCRIPTION
Webpack v5 is not using **contentBase**, use **static** option instead. Following the documentation below: https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md

![image](https://github.com/user-attachments/assets/b5ad754d-3c99-4b9f-b06f-2905533f35d9)
