### PR TITLE
Small bug fix in part8c.md: remove gql before the string literal

### DIFF
--- a/src/content/8/en/part8c.md
+++ b/src/content/8/en/part8c.md
@@ -73,7 +73,7 @@ mongoose.connect(MONGODB_URI)
     console.log('error connection to MongoDB:', error.message)
   })
 
-const typeDefs = gql`
+const typeDefs = `
   ...
 `
 


### PR DESCRIPTION
Remove gql before the string literal of the typeDefs constant, since it is used in the client and not the server to to queries.