### PR TITLE
added 'gql' tag for syntax highlights in GraphQL schema definition

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -249,7 +249,7 @@ Let's implement a GraphQL server with today's leading library: [Apollo Server](h
 Create a new npm project with *npm init* and install the required dependencies.
 
 ```bash
-npm install @apollo/server graphql
+npm install @apollo/server graphql graphql-tag
 ```
 
 Also create a `index.js` file in your project's root directory.
@@ -259,6 +259,7 @@ The initial code is as follows:
 ```js
 const { ApolloServer } = require('@apollo/server')
 const { startStandaloneServer } = require('@apollo/server/standalone')
+const { gql } = require('graphql-tag')
 
 let persons = [
   {
@@ -283,7 +284,7 @@ let persons = [
   },
 ]
 
-const typeDefs = `
+const typeDefs = gql`
   type Person {
     name: String!
     phone: String


### PR DESCRIPTION
added `gql` tag from `graphql-tag` package for syntax highlights in GraphQL schema definition in backend.  

**_Without gql:_**

![image](https://github.com/user-attachments/assets/87ace334-fed9-4edf-aa7f-457a486327e4)

_**With gql:**_

![image](https://github.com/user-attachments/assets/79ba662f-a396-4a3b-bca8-1e4a4b592464)
