### PR TITLE
Apollo Studio Explorer is now GraphOS Studio Explorer

### DIFF
--- a/src/content/8/en/part8a.md
+++ b/src/content/8/en/part8a.md
@@ -394,7 +394,7 @@ Start the server by running `node index.js` in the terminal.
 
 ### Apollo Studio Explorer
 
-When Apollo server is run in development mode the page [http://localhost:4000](http://localhost:4000) has a button <i>Query your server</i> that takes us to [Apollo Studio Explorer](https://www.apollographql.com/docs/studio/explorer/explorer/).  This is very useful for a developer, and can be used to make queries to the server.
+When Apollo server is run in development mode the page [http://localhost:4000](http://localhost:4000) has a button <i>Query your server</i> that takes us to [GraphOS Studio Explorer](https://www.apollographql.com/docs/graphos/platform/explorer).  This is very useful for a developer, and can be used to make queries to the server.
 
 Let's try it out:
 


### PR DESCRIPTION
[In part8a.md](https://fullstackopen.com/en/part8/graph_ql_server#apollo-studio-explorer),

1. updated name:  
\- Apollo Studio Explorer  
\+ GraphOS Studio Explorer

2. updated link:
\- https://www.apollographql.com/docs/studio/explorer/explorer/
\+ https://www.apollographql.com/docs/graphos/platform/explorer