### PR TITLE
Update part6a.md

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -99,7 +99,7 @@ The reducer is never supposed to be called directly from the application's code.
 
 ```js
 // highlight-start
-import { createStore } from 'redux'
+import { counterReducer } from 'redux'
 // highlight-end
 
 const counterReducer = (state = 0, action) => {


### PR DESCRIPTION
createStore been officially deprecated since Redux v4.2. Shouldn't we update the course material accordingly? stop using createStore and use the most updated tool?