### PR TITLE
Fix rollback order

### DIFF
--- a/src/content/13/en/part13c.md
+++ b/src/content/13/en/part13c.md
@@ -567,8 +567,8 @@ module.exports = {
     })
   },
   down: async ({ context: queryInterface }) => {
-    await queryInterface.dropTable('teams')
     await queryInterface.dropTable('memberships')
+    await queryInterface.dropTable('teams')
   },
 }
 ```


### PR DESCRIPTION
The original code would fail since `memberships` table contains a reference to `teams` table. To roll back, `memberships` has to be dropped before `teams`.