### PR TITLE
Update part4b.md

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -1063,7 +1063,7 @@ const helper = require('./test_helper')
 
 const Note = require('../models/note')
 
-describe('when there is initially some notes saved', () => {
+describe('when there are some notes saved initially', () => {
   beforeEach(async () => {
     await Note.deleteMany({})
     await Note.insertMany(helper.initialNotes)


### PR DESCRIPTION
"when there is initially some notes saved" should read "when there are some notes saved initially"

"is" should be changed for "are" given that "notes" is plural and a countable noun.  

The adverb "initially" sounds more natural at the end of the phrase.