### PR TITLE
Update part7d.md

### DIFF
--- a/src/content/7/en/part7d.md
+++ b/src/content/7/en/part7d.md
@@ -275,7 +275,7 @@ The syntax used above comes from JSX and it provides us with an alternative way 
 
 We can use [loaders](https://webpack.js.org/concepts/loaders/) to inform webpack of the files that need to be processed before they are bundled.
 
-Let's configure a loader to our application that transforms the JSX code into regular JavaScript:
+Let's configure a loader to our application at <i>webpack.config.js</i> that transforms the JSX code into regular JavaScript:
 
 ```js
 const path = require('path')


### PR DESCRIPTION
Why do I make pull requests like this? On seemingly small details that students "should" already know, or can easily find out themselves? The reason is that as we are learning, when we have to deviate away from the main flow of logic, to tasks such as finding out which file it belongs to, importing something or not, or "small" details where to find something, this extra step, deviates us from the flow of the logic of the course. I have heard a study that once a person gets distracted like this, it takes 20 minutes to get back to the focus of the main course. So for a more effective and efficient learning, it is best to take care of these details. Not to distract the students away from the main flow of the logic. Rather than just saying "they should know this by now". The key is in the details.