### PR TITLE
Revert "Update part2b.md"

### DIFF
--- a/src/content/2/es/part2b.md
+++ b/src/content/2/es/part2b.md
@@ -399,7 +399,7 @@ Puedes encontrar el código para nuestra aplicación actual en su totalidad en l
 
 <h3>Ejercicios 2.6.-2.10.</h3> 
 
-Este es un nuevo ejercicio que comenzaremos a trabajar en una aplicación que se continuará desarrollando en los ejercicios posteriores. En conjuntos de ejercicios relacionados, es suficiente con presentar la versión final de tu aplicación. También puedes realizar un commit por separado después de haber terminado cada parte del conjunto de ejercicios, pero no es necesario hacerlo.
+En el primer ejercicio, comenzaremos a trabajar en una aplicación que se continuara desarrollando en los ejercicios posteriores. En conjuntos de ejercicios relacionados, es suficiente con presentar la versión final de tu aplicación. También puedes realizar un commit por separado después de haber terminado cada parte del conjunto de ejercicios, pero no es necesario hacerlo.
 
 <h4>2.6: La Agenda Telefónica Paso 1</h4>
 


### PR DESCRIPTION
This seems to be a wrong correction. The original was indeed slightly ambiguous, but not wrong. The paragraph is meant to introduce the set of exercises. When it says "el primer ejercicio" it refers to the first exercise of this set of exercises (2.6-2.10), and not to the exercise 1 of the whole part. Just like afterwards it talks about the other exercises of the same set. The corrected version doesn't make sense and the original one was correct.