### PR TITLE
Changed asyncIterator to asyncIterableIterator

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -589,7 +589,7 @@ const resolvers = {
   // highlight-start
   Subscription: {
     personAdded: {
-      subscribe: () => pubsub.asyncIterator('PERSON_ADDED')
+      subscribe: () => pubsub.asyncIterableIterator('PERSON_ADDED')
     },
   },
   // highlight-end
@@ -610,7 +610,7 @@ There are only a few lines of code added, but quite a lot is happening under the
 ```js
 Subscription: {
   personAdded: {
-    subscribe: () => pubsub.asyncIterator('PERSON_ADDED')
+    subscribe: () => pubsub.asyncIterableIterator('PERSON_ADDED')
   },
 },
 ```


### PR DESCRIPTION
Changed all occurrances of asyncIterator to asyncIterableIterator. In graphql-subscriptions v3.0.0 the right way to handle subscription is with asyncIterableIterator. Relevant npm documentation: https://www.npmjs.com/package/graphql-subscriptions