### PR TITLE
Update part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -417,6 +417,7 @@ app.get('/api/notes', (request, response) => {
   })
 })
 ```
+// Somewhere here should be mentioned about 'require("dotenv").config()' being needed, since the next bit says you can verify it working in the browser, which I couldn't because the url was undefined.
 
 We can verify in the browser that the backend works for displaying all of the documents:
 


### PR DESCRIPTION
I think it should be mentioned somewhere nearby where I put the comment that you need 'require("dotenv").config();' to be able to access the env variable to test the database working with the backend code. It is mentioned only a bit further on in the text, but since it says you can verify in the browser, which is not possible without this reference.