### PR TITLE
Changing the .env references

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -389,25 +389,6 @@ const noteSchema = new mongoose.Schema({
 const Note = mongoose.model('Note', noteSchema)
 ```
 
-To avoid authentication issues with the password variable in index.js, we need to create a .env file by running npm install dotenv in the command line. Then, let's create the .env file in the root of your directory. In that file, you should place your URI:
-
-```
-MONGODB_URI="mongodb+srv://fullstack:password@db.gwcmebp.mongodb.net/?retryWrites=true&w=majority&appName=db"
-```
-Don't forget to replace the string with your details. 
-Once the .env file is ready, remember to add it to your .gitignore file to prevent pushing the password to Git:
-
-```
-/node_modules
-.env
-```
-Then, in your index.js file, make the necessary changes with the following line so that your code can access the URL in your .env file:
-
-```
-const url = process.env.MONGODB_URI;
-
-```
-
 Let's change the handler for fetching all notes to the following form:
 
 ```js
@@ -510,10 +491,6 @@ This way the _Note_ variable will be assigned to the same object that the module
 The way that the connection is made has changed slightly:
 
 ```js
-const url = process.env.MONGODB_URI
-
-console.log('connecting to', url)
-
 mongoose.connect(url)
   .then(result => {
     console.log('connected to MongoDB')
@@ -523,11 +500,17 @@ mongoose.connect(url)
   })
 ```
 
-It's not a good idea to hardcode the address of the database into the code, so instead the address of the database is passed to the application via the <em>MONGODB_URI</em> environment variable.
-
 The method for establishing the connection is now given functions for dealing with a successful and unsuccessful connection attempt. Both functions just log a message to the console about the success status:
 
 ![node output when wrong username/password](../../images/3/45e.png)
+
+It's also not a good idea to hardcode the address of the database into the code, so the url is obtained differently: the address of the database is passed to the application via the <em>MONGODB_URI</em> environment variable:
+
+```js
+const url = process.env.MONGODB_URI
+
+console.log('connecting to', url)
+```
 
 There are many ways to define the value of an environment variable. One way would be to define it when the application is started:
 


### PR DESCRIPTION
The way it was done originally was kind of confusing, because .env is mentioned at the beggining, without explaining that it must be imported (required). Then, the rest of the explanation was given below. This way, .env is mentioned when the whole explanation is given