### PR TITLE
Add clarification about Vite exported variables

### DIFF
--- a/src/content/2/en/part2e.md
+++ b/src/content/2/en/part2e.md
@@ -624,6 +624,8 @@ const api_key = import.meta.env.VITE_SOME_KEY
 
 Note that you will need to restart the server to apply the changes.
 
+**NB:** To prevent accidentally leaking environment variables to the client, only variables prefixed with VITE_ are exposed to Vite.
+
 This was the last exercise of this part of the course. It's time to push your code to GitHub and mark all of your finished exercises to the [exercise submission system](https://studies.cs.helsinki.fi/stats/courses/fullstackopen).
 
 </div>


### PR DESCRIPTION
While doing this part I was getting frustrated with my requests not going through to the weather provider. Ultimately tracking that down to my key not being registered. I believe it would be best to place a clarification that the VITE_ prefix is not optional but required. Placement of this clarification can be revised.