### PR TITLE
Update part3c.md

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -357,7 +357,7 @@ Person
   })
 ```
 
-**NB:** If you define a model with the name <i>Person</i>, mongoose will automatically name the associated collection as <i>people</i>.
+**NB:** If you define a model with the name <i>Person</i>, mongoose will automatically name the associated collection as <i>persons</i>.
 
 </div>
 


### PR DESCRIPTION
Changed "If you define a model with the name <i>Person</i>, mongoose will automatically name the associated collection as <i>people</i>" to "If you define a model with the name <i>Person</i>, mongoose will automatically name the associated collection as <i>persons</i>".