### PR TITLE
Update part9c.md

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -839,10 +839,10 @@ We could and propably should give a proper type as the type variable. In our cas
 
 ```js
 import { Response } from 'express'
-
+import { NonSensitiveDiaryEntry } from "../types";
 // ...
 
-router.get('/', (_req, res: Response<DiaryEntry[]>) => {
+router.get('/', (_req, res: Response<NonSensitiveDiaryEntry[]>) => {
   res.send(diaryService.getNonSensitiveEntries());
 });
 


### PR DESCRIPTION
The original code gives an error because you set the return type to be "DiaryEntry[]" but the res actually returns values from "getNonSensitiveEntries()" which has a "NonSensitiveDiaryEntry" type(without the "comment" property"). It gave an error - 'comment' is declared here. The fix is to set the "NonSensitiveDiaryEntry[]" type instead of "DiaryEntry[]" type.