### PR TITLE
Update part3b.md

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -475,6 +475,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3001',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     }
   },


### PR DESCRIPTION
After making changes to the frontend to work with backend by changing the baseUrl.The development version of the frontend does not work with the change of the relative path to 'api/notes'(even the phonebook app). The remedy shown in the webpage is to add a proxy. Even after adding the proxy to vite config file the request to the backend is not successful. I found it not working because the notes was saved to the endpoint '/notes' path in the json development server and when node was used to create our own server the notes was saved to the endpoint '/api/notes/'. Hence adding proxy made the request to be sent to '/api/notes/' in the json development server(while running the react app in development mode) instead of '/notes'. To fix this it  was required to remove the '/api'. This was achieved using the rewrite attribute added to the '/api' javascript object which replaces the endpoint from '/api/notes' to '/notes'. This made the request work for me. The changes made are in the line 478.