### PR TITLE
Dead link to JoshBritz object equality, update to MDN docs

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -461,7 +461,7 @@ Note the use of the React developer tools extension in the picture above!
 
 <h4>2.7: The Phonebook Step 2</h4>
 
-Prevent the user from being able to add names that already exist in the phonebook. JavaScript arrays have numerous suitable [methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) for accomplishing this task. Keep in mind [how object equality works](https://www.joshbritz.co/blog/why-its-so-hard-to-check-object-equality/) in Javascript.
+Prevent the user from being able to add names that already exist in the phonebook. JavaScript arrays have numerous suitable [methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) for accomplishing this task. Keep in mind [how object equality works](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness) in Javascript.
 
 Issue a warning with the [alert](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) command when such an action is attempted:
 


### PR DESCRIPTION
The link out to JoshBritz.co about object equality in JavaScript is dead, looks like the site is down.

The following article from Mozilla seems likely to cover the same information:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness