### PR TITLE
import path with slight typo; seen on other Stack Overflow solutions, "../lib/.." is an import error/the culprit 

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -464,7 +464,7 @@ The file <i>index.js</i> is changed to:
 ```js
 // highlight-start
 const { WebSocketServer } = require('ws')
-const { useServer } = require('graphql-ws/lib/use/ws')
+const { useServer } = require('graphql-ws/use/ws')
 // highlight-end
 
 // ...

--- a/src/content/8/fi/osa8e.md
+++ b/src/content/8/fi/osa8e.md
@@ -468,7 +468,7 @@ Tiedosto <i>index.js</i> muuttuu seuraavasti
 ```js
 // highlight-start
 const { WebSocketServer } = require('ws')
-const { useServer } = require('graphql-ws/lib/use/ws')
+const { useServer } = require('graphql-ws/use/ws')
 // highlight-end
 
 // ...


### PR DESCRIPTION
When I follow the course instructions, I get this path export error:

`npm run graph   
//equivalent to npm run node library-backend.js (being the index.js for this file)                                               

> library-ql@1.0.0 graph
> node library-backend.js

node:internal/modules/cjs/loader:661
      throw e;
      ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/use/ws' is not defined by "exports" in /Users/jaycrawford/Documents/GitHub/FullStackOpenSubmissions/part8/library/node_modules/graphql-ws/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:661:9)
    at resolveExports (node:internal/modules/cjs/loader:654:36)
    at Function._findPath (node:internal/modules/cjs/loader:753:31)
    at Function._resolveFilename (node:internal/modules/cjs/loader:1396:27)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1061:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1066:22)
    at Function._load (node:internal/modules/cjs/loader:1215:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:234:24) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
`

by making the changes in the pull request, the server runs successfully

