### PR TITLE
Remove commented out duplicate code in part6b.md

### DIFF
--- a/src/content/6/en/part6b.md
+++ b/src/content/6/en/part6b.md
@@ -154,13 +154,6 @@ const store = createStore(reducer) // highlight-line
 
 console.log(store.getState())
 
-/*
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <Provider store={store}>
-    <App />
-  </Provider>
-)*/
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <Provider store={store}>
     <div />


### PR DESCRIPTION
There's two identical instances of:

ReactDOM.createRoot(document.getElementById('root')).render(
  <Provider store={store}>
    <div />
  </Provider>
)

One of them is commented out and doesn't seem to serve any purpose.