### PR TITLE
Update part8e.md to fix useServer import

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -533,6 +533,12 @@ const start = async () => {
 start()
 ```
 
+Note: in graphql-ws version ^6.0.0, the correct import is
+
+```js
+const { useServer } = require('graphql-ws/use/ws')
+```
+
 When queries and mutations are used, GraphQL uses the HTTP protocol in the communication. In case of subscriptions, the communication between client and server happens with [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
 
 The above code registers a WebSocketServer object to listen the WebSocket connections, besides the usual HTTP connections that the server listens to. The second part of the definition registers a function that closes the WebSocket connection on server shutdown.


### PR DESCRIPTION
GraphQL-ws version 6 changed the file structure of the useServer import.

old:
import { useServer } from 'graphql-ws/lib/use/ws'

new:
import { useServer } from 'graphql-ws/use/ws'


https://github.com/enisdenjo/graphql-ws/releases/tag/v6.0.0