### PR TITLE
Correct information about env context availability

### DIFF
--- a/src/content/11/en/part11d.md
+++ b/src/content/11/en/part11d.md
@@ -292,6 +292,8 @@ env:
 jobs:
   job1:
     # rest of the job
+    outputs:
+      condition: ${{ env.CONDITION }}
     steps:
       - if: ${{ env.CONDITION == 'true' }}
         run: echo 'this step is executed'
@@ -300,8 +302,9 @@ jobs:
         run: echo 'this step will not be executed'
 
   job2:
-    # this job will be dependent on the above env.CONDITION, note the `github.` prefix which seem to be required while referencing the variable on the job level, but not the step level
-    if: ${{ github.env.CONDITION == 'true' }}
+    # as env variables are not available at job level, we can use the output of job1 instead
+    needs: [job1]
+    if: ${{ needs.job1.outputs.condition == 'true' }}
     # rest of the job
 ```
 


### PR DESCRIPTION
To the best of my knowledge, the removed information was not correct. I have tried myself to access environment variable with `github.env`, and it doesn't work. I then went online only to find advice such as [this one](https://stackoverflow.com/questions/73558652/github-actions-how-to-use-environment-variable-at-job-level), which worked for me and which I changed in the materials.

[The officiall documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability) also doesn't mention availability at the `jobs` level, though I may be reading that incorrectly.