### PR TITLE
Suggest different Discord notification action

### DIFF
--- a/src/content/11/en/part11e.md
+++ b/src/content/11/en/part11e.md
@@ -39,7 +39,7 @@ Register now to Discord if you have not already done that. You will also need a 
 
 #### 11.18 Build success/failure notification action
 
-You can find quite a few third-party actions from [GitHub Action Marketplace](https://github.com/marketplace?type=actions) by using the search phrase [discord](https://github.com/marketplace?type=actions&query=discord). Pick one for this exercise. My choice was [discord-webhook-notify](https://github.com/marketplace/actions/discord-webhook-notify) since it has quite many stars and decent documentation.
+You can find quite a few third-party actions from [GitHub Action Marketplace](https://github.com/marketplace?type=actions) by using the search phrase [discord](https://github.com/marketplace?type=actions&query=discord). Pick one for this exercise. A good choice could be [Discord for GitHub Actions](https://github.com/marketplace/actions/actions-for-discord) since it has quite many stars, few dependencies, and simple implementation that directly uses Discord Webhook API fields.
 
 Setup the action so that it gives two types of notifications:
 - A success indication if a new version gets deployed


### PR DESCRIPTION
While the exercise description advises picking *any* action from the Marketplace that does the job, I found the inclusion of previous action to be misleading, as it is currently broken even for most basic functionality.

After using embarrassing amount of time to make sure the problem was not with me, I found an alternative that can create notifications identical to the one included in the screenshots (also much more robust, given its simplicity of implementation). See my own notifications for proof

![custom_notifications](https://github.com/user-attachments/assets/b6480adc-4f90-4a98-ad33-c263b6126f35)

*Ignore identical commit times for both notifications, that is not action's fault, but mine. I'm aware I shouldn't --force push, but that's outside of the scope of this PR*