### PR TITLE
part12b - highlight changed line

### DIFF
--- a/src/content/12/en/part12b.md
+++ b/src/content/12/en/part12b.md
@@ -560,7 +560,7 @@ services:
       MONGO_INITDB_DATABASE: the_database
     volumes:
       - ./mongo/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js
-      - mongo_data:/data/db
+      - mongo_data:/data/db # highlight-line
 
 volumes: # highlight-line
   mongo_data: # highlight-line


### PR DESCRIPTION
While syntactic difference might be small, semantically it's pretty significant, as it illustrates different types of volumes (bind mounts vs Docker's named volumes).

It's easy to miss this change, so I think it's important to highlight it.