### PR TITLE
Fix useServer import path for graphql-ws 6.0.4

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -464,7 +464,7 @@ The file <i>index.js</i> is changed to:
 ```js
 // highlight-start
 const { WebSocketServer } = require('ws')
-const { useServer } = require('graphql-ws/lib/use/ws')
+const { useServer } = require('graphql-ws/use/ws')
 // highlight-end
 
 // ...


### PR DESCRIPTION
npm installs "graphql-ws": "^6.0.4" in package.json. The new path to import useServer is 'graphql-ws/use/ws' instead of 'graphql-ws/lib/use/ws'.