### PR TITLE
Update part5b.md forwardRef

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -388,9 +388,9 @@ The [useRef](https://react.dev/reference/react/useRef) hook is used to create a 
 We also make the following changes to the <i>Togglable</i> component:
 
 ```js
-import { useState, forwardRef, useImperativeHandle } from 'react' // highlight-line
+import { useState, useImperativeHandle } from 'react' // highlight-line
 
-const Togglable = forwardRef((props, refs) => { // highlight-line
+const Togglable = (props) => { // highlight-line
   const [visible, setVisible] = useState(false)
 
   const hideWhenVisible = { display: visible ? 'none' : '' }
@@ -401,7 +401,7 @@ const Togglable = forwardRef((props, refs) => { // highlight-line
   }
 
 // highlight-start
-  useImperativeHandle(refs, () => {
+  useImperativeHandle(props.ref, () => {
     return {
       toggleVisibility
     }
@@ -419,12 +419,14 @@ const Togglable = forwardRef((props, refs) => { // highlight-line
       </div>
     </div>
   )
-})  // highlight-line
+}  // highlight-line
 
 export default Togglable
 ```
 
-The function that creates the component is wrapped inside of a [forwardRef](https://react.dev/reference/react/forwardRef) function call. This way the component can access the ref that is assigned to it.
+The reference assigned to the component can be accessed as a prop using `props.ref`.
+
+**NOTE:** Before React 19 the function that creates the component was supposed to be wrapped inside of a [forwardRef](https://react.dev/reference/react/forwardRef) function call to enable the component to access the ref assigned to it, that is no longer required, as it's now possible to access the ref as a prop.
 
 The component uses the [useImperativeHandle](https://react.dev/reference/react/useImperativeHandle) hook to make its <i>toggleVisibility</i> function available outside of the component.
 


### PR DESCRIPTION
Updated the code in the section "References to components with ref" section and added explanation relative to the deprecated function forwardRef (deprecated as of React 19) and the new way to access refs in react components as props.