### PR TITLE
Remove explicit italics styling that is implicitly included to <em> tag

### DIFF
--- a/src/content/2/en/part2e.md
+++ b/src/content/2/en/part2e.md
@@ -236,8 +236,7 @@ Next, we could add a "bottom block" to our application by creating a <i>Footer</
 const Footer = () => {
   const footerStyle = {
     color: 'green',
-    fontStyle: 'italic',
-    fontSize: 16
+    fontSize: 18
   }
 
   return (


### PR DESCRIPTION
The example shows the following CSS applied to `Footer`:
```
const footerStyle = {
    color: 'green',
    fontStyle: 'italic',
    fontSize: 16
  }
```


However, explicitly specified `fontStyle: 'italic'` and `fontSize: 16` properties don't make any difference, as `<em>` already makes the text in `italic` style, and the footer font size is `16` by default (at least when rendered in Chrome).

To avoid any confusion for the students, I'd suggest removing `fontStyle: 'italic'` and updating `fontSize: 16` to `fontSize: 18`, so the custom styling does affect the appearance of the text.