### PR TITLE
Part6c: fix: add `dispatch` to useEffect dependency array

### DIFF
--- a/src/content/6/en/part6c.md
+++ b/src/content/6/en/part6c.md
@@ -234,7 +234,7 @@ const App = () => {
   useEffect(() => {
     noteService
       .getAll().then(notes => dispatch(setNotes(notes)))
-  }, [])
+  }, [dispatch])
   // highlight-end
 
   return (


### PR DESCRIPTION
Updated the useEffect dependency array in `App.js` to include dispatch

https://github.com/fullstack-hy2020/redux-notes/commit/2daea560ebb4501e58b0b8913f84ddea5585e56d#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R14

<img width="1470" alt="Screenshot 2025-04-18 at 11 56 39 AM" src="https://github.com/user-attachments/assets/d5e05ba3-e2bb-41b8-b464-9199d67d0f10" />
