### PR TITLE
Update part3c.md : typo

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -343,7 +343,7 @@ Person
   })
 ```
 
-**NB:** If you define a model with the name <i>Person</i>, mongoose will automatically name the associated collection as <i>people</i>.
+**NB:** If you define a model with the name <i>Person</i>, mongoose will automatically name the associated collection as <i>persons</i>.
 
 </div>
 


### PR DESCRIPTION
Corrected a small typo: 
"If you define a model with the name Person, mongoose will automatically name the associated collection as people."  The collection name should be "persons".