### PR TITLE
Update part8e.md

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -464,7 +464,7 @@ The file <i>index.js</i> is changed to:
 ```js
 // highlight-start
 const { WebSocketServer } = require('ws')
-const { useServer } = require('graphql-ws/lib/use/ws')
+const { useServer } = require('graphql-ws/use/ws')
 // highlight-end
 
 // ...


### PR DESCRIPTION
Updated `graphql-ws` import to match current version. Following the tutorial as it is currently, the code breaks because it cannot find the export path:

`const { useServer } = require("graphql-ws/lib/use/ws")`

![image](https://github.com/user-attachments/assets/71d9ccfb-6869-4abe-83a9-e8ed84f0d776)


I checked the `graphql-ws` docs and found the import path was different. Updated my code and everything works again:

`const { useServer } = require("graphql-ws/use/ws")`