### PR TITLE
Update part8e.md

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -589,7 +589,7 @@ const resolvers = {
   // highlight-start
   Subscription: {
     personAdded: {
-      subscribe: () => pubsub.asyncIterator('PERSON_ADDED')
+      subscribe: () => pubsub.asyncIterableIterator('PERSON_ADDED')
     },
   },
   // highlight-end
@@ -610,7 +610,7 @@ There are only a few lines of code added, but quite a lot is happening under the
 ```js
 Subscription: {
   personAdded: {
-    subscribe: () => pubsub.asyncIterator('PERSON_ADDED')
+    subscribe: () => pubsub.asyncIterableIterator('PERSON_ADDED')
   },
 },
 ```


### PR DESCRIPTION
Update use of `pubsub.asyncIterator` to `pubsub.asyncIterableIterator`.

Following the tutorial as it is currently, you get this error when you try to listen for subscriptions:

![image](https://github.com/user-attachments/assets/28b31a0e-94d9-4157-9ea1-9788ba52a4f4)

The current code makes use of `pubsub.asyncIterator`, but this method no longer exists and has been changed to `pubsub.asyncIterableIterator` in the latest `graphql-subscriptions` version. Updating the code with this makes everything work fine:

![image](https://github.com/user-attachments/assets/5e66807c-7d39-46b8-b7e9-7599da4028c8)
