### PR TITLE
Fix typo in Spanish translation

### DIFF
--- a/src/content/2/es/part2e.md
+++ b/src/content/2/es/part2e.md
@@ -306,7 +306,7 @@ Soluciona el problema según el ejemplo mostrado en [promesas y errores](/es/par
 
 ### Algunas observaciones importantes
 
-Al final de esta parte, hay algunos ejercicios más desafiantes. En este momento, puedes saltarte los ejercicios si son demasiado difíciles; volveremos a los mismos temas más adelante. De todas formas, vale la pena lee el material.
+Al final de esta parte, hay algunos ejercicios más desafiantes. En este momento, puedes saltarte los ejercicios si son demasiado difíciles; volveremos a los mismos temas más adelante. De todas formas, vale la pena leer el material.
 
 Hemos hecho algo en nuestra aplicación que enmascara una fuente muy típica de errores.
 


### PR DESCRIPTION
Minor correction in a Spanish sentence to improve grammar and clarity. Changed "vale la pena lee el material" to "vale la pena leer el material". No other content was changed.
