### PR TITLE
Update part11d.md

### DIFF
--- a/src/content/11/en/part11d.md
+++ b/src/content/11/en/part11d.md
@@ -209,12 +209,12 @@ on:
 
 jobs:
   simple_deployment_pipeline:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       // steps here
   tag_release:
     needs: [simple_deployment_pipeline]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       // steps here
 ```
@@ -255,7 +255,7 @@ on:
 
 jobs:
   a_test_job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: github context


### PR DESCRIPTION
Change workflow to run on Ubuntu 24.04 as 20.04 is unsupported in GitHub Actions as of 2025-04-15

https://github.com/actions/runner-images/issues/11101