### PR TITLE
Update part8e.md

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -464,7 +464,7 @@ The file <i>index.js</i> is changed to:
 ```js
 // highlight-start
 const { WebSocketServer } = require('ws')
-const { useServer } = require('graphql-ws/lib/use/ws')
+const { useServer } = require('graphql-ws/use/ws')
 // highlight-end
 
 // ...


### PR DESCRIPTION
fixing an import bug. the import path of 'useServer' has changed from `graphql-ws/lib/use/ws` to `graphql-ws/use/ws`.

installed with `graphql-ws^6.0.5`.

see: https://github.com/enisdenjo/graphql-ws/issues/617