### PR TITLE
Update part8e.md

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -589,7 +589,7 @@ const resolvers = {
   // highlight-start
   Subscription: {
     personAdded: {
-      subscribe: () => pubsub.asyncIterator('PERSON_ADDED')
+      subscribe: () => pubsub.asyncIterableIterator('PERSON_ADDED')
     },
   },
   // highlight-end


### PR DESCRIPTION
fix a pubsub method that's been renamed.

a newer version of the `PubSub` class from `graphql-subscriptions` defines the method `PubSub.asyncIterableIterator` instead of `PubSub.asyncIterator`.

see https://stackoverflow.com/questions/79302579/pubsub-error-property-asynciterator-does-not-exist-on-type-pubsubrecordstr.

i've used the code in my codebase and it works!

for reference:
```json
"dependencies": {
        "@apollo/server": "^4.12.2",
        "@as-integrations/express5": "^1.1.0",
        "@graphql-tools/schema": "^10.0.23",
        "bcrypt": "^6.0.0",
        "cors": "^2.8.5",
        "dotenv": "^16.5.0",
        "express": "^5.1.0",
        "graphql": "^16.11.0",
        "graphql-subscriptions": "^3.0.0",
        "graphql-ws": "^6.0.5",
        "json-web-token": "^3.2.0",
        "jsonwebtoken": "^9.0.2",
        "mongoose": "^7.8.7",
        "mongoose-unique-validator": "^4.0.1",
        "ws": "^8.18.2"
      }
```