### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/src/content/11/en/part11b.md
+++ b/src/content/11/en/part11b.md
@@ -281,6 +281,8 @@ jobs:
         run: npm run eslint # highlight-line
 ```
 
+ubunutu-20.04 is no longer supported on workflow. 22.04 works.
+
 Note that the _name_ of a step is optional, if you define a step as follows
 
 ```yml


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use `ubuntu-22.04` instead of the deprecated `ubuntu-20.04` runner.

GitHub scheduled the removal of the Ubuntu 20.04 runner on April 15, 2025:
> "Ubuntu 20.04 LTS runner will be removed on 2025-04-15."

Updating to ubuntu-22.04 ensures the workflow continues to function correctly after this date and aligns with GitHub's recommended runner version.

No other changes were made.
