### PR TITLE
docs: add warning about express-async-errors peer-dependency on Expre…

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -817,6 +817,8 @@ Let's install the library
 npm install express-async-errors
 ```
 
+**⚠️ Warning (Express 5 users):** Installing `express-async-errors` will fail due to its peer-dependency on Express 4.
+
 Using the library is <i>very</i> easy.
 You introduce the library in <i>app.js</i>, _before_ you import your routes:
 


### PR DESCRIPTION
Added a conspicuous markdown warning below the `npm install express-async-errors` instruction  to inform Express 5 users that the package currently declares a peer dependency on Express 4.