### PR TITLE
Docs: add Codespaces troubleshooting tips for c section of  Part 2

### DIFF
--- a/src/content/2/en/part2c.md
+++ b/src/content/2/en/part2c.md
@@ -346,6 +346,58 @@ This method could be acceptable in some circumstances, but it's somewhat problem
 
 What's not immediately obvious, however, is where the command <em>axios.get</em> should be placed within the component.
 
+### Codespaces Specific Notes for json-server setup:</span>
+
+If you are using GitHub Codespaces and encounter issues starting json-server or accessing it from your frontend, consider the following:
+
+1- Error: Cannot find module 'json-server':
+
+Check server.js vs server.cjs: If your package.json has "type": "module", Node.js expects ES Modules by default. If you use require('json-server') in a server script (e.g., server.js), you might need to rename it to server.cjs to explicitly tell Node.js to use CommonJS for that file.
+
+Persistent npm install issues: If json-server isn't found in node_modules even after npm install, try a deep cleanup:
+```Bash
+rm -rf node_modules
+rm package-lock.json
+npm cache clean --force
+npm install
+```
+If the issue persists, create a new, clean project folder, copy all your project files (except node_modules and package-lock.json) into it, and run npm install there. This often resolves environment-specific installation quirks.
+
+2- CORS Errors or 302 Redirects (github.dev/pf-signin):
+
+- Port Visibility in Codespaces: GitHub Codespaces often sets ports to "Private" by default. For your frontend to access json-server (even via a proxy), the backend port (e.g., 3001) needs to be accessible. Go to the "PORTS" tab in your Codespaces environment (usually at the bottom of VS Code), find port 3001, and change its Visibility to "Public".
+
+- Vite Proxy Configuration: To avoid CORS issues during development, it's best practice to proxy API requests through Vite's development server.
+
+  - Modify vite.config.js:
+    ```js
+    // vite.config.js
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173, // Your frontend port
+    proxy: {
+      '/notes': { // Or '/api' if your backend uses that prefix
+        target: 'https://<your-codespace-name>-3001.app.github.dev', // Replace with your actual json-server URL
+        changeOrigin: true,
+        // If your backend uses a prefix like /api, you might need:
+        // rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+})
+    ```
+  Important: Replace <your-codespace-name> with the actual unique part of your Codespaces URL (e.g., cuddly-meme-456pqv4vgrvc7prw).
+  
+- Update Axios requests: Change your Axios calls in App.jsx (and main.jsx if applicable) to use the relative path
+  ```js
+  // In src/main.jsx
+    axios.get('/notes') // Instead of 'http://localhost:3001/notes' or the full Codespaces URL
+
+
 ### Effect-hooks
 
 We have already used [state hooks](https://react.dev/learn/state-a-components-memory) that were introduced along with React version [16.8.0](https://www.npmjs.com/package/react/v/16.8.0), which provide state to React components defined as functions - the so-called <i>functional components</i>. Version 16.8.0 also introduces [effect hooks](https://react.dev/reference/react/hooks#effect-hooks) as a new feature. As per the official docs:


### PR DESCRIPTION
Hello Full Stack Open Team,

I am a student currently learning at the platform.
I started the course since a little while, and I am very grateful to the great work done by all contributors to make good resources for learners. I also noticed how updated was informations there. Thanks a lot 🙌 for the great job.

While working through Part 2 of the course ("Getting data from server"), I encountered significant challenges when integrating json-server with my React application, specifically while using GitHub Codespaces.
 After extensive debugging, i identified and resolved several recurring issues that could benefit from clearer guidance or a dedicated section in the course for Codespaces users.

**Problem_ Encountered (Initial Symptoms):**

1- Error: Cannot find module 'json-server' after npm install, even when the module was listed in package.json and node_modules appeared to be present.

2- CORS errors (No 'Access-Control-Allow-Origin' header is present) when accessing json-server from the React application.

3- 302 Redirects (ERR_FAILED 302 (Found)) to GitHub authentication pages (github.dev/pf-signin) during backend (json-server) requests via Codespaces.

**Environment Context:**

- Platform: GitHub Codespaces

- Project: Part 2 - "Getting data from server" (e.g., introdemo project)

- Technologies: React (Vite), json-server, Axios.

- _package.json_ configuration: "type": "module" for the frontend.

**Debugging Process and Solutions:**

1- Error: Cannot find module 'json-server' (Part 1)

- Initial Issue: Using require() in server.js while package.json specifies "type": "module".

- Solution: Renaming server.js to server.cjs to explicitly tell Node.js to use CommonJS for that specific file.

- Persistent Issue: Despite the .cjs extension and presence in package.json, the module was still not found in node_modules. This was a particularly stubborn problem.

- Solution: Performing a deep cleanup _(rm -rf node_modules, rm package-lock.json, npm cache clean --force_) followed by _npm install_ within the project directory. When this proved insufficient, the ultimate solution was to create a completely new project folder (e.g., introdemo-clean), copy all relevant project files (_src/, db.json, server.cjs, package.json_, etc., but WITHOUT _node_modules or package-lock.json_) into this new folder, and then run _npm install_ in the new, clean folder. This final step successfully allowed json-server to install correctly.

2- CORS Issues and 302 Redirects (github.dev/pf-signin)

- Initial Issue (CORS): json-server was not returning Access-Control-Allow-Origin headers. The --cors command-line option for json-server did not seem to work with my specific json-server version.

- Partial Solution: Using npx json-server -p 3001 db.json --host 0.0.0.0 directly in the package.json server script. This command inherently enables CORS for json-server.

- Persistent Issue (302 Redirect): Even with CORS seemingly enabled on json-server, Codespaces was redirecting requests to a GitHub authentication page, blocking access to the backend. This happened when the frontend, through the Vite proxy, tried to access the backend port.

- Solution: Changing the visibility of port 3001 in the "PORTS" tab within GitHub Codespaces from "Private" to "Public". This is a critical step to allow proper access to the json-server from the frontend in a Codespaces environment.

- Best Practice for development CORS: Configuring a Vite proxy in vite.config.js to seamlessly relay frontend requests (e.g., /notes) to the backend (https://cuddly-meme-456pqv4vgrvc7prw-3001.app.github.dev). This makes requests appear as if they come from the same origin to the browser, effectively bypassing CORS browser restrictions.

**Suggested Course Improvements:**

I believe adding a dedicated section or supplementary notes within Part 2 specifically addressing the use of GitHub Codespaces would be incredibly beneficial. Such guidance could cover:

- Procedures for deep cleanup and project folder re-creation in case of persistent npm install issues.

- The crucial importance of port visibility in Codespaces and how to set it to "Public".

- The configuration of a Vite proxy in vite.config.js as a standard solution for CORS issues during development in Codespaces.

This would significantly help future students avoid the hours of debugging I experienced.

Thank you very much for this excellent course!