### PR TITLE
To maintain consistency, the description of the fourth component has been removed.

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -532,7 +532,7 @@ This saves you from having to manually input data into your application for test
 
 If you have implemented your application in a single component, refactor it by extracting suitable parts into new components. Maintain the application's state and all event handlers in the <i>App</i> root component.
 
-It is sufficient to extract <i>**three**</i> components from the application. Good candidates for separate components are, for example, the search filter, the form for adding new people to the phonebook, a component that renders all people from the phonebook, and a component that renders a single person's details.
+It is sufficient to extract <i>**three**</i> components from the application. Good candidates for separate components are, for example, the search filter, the form for adding new people to the phonebook, and a component that renders all people from the phonebook.
 
 The application's root component could look similar to this after the refactoring. The refactored root component below only renders titles and lets the extracted components take care of the rest.
 


### PR DESCRIPTION
* Deleted the specific description of the fourth component mentioned in the example.
* Ensured the text now consistently refers to and describes three components, matching the initial statement.