### PR TITLE
clarification on axios request handling

### DIFF
--- a/src/content/2/en/part2d.md
+++ b/src/content/2/en/part2d.md
@@ -608,7 +608,7 @@ When we try to change the importance of the hardcoded note, we see the following
 
 The application should be able to handle these types of error situations gracefully. Users won't be able to tell that an error has occurred unless they happen to have their console open. The only way the error can be seen in the application is that clicking the button does not affect the note's importance.
 
-We had [previously](/en/part2/getting_data_from_server#axios-and-promises) mentioned that a promise can be in one of three different states. When an HTTP request fails, the associated promise is <i>rejected</i>. Our current code does not handle this rejection in any way.
+We had [previously](/en/part2/getting_data_from_server#axios-and-promises) mentioned that a promise can be in one of three different states. When an axios HTTP request fails, the associated promise is <i>rejected</i>. Our current code does not handle this rejection in any way.
 
 The rejection of a promise is [handled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) by providing the <em>then</em> method with a second callback function, which is called in the situation where the promise is rejected.
 


### PR DESCRIPTION
HTTP requests dont inherently reject promises, and requests executed trough fetch dont reject the promise on error codes like 4xx. It can be confusing when reading the sentence as is, because one could assume this is the behavior of every HTTP request. I suggest specifying it's axios requests that have that behavior.