### PR TITLE
Update part8e.md: replace asyncIterator with asyncIterableIterator

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -589,7 +589,7 @@ const resolvers = {
   // highlight-start
   Subscription: {
     personAdded: {
-      subscribe: () => pubsub.asyncIterator('PERSON_ADDED')
+      subscribe: () => pubsub.asyncIterableIterator('PERSON_ADDED')
     },
   },
   // highlight-end


### PR DESCRIPTION
v3 of graphql-subscriptions renamed the pubsub method to `asyncIterableIterator`