### PR TITLE
part8e: update import path for useServer

### DIFF
--- a/src/content/8/en/part8e.md
+++ b/src/content/8/en/part8e.md
@@ -464,7 +464,7 @@ The file <i>index.js</i> is changed to:
 ```js
 // highlight-start
 const { WebSocketServer } = require('ws')
-const { useServer } = require('graphql-ws/lib/use/ws')
+const { useServer } = require('graphql-ws/use/ws')
 // highlight-end
 
 // ...


### PR DESCRIPTION
Previous import path for `useServer` `graphql-ws/lib/use/ws` leads to runtime error `useServer is not a function`

`graphql-ws` v6 updated path to `graphql-ws/use/ws`