### PR TITLE
Fix ApolloClient initialization for newer versions

### DIFF
--- a/src/content/8/en/part8b.md
+++ b/src/content/8/en/part8b.md
@@ -35,11 +35,13 @@ We'll start with the following code for our application:
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
-import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
+import { ApolloClient, InMemoryCache, HttpLink, gql } from '@apollo/client'
 
 const client = new ApolloClient({
-  uri: 'http://localhost:4000',
   cache: new InMemoryCache(),
+  link: new HttpLink({
+    uri: 'http://localhost:4000',
+  }),
 })
 
 const query = gql`


### PR DESCRIPTION
The previous ApolloClient setup used:

const client = new ApolloClient({
  uri: 'http://localhost:4000',
  cache: new InMemoryCache(),
})

Using Apollo Client 4.0.3, this results in the error:

Uncaught Invariant Violation: To initialize Apollo Client, you must specify a 'link' property.

This update adds an explicit HttpLink:

const client = new ApolloClient({
  cache: new InMemoryCache(),
  link: new HttpLink({ uri: 'http://localhost:4000' }),
});

This ensures compatibility with newer Apollo Client releases without changing existing functionality.