### PR TITLE
Fix ApolloProvider import for React compatibility

### DIFF
--- a/src/content/8/en/part8b.md
+++ b/src/content/8/en/part8b.md
@@ -84,9 +84,10 @@ The application can communicate with a GraphQL server using the *client* object.
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
+import { ApolloProvider } from '@apollo/client/react' // highlight-line
+
 import {
   ApolloClient,
-  ApolloProvider, // highlight-line
   InMemoryCache,
 } from '@apollo/client'
 


### PR DESCRIPTION
In the current course material, ApolloProvider is imported as:

import {
  ApolloClient,
  ApolloProvider,
  InMemoryCache,
} from '@apollo/client'

With recent versions of Apollo Client, this produces the error:

Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/@apollo_client.js?v=8222a40d' does not provide an export named 'ApolloProvider'

This happens because ApolloProvider is now exported from a separate submodule for React. 

The fix is to import ApolloProvider from '@apollo/client/react' instead:

import { ApolloProvider } from '@apollo/client/react';

This follows the official Apollo documentation:
https://www.apollographql.com/docs/react/get-started#step-4-connect-your-client-to-react

**Corresponding course part:** Part 8