### PR TITLE
Update part12c.md

### DIFF
--- a/src/content/12/en/part12c.md
+++ b/src/content/12/en/part12c.md
@@ -525,7 +525,7 @@ To help us, Docker Compose has set up a network when we ran _docker compose up_.
 Since we are inside the container, we can also test the DNS! Let's curl the service name (app) in port 5173
 
 ```html
-root@374f9e62bfa8:\# curl http://app:5173
+/ # curl http://app:5173
 <!doctype html>
 <html lang="en">
   <head>


### PR DESCRIPTION
Use the same Nginx version (`nginx:1.25-alpine`) as earlier (Part 12c: Using multiple stages) instead of `nginx:1.20.1`.

`bash` is not included in Alpine-based images (like `nginx:1.25-alpine`).
Got this error:
> OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown

Use `sh` instead of `bash`: `docker exec -it reverse-proxy sh`