### PR TITLE
Part8: Fix the function to get error message

### DIFF
--- a/src/content/8/en/part8b.md
+++ b/src/content/8/en/part8b.md
@@ -598,7 +598,7 @@ const PersonForm = ({ setError }) => {
     refetchQueries: [  {query: ALL_PERSONS } ],
     // highlight-start
     onError: (error) => {
-      const messages = error.graphQLErrors.map(e => e.message).join('\n')
+      const messages = error.message
       setError(messages)
     }
     // highlight-end


### PR DESCRIPTION
The original error handling method is broken in Apollo Client 4. This is a simple way to fix it.