### PR TITLE
React no longer uses "Vite + React" for title

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -87,7 +87,7 @@ By default, the file <i>index.html</i> doesn't contain any HTML markup that is v
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>introdemo</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION


React no longer uses "Vite + React" for title. Instead it uses the directory name. since your directory is named "introdemo", that is what it is now in index.html