### PR TITLE
Add GitHub link to example applications reference

### DIFF
--- a/src/content/0/en/part0a.md
+++ b/src/content/0/en/part0a.md
@@ -29,7 +29,7 @@ The material contains exercises, which are placed so that the preceding material
 
 In many parts of the course, the exercises build one larger application one small piece at a time. Some of the exercise applications are developed through multiple parts.
 
-The course material is based on incrementally expanding example applications, which change from part to part. It's best to follow the code along while making small modifications independently. The code of the example applications for each step of each part can be found on GitHub.
+The course material is based on incrementally expanding example applications, which change from part to part. It's best to follow the code along while making small modifications independently. The code of the example applications for each step of each part can be found on [GitHub](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io).
 
 ### Taking the course
 


### PR DESCRIPTION
The course material mentions that the code for the example applications can be found on GitHub, but no link was provided.   I couldn’t find a direct repo or folder that contains all of the example applications in one place, but I added a link to the official course repository (https://github.com/fullstack-hy2020/fullstack-hy2020.github.io) so that readers have at least one starting point to navigate from.