### PR TITLE
Clarify HTTP GET route handling in exercise 3.18

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -953,7 +953,7 @@ Verify that the frontend works after making your changes.
 
 #### 3.18*: Phonebook database step 6
 
-Also update the handling of the <i>api/persons/:id</i> and <i>info</i> routes to use the database, and verify that they work directly with the browser, Postman, or VS Code REST client.
+Also update the handling of the HTTP GET <i>api/persons/:id</i> and <i>info</i> routes to use the database, and verify that they work directly with the browser, Postman, or VS Code REST client.
 
 Inspecting an individual phonebook entry from the browser should look like this:
 


### PR DESCRIPTION
The text "handling of the api/persons/:id and info routes" is a bit ambiguous since exercise 3.17 requires you to also implement a route with path api/persons/:id (HTTP PUT request), as did exercise 3.15 (HTTP DELETE request). I think adding HTTP GET in the exercise makes it a bit more clear to the student that it is the GET /api/persons/:id and GET /info routes that are to be updated in this exercise.