### PR TITLE
Fix linting issue

### DIFF
--- a/src/content/6/en/part6c.md
+++ b/src/content/6/en/part6c.md
@@ -526,7 +526,7 @@ export const initializeNotes = () => {
 export const appendNote = (content) => {
   return async (dispatch) => {
     const newNote = await noteService.createNew(content)
-    dispatch(noteSlice.actions.createNote(newNote))
+    dispatch(createNote(newNote))
   }
 }
 // highlight-end

--- a/src/content/6/fi/osa6c.md
+++ b/src/content/6/fi/osa6c.md
@@ -525,7 +525,7 @@ export const initializeNotes = () => {
 export const appendNote = (content) => {
   return async (dispatch) => {
     const newNote = await noteService.createNew(content)
-    dispatch(noteSlice.actions.createNote(newNote))
+    dispatch(createNote(newNote))
   }
 }
 // highlight-end


### PR DESCRIPTION
## Location

Part 6c; Final version of ```noteReducer.js```

## Summary
In the final version of ```noteReducer.js``` in Part 6c, ```createNote``` was deconstructed but never used. So instead, use ```createNote``` in ```appendNote``` action creator so [no-unused-vars](https://eslint.org/docs/latest/rules/no-unused-vars) warning wouldn't appear.

(Basically do what [this commit](https://github.com/fullstack-hy2020/redux-notes/commit/6de3cb41282f0115894af84540dc4880ce05610f) does but don't forget about ```createNote```)