### PR TITLE
Missing close parenthesis and close curly brace in Togglable test in part 5c

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -482,6 +482,7 @@ describe('<Togglable />', () => {
     const element = screen.getByText('togglable content')
     expect(element).toBeVisible()
   })
+})
 ```
 
 The _beforeEach_ function gets called before each test, which then renders the <i>Togglable</i> component.


### PR DESCRIPTION
Missing close parenthesis and close curly brace in Togglable test in part 5c. If you try and copy and paste the code into Togglable.test.jsx without the close parenthesis and close curly brace you will get a syntax error when running the test.