### PR TITLE
Changed page.post to request.post after changing baseURL in part 5d section Helper functions for tests

### DIFF
--- a/src/content/5/en/part5d.md
+++ b/src/content/5/en/part5d.md
@@ -980,14 +980,14 @@ All the commands in the tests that use the application url, e.g.
 
 ```js
 await page.goto('http://localhost:5173')
-await page.post('http://localhost:5173/api/testing/reset')
+await request.post('http://localhost:5173/api/testing/reset')
 ```
 
 can now be transformed into:
 
 ```js
 await page.goto('/')
-await page.post('/api/testing/reset')
+await request.post('/api/testing/reset')
 ```
 
 The current code for the tests is on [GitHub](https://github.com/fullstack-hy2020/notes-e2e/tree/part5-2), branch <i>part5-2</i>.


### PR DESCRIPTION
In part 5d section _Helper functions for tests_, the correct function call here is request.post(...), not page.post(...). The sample code has been modified to reflect this.