### PR TITLE
docs(part1d): Fix minor grammatical issue in "Do Not Define Components Within Components"

### DIFF
--- a/src/content/1/en/part1d.md
+++ b/src/content/1/en/part1d.md
@@ -1084,7 +1084,7 @@ const App = () => {
 }
 ```
 
-The application still appears to work, but **don't implement components like this!** Never define components inside of other components. The method provides no benefits and leads to many unpleasant problems. The biggest problems are because React treats a component defined inside of another component as a new component in every render. This makes it impossible for React to optimize the component.
+The application still appears to work, but **do not implement components like this!** Never define components inside of other components. The method provides no benefits and only leads to problems. One such problem is that React will treat a component defined inside of another component as a "new component" in every render. This makes it impossible for React to optimize the component.
 
 Let's instead move the <i>Display</i> component function to its correct place, which is outside of the <i>App</i> component function:
 


### PR DESCRIPTION
- Changed "The biggest problems are" to "One such problem is" because of grammatical issues
- Replace "don't" with "do not" to emphasize that the reader should *not* implement components a certain way
- Place quotations around `"new component"` to show that React's interpretation of a component inside a component is not *really* a new component
