### PR TITLE
Fix Apollo imports in part8b.md

### DIFF
--- a/src/content/8/en/part8b.md
+++ b/src/content/8/en/part8b.md
@@ -86,9 +86,9 @@ import App from './App'
 
 import {
   ApolloClient,
-  ApolloProvider, // highlight-line
   InMemoryCache,
 } from '@apollo/client'
+import { ApolloProvider } from "@apollo/client/react"; // highlight-line
 
 const client = new ApolloClient({
   uri: 'http://localhost:4000',
@@ -112,7 +112,8 @@ Currently, the use of the hook function [useQuery](https://www.apollographql.com
 The query is made by the <i>App</i> component, the code of which is as follows:
 
 ```js
-import { gql, useQuery } from '@apollo/client'
+import { gql } from '@apollo/client'
+import { useQuery } from "@apollo/client/react";
 
 const ALL_PERSONS = gql`
 query {


### PR DESCRIPTION
Updated imports for ApolloProvider and useQuery to use the correct paths.

In the latest Apollo (v4) the react components and hooks have been moved to "@apollo/client/react"