### PR TITLE
Fix a small bug in Part5C

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -699,8 +699,9 @@ test('<NoteForm /> updates parent state and calls onSubmit', () => {
   const input = screen.getByLabelText('content') // highlight-line
   const sendButton = screen.getByText('save')
 
-  userEvent.type(input, 'testing a form...' )
-  userEvent.click(sendButton)
+  const user = userEvent.setup()
+  await user.type(input, 'testing a form...' )
+  await user.click(sendButton)
 
   expect(createNote.mock.calls).toHaveLength(1)
   expect(createNote.mock.calls[0][0].content).toBe('testing a form...' )
@@ -745,8 +746,9 @@ test('<NoteForm /> updates parent state and calls onSubmit', () => {
   const input = screen.getByPlaceholderText('write note content here') // highlight-line 
   const sendButton = screen.getByText('save')
 
-  userEvent.type(input, 'testing a form...')
-  userEvent.click(sendButton)
+  const user = userEvent.setup()
+  await user.type(input, 'testing a form...')
+  await user.click(sendButton)
 
   expect(createNote.mock.calls).toHaveLength(1)
   expect(createNote.mock.calls[0][0].content).toBe('testing a form...')


### PR DESCRIPTION
After [@testing-library/user-event v14](https://github.com/testing-library/user-event/releases/tag/v14.0.0), APIs now return promises. Lots of examples had already been updated, but a few outdated snippets remained. This patch updates the remaining snippets.