### PR TITLE
Part8d: Refactor LoginForm component

### DIFF
--- a/src/content/8/en/part8d.md
+++ b/src/content/8/en/part8d.md
@@ -54,7 +54,7 @@ The *LoginForm* component works pretty much just like all the other components d
 Interesting lines in the code have been highlighted:
 
 ```js
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useMutation } from '@apollo/client/react'
 import { LOGIN } from '../queries'
 
@@ -62,26 +62,22 @@ const LoginForm = ({ setError, setToken }) => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
 
-  const [ login, result ] = useMutation(LOGIN, { // highlight-line
+  const [ login ] = useMutation(LOGIN, { // highlight-line
     onError: (error) => {
       setError(error.graphQLErrors[0].message)
     }
   })
 
-// highlight-start
-  useEffect(() => {
-    if ( result.data ) {
+  const submit = async (event) => {
+    event.preventDefault()
+    //highlight-start
+    const result = await login({ variables: { username, password } })
+    if (result.data) {
       const token = result.data.login.value
       setToken(token)
       localStorage.setItem('phonenumbers-user-token', token)
     }
-  }, [result.data])
-// highlight-end
-
-  const submit = async (event) => {
-    event.preventDefault()
-
-    login({ variables: { username, password } })
+    //highlight-end
   }
 
   return (
@@ -108,9 +104,6 @@ const LoginForm = ({ setError, setToken }) => {
 
 export default LoginForm
 ```
-
-We are using an effect hook to save the token's value to the state of the *App* component and the local storage after the server has responded to the mutation.
-Use of the effect hook is necessary to avoid an endless rendering loop.
 
 Let's also add a button which enables a logged-in user to log out. The button's onClick handler sets the *token* state to null, removes the token from local storage and resets the cache of the Apollo client. The last step is [important](https://www.apollographql.com/docs/react/networking/authentication/#reset-store-on-logout), because some queries might have fetched data to cache, which only logged-in users should have access to.
 


### PR DESCRIPTION
Refactor LoginForm to remove useEffect and handle login directly in submit function. Update import statement to suit.

Reasoning: I don't see much benefit in useEffect here. The function returned by useMutation can be awaited for the result, so the setting of the token and saving to localStorage can both be handled inside the submit function.