### PR TITLE
Part8d: Adding a token to a header. Replace setContext with SetContextLink in Apollo setup

### DIFF
--- a/src/content/8/en/part8d.md
+++ b/src/content/8/en/part8d.md
@@ -166,10 +166,10 @@ After the backend changes, creating new persons requires that a valid user token
 ```js
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client'  // highlight-line
 import { ApolloProvider } from '@apollo/client/react'
-import { setContext } from '@apollo/client/link/context' // highlight-line
+import { SetContextLink } from '@apollo/client/link/context' // highlight-line
 
 // highlight-start
-const authLink = setContext((_, { headers }) => {
+const authLink  = new SetContextLink(({ headers }) => {
   const token = localStorage.getItem('phonenumbers-user-token')
   return {
     headers: {


### PR DESCRIPTION
From @apollo/client v4 setContext is now SetContextLink.

fixes #4202 