### PR TITLE
Part 5b: Using 'ref' directly is not allowed.

### DIFF
--- a/src/content/5/en/part5b.md
+++ b/src/content/5/en/part5b.md
@@ -374,6 +374,7 @@ const App = () => {
   const noteFormRef = useRef() // highlight-line
 
   const noteForm = () => (
+// (Using 'ref' throws an error. According to this, https://react.dev/warnings/special-props, 'ref' and 'key' "are two special props which are used by React, and are thus not forwarded to the component". It should be renamed to something else.)
     <Togglable buttonLabel='new note' ref={noteFormRef}>  // highlight-line
       <NoteForm createNote={addNote} />
     </Togglable>
@@ -401,6 +402,7 @@ const Togglable = (props) => { // highlight-line
   }
 
 // highlight-start
+// It should be renamed here too
   useImperativeHandle(props.ref, () => {
     return { toggleVisibility }
   })


### PR DESCRIPTION
Using 'ref' directly is not allowed as it it a special prop (along with 'key') in React which cannot be forwarded to the component. See here https://react.dev/warnings/special-props. It should be renamed to something else.