### PR TITLE
Fix typo in object literals section

### DIFF
--- a/src/content/1/en/part1b.md
+++ b/src/content/1/en/part1b.md
@@ -126,7 +126,7 @@ Above, the variable _first_ is assigned the first integer of the array and the v
 
 ### Objects
 
-There are a few different ways of defining objects in JavaScript. One very common method is using [object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Object_literals), which happens by listing its properties within braces:
+There are a few different ways of defining objects in JavaScript. One very common method is using [object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals), which happens by listing its properties within braces:
 
 ```js
 const object1 = {


### PR DESCRIPTION
link fix - #object_literals
Link in course does not redirect to Object literals section in the page but just links to the Grammar_and_types page.
(Actual link has a non-capitalised letter o in object_literals)