### PR TITLE
Refactor ESLint config to resolve tseslint.config deprecation warnings

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -904,25 +904,25 @@ npm install --save-dev eslint @eslint/js @types/eslint__js typescript typescript
 We will configure ESlint to [disallow explicit any](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-explicit-any.mdx). Write the following rules to *eslint.config.mjs*:
 
 ```js
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
 
-export default tseslint.config({
-  files: ['**/*.ts'],
-  extends: [
-    eslint.configs.recommended,
-    ...tseslint.configs.recommendedTypeChecked,
-  ],
-  languageOptions: {
-    parserOptions: {
-      project: true,
-      tsconfigRootDir: import.meta.dirname,
+export default [
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
-  rules: {
-    '@typescript-eslint/no-explicit-any': 'error',
-  },
-});
+];
 ```
 
 Let us also set up a *lint* npm script to inspect the files by modifying the *package.json* file:
@@ -955,39 +955,39 @@ npm install --save-dev @stylistic/eslint-plugin
 Our final *eslint.config.mjs* looks as follows:
 
 ```js
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
 import stylistic from "@stylistic/eslint-plugin";
 
-export default tseslint.config({
-  files: ['**/*.ts'],
-  extends: [
-    eslint.configs.recommended,
-    ...tseslint.configs.recommendedTypeChecked,
-  ],
-  languageOptions: {
-    parserOptions: {
-      project: true,
-      tsconfigRootDir: import.meta.dirname,
+export default [
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
-  },
-  plugins: {
-    "@stylistic": stylistic,
-  },
-  rules: {
-    '@stylistic/semi': 'error',
-    '@typescript-eslint/no-unsafe-assignment': 'error',
-    '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/restrict-template-expressions': 'off',
-    '@typescript-eslint/restrict-plus-operands': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      'error',
-      { 'argsIgnorePattern': '^_' }
-    ],
-  },
-});
+    plugins: {
+      "@stylistic": stylistic,
+    },
+    rules: {
+      "@stylistic/semi": "error",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "@typescript-eslint/restrict-plus-operands": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
+    },
+  }
+];
 ```
 
 Quite a few semicolons are missing, but those are easy to add. We also have to solve the ESlint issues concerning the *any* type:


### PR DESCRIPTION
This PR updates the ESLint configuration file ([eslint.config.mjs](code-assist-path:c:\Users\HP\Desktop\fso\fullstackopen\part9\WebExercises\eslint.config.mjs)) to fix deprecation warnings related to typescript-eslint.

### Changes:


- Replaced the tseslint.config() helper function with a standard array export (export default [...]).
- Removed the deprecated extends property usage inside the config object.
- Manually spread tseslint.configs.recommendedTypeChecked into the flat config array.

### Reason for Change: 

The tseslint.config helper (specifically the signature accepting extends) is deprecated in newer versions of typescript-eslint. Switching to a native array export for ESLint's Flat Config format resolves the following warning:


> The signature '(...configs: InfiniteDepthConfigWithExtends[]): ConfigArray' of 'tseslint.config' is deprecated.



### Verification:

Run `npm run lint` to ensure linting still functions correctly without the warning.