### PR TITLE
docs(part4a): Clarify explanation of exporting and importing multiple modules

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -376,7 +376,7 @@ const Note = require('../models/note')
 module.exports = notesRouter // highlight-line
 ```
 
-Because only one "thing" exported, it can only be imported and used as one object:
+Because only one "thing" is exported, it can only be imported and used as one object:
 
 ```js
 const notesRouter = require('./controllers/notes')


### PR DESCRIPTION
In part 4a, there is a section of text that explains how to import and export multiple functions. However, it does not transition cleanly into a case where only one "thing" is exported and imported.

This PR fixes that by providing a clear transition to that specific case and rewords the explanation to fit that transition.