### PR TITLE
Part 5b: update heading to match React 19 content

### DIFF
--- a/src/content/partnavigation/partnavigation.js
+++ b/src/content/partnavigation/partnavigation.js
@@ -99,7 +99,7 @@ module.exports = {
     },
     5: {
       a: 'Login in frontend',
-      b: 'props.children and proptypes',
+      b: 'props.children and component refs',
       c: 'Testing React apps',
       d: 'End to end testing: Playwright',
       e: 'End to end testing: Cypress',


### PR DESCRIPTION
The heading for Part 5b currently includes "proptypes," but the curriculum has been updated to remove the prop-types library in favor of React 19 patterns.

### Changes:
Updated src/content/en/part5/part5b.md heading to "props.children and component refs".

### Note on Translations:
I have only updated the English version. The following headings still contain the outdated "proptypes" reference in their headings:
- [ ] fi
- [ ] zh
- [ ] es
- [ ] fr
- [ ] pt