### PR TITLE
Part 9c: Update broken link for Zod error handling

### DIFF
--- a/src/content/9/en/part9c.md
+++ b/src/content/9/en/part9c.md
@@ -1611,7 +1611,7 @@ export const toNewDiaryEntry = (object: unknown): NewDiaryEntry => {
 };
 ```
 
-With the help from [documentation](https://zod.dev/ERROR_HANDLING) we could also improve the error handling:
+With the help from [documentation](https://zod.dev/basics?id=handling-errors) we could also improve the error handling:
 
 ```js
 router.post('/', (req, res) => {


### PR DESCRIPTION
The current link in the lecture return 404. From the doc, this is what I found regarding error handling

https://zod.dev/basics?id=handling-errors

<img width="1728" height="1011" alt="Screenshot 2026-01-23 at 06-14-47 Basic usage Zod" src="https://github.com/user-attachments/assets/ac64b643-e825-4d55-9fa9-713cd0601d50" />
