### PR TITLE
Part 9d: Update broken link for types of useState function.

### DIFF
--- a/src/content/9/en/part9d.md
+++ b/src/content/9/en/part9d.md
@@ -614,7 +614,7 @@ The type of the returned array is the following:
 [string, React.Dispatch<React.SetStateAction<string>>]
 ```
 
-So the first element, assigned to *newNote* is a string and the second element that we assigned *setNewNote* has a slightly more complex type. We notice that there is a string mentioned there, so we know that it must be the type of a function that sets a valued data. See [here](https://codewithstyle.info/Using-React-useState-hook-with-TypeScript/) if you want to learn more about the types of useState function.
+So the first element, assigned to *newNote* is a string and the second element that we assigned *setNewNote* has a slightly more complex type. We notice that there is a string mentioned there, so we know that it must be the type of a function that sets a valued data. See [here](https://web.archive.org/web/20241224052343/https://codewithstyle.info/Using-React-useState-hook-with-TypeScript/) if you want to learn more about the types of useState function.
 
 From all this we see that TypeScript has indeed [inferred](https://www.typescriptlang.org/docs/handbook/type-inference.html#handbook-content) the type of the first useState correctly, a state with type string is created.
 


### PR DESCRIPTION
The original link 
https://codewithstyle.info/Using-React-useState-hook-with-TypeScript/
is broken. However there is a snapshot of the page on Way back machine.

https://web.archive.org/web/20241224052343/https://codewithstyle.info/Using-React-useState-hook-with-TypeScript/

<img width="3370" height="1596" alt="Screenshot 2026-01-24 at 05-14-25 React useState Hook with TypeScript The Complete Guide - codewithstyle info" src="https://github.com/user-attachments/assets/d331fd94-a291-499c-ab0d-0dde8ee3af55" />
