### PR TITLE
Part 9B: Clarification to command line argument indexing

### DIFF
--- a/src/content/9/en/part9b.md
+++ b/src/content/9/en/part9b.md
@@ -377,6 +377,8 @@ The reason for this is, that *Number('lol')* returns *NaN*, which is actually of
 
 To prevent this kind of behavior, we have to validate the data given to us from the command line.
 
+(Note that command line arguments start from process.argv[2], as index 0 is the Node binary path and index 1 is the script path.)
+
 The improved version of the multiplicator looks like this:
 
 ```js


### PR DESCRIPTION
Added note about command line argument indexing. 

Spent a day wondering why my ex. 9.3 code didn't work, because I couldn't understand how and why the arguments parsing worked, so I thought this change to the material might help the students in the future.