### PR TITLE
Part4b(en): fix mistake in the link title for the --test-name-pattern

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -371,7 +371,7 @@ The following command only runs the tests found in the <i>tests/note_api.test.js
 npm test -- tests/note_api.test.js
 ```
 
-The [--tests-by-name-pattern](https://nodejs.org/api/test.html#filtering-tests-by-name) option can be used for running tests with a specific name:
+The [--test-name-pattern](https://nodejs.org/api/test.html#filtering-tests-by-name) option can be used for running tests with a specific name:
 
 ```js
 npm test -- --test-name-pattern="a specific note is within the returned notes"


### PR DESCRIPTION
The option name in the link title is incorrect.

It should be:
--test-by-name

Instead of:
--tests-by-name-pattern