### PR TITLE
Simplify import statement for useCounter

### DIFF
--- a/src/content/6/en/part6c.md
+++ b/src/content/6/en/part6c.md
@@ -957,7 +957,7 @@ export default useCounter
 Using the context is now one step simpler:
 
 ```js
-import { useCounter } from '../hooks/useCounter'
+import useCounter from '../hooks/useCounter'
 
 const Display = () => {
   const { counter } = useCounter()


### PR DESCRIPTION
I may be missing something, so feel free to turned this down. However, if you're exporting something as the default...

```
export default useCounter
```

Then my understanding is that you don't need to import that thing as a named import 

```
import { useCounter } from '../hooks/useCounter'
```

You can instead just use

```
import useCounter from '../hooks/useCounter'
```