### PR TITLE
Update setup instructions for routed-anecdotes

### DIFF
--- a/src/content/7/en/part7a.md
+++ b/src/content/7/en/part7a.md
@@ -594,12 +594,17 @@ Let's once again return to working with anecdotes. Use the app found in the repo
 
 If you clone the project into an existing git repository, remember to delete the git configuration of the cloned application:
 
+```bash
 cd routed-anecdotes   // go first to directory of the cloned repository
 rm -rf .git
+```
+
 The application starts the usual way, but first, you need to install its dependencies:
 
+```bash
 npm install
 npm run dev
+```
 
 #### 7.1: useField hook
 


### PR DESCRIPTION
Added markdown to bash commands.

> cd routed-anecdotes // go first to directory of the cloned repository rm -rf .git The application starts the usual way, but first, you need to install its dependencies:
>
> npm install npm run dev

This appears as plain text, which stands out from other instances where formatting is used. 

For example, later on the page "npm run server" appears as:

```bash
npm run server
```