### PR TITLE
Fix comment syntax for simulated error example

### DIFF
--- a/src/content/7/en/part7d.md
+++ b/src/content/7/en/part7d.md
@@ -49,7 +49,7 @@ You can simulate a rendering error by temporarily throwing an exception inside o
 
 ```js
 const BlogList = ({ blogs }) => {
-  throw new Error('simulated error') /*/ highlight line
+  throw new Error('simulated error') // highlight line
   return (
     // ...
   )


### PR DESCRIPTION
There's an extra character in the highlight line syntax with "7.8: Error boundary". It's not actually highlighting the line currently, and is rendering as...

```
  throw new Error('simulated error') /*/ highlight line
``` 

...on the page.