### PR TITLE
typo: index.jsx to main.jsx

### DIFF
--- a/src/content/7/en/part7b.md
+++ b/src/content/7/en/part7b.md
@@ -82,7 +82,7 @@ Let us now create a simple React app with the following directory structure:
 ├── dist
 │   └── index.html
 ├── src
-│   ├── index.jsx
+│   ├── main.jsx
 │   └── App.jsx
 └── package.json
 ```


### PR DESCRIPTION
Directory structure shows index.jsx but all scripts point to main.jsx