### PR TITLE
Simplify import statement for useCounter hook

### DIFF
--- a/src/content/6/en/part6c.md
+++ b/src/content/6/en/part6c.md
@@ -957,14 +957,14 @@ export default useCounter
 Using the context is now one step simpler:
 
 ```js
-import { useCounter } from '../hooks/useCounter'
+import useCounter from '../hooks/useCounter'
 
 const Display = () => {
   const { counter } = useCounter()
   // ...
 }
 
-import { useCounter } from '../hooks/useCounter'
+import useCounter from '../hooks/useCounter'
 
 const Controls = () => {
   const { increment, decrement, zero } = useCounter()


### PR DESCRIPTION
fixed import for ```useCounter``` hook in ```Defining the counter context in its own file```