### PR TITLE
docs: fix duplicate code snippet typo in Zustand selector example (Part 6a)

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -363,7 +363,9 @@ The solution works, but it has a significant drawback. Destructuring causes the 
 The best practice in Zustand is therefore to select from the state exactly only those parts that are needed in the given component. A component re-renders only when the part of the state it has selected changes. When instead writing:
 
 ```js
-  const { increment, decrement, zero } = useCounterStore() 
+const increment = useCounterStore(state => state.increment)
+const decrement = useCounterStore(state => state.decrement)
+const zero = useCounterStore(state => state.zero)Ï
 ```
 
 the component no longer reacts to changes in the counter value, because it has not selected it from the state.


### PR DESCRIPTION
### Description
Fixes a copy-paste snippet error in the Zustand state selection documentation section of `part6a.md`. 

### Context
The explanatory text states: *"When instead writing: ... the component no longer reacts to changes in the counter value"*. However, the code block directly beneath it mistakenly duplicated the original unoptimized destructuring snippet (`const { increment, decrement, zero } = useCounterStore()`) from line 359.

### Changes Made
Updated lines 365–367 to demonstrate the actual atomic selector pattern intended by the text:
```js
const increment = useCounterStore((state) => state.increment)
const decrement = useCounterStore((state) => state.decrement)
const zero = useCounterStore((state) => state.zero)
```