### PR TITLE
Part 3a: fix broken Express.js documentation links

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -318,9 +318,9 @@ app.get('/', (request, response) => {
 })
 ```
 
-The event handler function accepts two parameters. The first [request](http://expressjs.com/en/4x/api.html#req) parameter contains all of the information of the HTTP request, and the second [response](http://expressjs.com/en/4x/api.html#res) parameter is used to define how the request is responded to.
+The event handler function accepts two parameters. The first [request](https://expressjs.com/en/5x/api/request/) parameter contains all of the information of the HTTP request, and the second [response](https://expressjs.com/en/5x/api/response/) parameter is used to define how the request is responded to.
 
-In our code, the request is answered by using the [send](http://expressjs.com/en/4x/api.html#res.send) method of the _response_ object. Calling the method makes the server respond to the HTTP request by sending a response containing the string <code>\<h1>Hello World!\</h1></code> that was passed to the _send_ method. Since the parameter is a string, Express automatically sets the value of the <i>Content-Type</i> header to be <i>text/html</i>. The status code of the response defaults to 200.
+In our code, the request is answered by using the [send](https://expressjs.com/en/5x/api/response/#ressendbody) method of the _response_ object. Calling the method makes the server respond to the HTTP request by sending a response containing the string <code>\<h1>Hello World!\</h1></code> that was passed to the _send_ method. Since the parameter is a string, Express automatically sets the value of the <i>Content-Type</i> header to be <i>text/html</i>. The status code of the response defaults to 200.
 
 We can verify this from the <i>Network</i> tab in developer tools:
 
@@ -334,7 +334,7 @@ app.get('/api/notes', (request, response) => {
 })
 ```
 
-The request is responded to with the [json](http://expressjs.com/en/4x/api.html#res.json) method of the _response_ object. Calling the method will send the __notes__ array that was passed to it as a JSON formatted string. Express automatically sets the <i>Content-Type</i> header with the appropriate value of <i>application/json</i>.
+The request is responded to with the [json](https://expressjs.com/en/5x/api/response/#resjsonbody) method of the _response_ object. Calling the method will send the __notes__ array that was passed to it as a JSON formatted string. Express automatically sets the <i>Content-Type</i> header with the appropriate value of <i>application/json</i>.
 
 ![api/notes gives the formatted JSON data again](../../images/3/6new.png)
 
@@ -428,11 +428,11 @@ In some places (see e.g. [Richardson, Ruby: RESTful Web Services](http://shop.or
 
 ### Fetching a single resource
 
-Let's expand our application so that it offers a REST interface for operating on individual notes. First, let's create a [route](http://expressjs.com/en/guide/routing.html) for fetching a single resource.
+Let's expand our application so that it offers a REST interface for operating on individual notes. First, let's create a [route](https://expressjs.com/en/5x/guide/routing/) for fetching a single resource.
 
 The unique address we will use for an individual note is of the form <i>notes/10</i>, where the number at the end refers to the note's unique id number.
 
-We can define [parameters](http://expressjs.com/en/guide/routing.html#route-parameters) for routes in Express by using the colon syntax:
+We can define [parameters](https://expressjs.com/en/5x/guide/routing/#route-parameters) for routes in Express by using the colon syntax:
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -444,7 +444,7 @@ app.get('/api/notes/:id', (request, response) => {
 
 Now <code>app.get('/api/notes/:id', ...)</code> will handle all HTTP GET requests that are of the form <i>/api/notes/SOMETHING</i>, where <i>SOMETHING</i> is an arbitrary string.
 
-The <i>id</i> parameter in the route of a request can be accessed through the [request](http://expressjs.com/en/api.html#req) object:
+The <i>id</i> parameter in the route of a request can be accessed through the [request](https://expressjs.com/en/5x/api/request/) object:
 
 ```js
 const id = request.params.id
@@ -484,7 +484,7 @@ app.get('/api/notes/:id', (request, response) => {
 })
 ```
 
-Since no data is attached to the response, we use the [status](http://expressjs.com/en/4x/api.html#res.status) method for setting the status and the [end](http://expressjs.com/en/4x/api.html#res.end) method for responding to the request without sending any data.
+Since no data is attached to the response, we use the [status](https://expressjs.com/en/5x/api/response/#resstatuscode) method for setting the status and the [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) method for responding to the request without sending any data.
 
 The if-condition leverages the fact that all JavaScript objects are [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), meaning that they evaluate to true in a comparison operation. However, _undefined_ is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) meaning that it will evaluate to false.
 
@@ -549,7 +549,7 @@ If you use *IntelliJ WebStorm* instead, you can use a similar procedure with its
 
 Next, let's make it possible to add new notes to the server. Adding a note happens by making an HTTP POST request to the address <http://localhost:3001/api/notes>, and by sending all the information for the new note in the request [body](https://www.rfc-editor.org/rfc/rfc9112#name-message-body) in JSON format.
 
-To access the data easily, we need the help of the Express [json-parser](https://expressjs.com/en/api.html) that we can use with the command _app.use(express.json())_.
+To access the data easily, we need the help of the Express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) that we can use with the command _app.use(express.json())_.
 
 Let's activate the json-parser and implement an initial handler for dealing with the HTTP POST requests:
 
@@ -630,7 +630,7 @@ Postman also allows users to save requests, but the situation can get quite chao
 
 > **Important sidenote**
 >
-> Sometimes when you're debugging, you may want to find out what headers have been set in the HTTP request. One way of accomplishing this is through the [get](http://expressjs.com/en/4x/api.html#req.get) method of the _request_ object, that can be used for getting the value of a single header. The _request_ object also has the <i>headers</i> property, that contains all of the headers of a specific request.
+> Sometimes when you're debugging, you may want to find out what headers have been set in the HTTP request. One way of accomplishing this is through the [get](https://expressjs.com/en/5x/api/request/#reqgetfield) method of the _request_ object, that can be used for getting the value of a single header. The _request_ object also has the <i>headers</i> property, that contains all of the headers of a specific request.
 >
 > Problems can occur with the VS REST client if you accidentally add an empty line between the top row and the row specifying the HTTP headers. In this situation, the REST client interprets this to mean that all headers are left empty, which leads to the backend server not knowing that the data it has received is in the JSON format.
 >
@@ -861,7 +861,7 @@ POST is the only HTTP request type that is neither <i>safe</i> nor <i>idempotent
 
 ### Middleware
 
-The Express [json-parser](https://expressjs.com/en/api.html) used earlier is a [middleware](http://expressjs.com/en/guide/using-middleware.html).
+The Express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) used earlier is a [middleware](https://expressjs.com/en/resources/middleware/body-parser/).
 
 Middleware are functions that can be used for handling _request_ and _response_ objects.
 

--- a/src/content/3/es/part3a.md
+++ b/src/content/3/es/part3a.md
@@ -318,9 +318,9 @@ app.get('/', (request, response) => {
 })
 ```
 
-La función del controlador de eventos acepta dos parámetros. El primer parámetro [request](http://expressjs.com/en/4x/api.html#req) contiene toda la información de la solicitud HTTP y el segundo parámetro [response](http://expressjs.com/en/4x/api.html#res) se utiliza para definir cómo se responde a la solicitud.
+La función del controlador de eventos acepta dos parámetros. El primer parámetro [request](https://expressjs.com/en/5x/api/request/) contiene toda la información de la solicitud HTTP y el segundo parámetro [response](https://expressjs.com/en/5x/api/response/) se utiliza para definir cómo se responde a la solicitud.
 
-En nuestro código, la solicitud se responde utilizando el método [send](http://expressjs.com/en/4x/api.html#res.send) del objeto _response_. Llamar al método hace que el servidor responda a la solicitud HTTP enviando una respuesta que contiene el string <code>\<h1>Hello World!\</h1></code>, que se pasó al método _send_. Dado que el parámetro es un string, Express establece automáticamente el valor de la cabecera <i>Content-Type</i> en <i>text/html</i>. El código de estado de la respuesta predeterminado es 200.
+En nuestro código, la solicitud se responde utilizando el método [send](https://expressjs.com/en/5x/api/response/#ressendbody) del objeto _response_. Llamar al método hace que el servidor responda a la solicitud HTTP enviando una respuesta que contiene el string <code>\<h1>Hello World!\</h1></code>, que se pasó al método _send_. Dado que el parámetro es un string, Express establece automáticamente el valor de la cabecera <i>Content-Type</i> en <i>text/html</i>. El código de estado de la respuesta predeterminado es 200.
 
 Podemos verificar esto desde la pestaña <i>Network</i> en las herramientas para desarrolladores:
 
@@ -334,7 +334,7 @@ app.get('/api/notes', (request, response) => {
 })
 ```
 
-La solicitud se responde con el método [json](http://expressjs.com/en/4x/api.html#res.json) del objeto _response_. Llamar al método enviará el array __notes__ que se le pasó como un string con formato JSON. Express establece automáticamente la cabecera <i>Content-Type</i> con el valor apropiado de <i>application/json</i>.
+La solicitud se responde con el método [json](https://expressjs.com/en/5x/api/response/#resjsonbody) del objeto _response_. Llamar al método enviará el array __notes__ que se le pasó como un string con formato JSON. Express establece automáticamente la cabecera <i>Content-Type</i> con el valor apropiado de <i>application/json</i>.
 
 ![api/notes devuelve los datos en formato JSON otra vez](../../images/3/6new.png)
 
@@ -460,11 +460,11 @@ En algunos lugares (ver por ejemplo, [Richardson, Ruby: RESTful Web Services](ht
 
 ### Obteniendo un solo recurso
 
-Ampliemos nuestra aplicación para que ofrezca una interfaz REST para operar con notas individuales. Primero, creemos una [ruta](http://expressjs.com/en/guide/routing.html) para buscar un solo recurso.
+Ampliemos nuestra aplicación para que ofrezca una interfaz REST para operar con notas individuales. Primero, creemos una [ruta](https://expressjs.com/en/5x/guide/routing/) para buscar un solo recurso.
 
 La dirección única que usaremos para una nota individual es de la forma <i>notes/10</i>, donde el número al final se refiere al número de id único de la nota.
 
-Podemos definir [parámetros](http://expressjs.com/en/guide/routing.html#route-parameters) para rutas en Express usando la sintaxis de dos puntos:
+Podemos definir [parámetros](https://expressjs.com/en/5x/guide/routing/#route-parameters) para rutas en Express usando la sintaxis de dos puntos:
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -476,7 +476,7 @@ app.get('/api/notes/:id', (request, response) => {
 
 Ahora <code>app.get('/api/notes/:id', ...)</code> manejará todas las solicitudes HTTP GET, que tienen el formato <i>/api/notes/SOMETHING</i>, donde <i>SOMETHING</i> es una cadena arbitraria.
 
-Se puede acceder al parámetro <i>id</i> en la ruta de una solicitud a través del objeto [request](http://expressjs.com/en/api.html#req):
+Se puede acceder al parámetro <i>id</i> en la ruta de una solicitud a través del objeto [request](https://expressjs.com/en/5x/api/request/):
 
 ```js
 const id = request.params.id
@@ -569,7 +569,7 @@ app.get('/api/notes/:id', (request, response) => {
 })
 ```
 
-Dado que no se adjuntan datos a la respuesta, utilizamos el método [status](http://expressjs.com/en/4x/api.html#res.status) para establecer el estado y el método [end](http://expressjs.com/en/4x/api.html#res.end) para responder a la solicitud sin enviar ningún dato.
+Dado que no se adjuntan datos a la respuesta, utilizamos el método [status](https://expressjs.com/en/5x/api/response/#resstatuscode) para establecer el estado y el método [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) para responder a la solicitud sin enviar ningún dato.
 
 La condición if aprovecha el hecho de que todos los objetos JavaScript son [truthy](https://developer.mozilla.org/es/docs/Glossary/Truthy), lo que significa que se evalúan como verdaderos en una operación de comparación. Sin embargo, _undefined_ es [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), lo que significa que se evaluará como falso.
 
@@ -634,7 +634,7 @@ Si usas *IntelliJ WebStorm* en cambio, puedes usar un procedimiento similar con 
 
 A continuación, hagamos posible agregar nuevas notas al servidor. La adición de una nota ocurre al hacer una solicitud HTTP POST a la dirección <http://localhost:3001/api/notes>, y al enviar toda la información de la nueva nota en el [body](https://www.rfc-editor.org/rfc/rfc9112#name-message-body) de la solicitud en formato JSON.
 
-Para acceder a los datos fácilmente, necesitamos la ayuda del [json-parser](https://expressjs.com/en/api.html) de Express, que se usa con el comando _app.use(express.json())_.
+Para acceder a los datos fácilmente, necesitamos la ayuda del [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) de Express, que se usa con el comando _app.use(express.json())_.
 
 Activemos json-parser e implementemos un controlador inicial para manejar las solicitudes HTTP POST:
 
@@ -715,7 +715,7 @@ Postman también permite a los usuarios guardar solicitudes, pero la situación 
 
 > **Nota al margen importante**
 >
-> A veces, cuando estas depurando, es posible que desees averiguar qué cabeceras se han configurado en la solicitud HTTP. Una forma de lograr esto es mediante el método [get](http://expressjs.com/en/4x/api.html#req.get) del objeto _request_, que se puede usar para obtener el valor de una sola cabecera. El objeto _request_ también tiene la propiedad <i>headers (cabeceras)</i>, que contiene todas los cabeceras de una solicitud específica.
+> A veces, cuando estas depurando, es posible que desees averiguar qué cabeceras se han configurado en la solicitud HTTP. Una forma de lograr esto es mediante el método [get](https://expressjs.com/en/5x/api/request/#reqgetfield) del objeto _request_, que se puede usar para obtener el valor de una sola cabecera. El objeto _request_ también tiene la propiedad <i>headers (cabeceras)</i>, que contiene todas los cabeceras de una solicitud específica.
 >
 > Pueden ocurrir problemas con el cliente VS REST si agrega accidentalmente una línea vacía entre la fila superior y la fila que especifica los cabeceras HTTP. En esta situación, el cliente REST interpreta que esto significa que todos los cabeceras se dejan vacíos, lo que hace que el servidor backend no sepa que los datos que ha recibido están en formato JSON.
 >
@@ -950,7 +950,7 @@ POST es el único tipo de solicitud HTTP que no es ni <i>seguro</i> ni <i>idempo
 
 ### Middleware
 
-El [json-parser](https://expressjs.com/en/api.html) de Express que utilizamos anteriormente es un [middleware](https://expressjs.com/es/guide/using-middleware.html).
+El [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) de Express que utilizamos anteriormente es un [middleware](https://expressjs.com/en/resources/middleware/body-parser/).
 
 Los middleware son funciones que se pueden utilizar para manejar objetos de _request_ y _response_.
 

--- a/src/content/3/fi/osa3a.md
+++ b/src/content/3/fi/osa3a.md
@@ -315,9 +315,9 @@ app.get('/', (request, response) => {
 })
 ```
 
-Tapahtumankäsittelijäfunktiolla on kaksi parametria. Näistä ensimmäinen eli [request](http://expressjs.com/en/4x/api.html#req) sisältää kaikki HTTP-pyynnön tiedot ja toisen parametrin [response](http://expressjs.com/en/4x/api.html#res):n avulla määritellään, miten pyyntöön vastataan.
+Tapahtumankäsittelijäfunktiolla on kaksi parametria. Näistä ensimmäinen eli [request](https://expressjs.com/en/5x/api/request/) sisältää kaikki HTTP-pyynnön tiedot ja toisen parametrin [response](https://expressjs.com/en/5x/api/response/):n avulla määritellään, miten pyyntöön vastataan.
 
-Koodissa pyyntöön vastataan käyttäen _response_-olion metodia [send](http://expressjs.com/en/4x/api.html#res.send), jonka kutsumisen seurauksena palvelin vastaa HTTP-pyyntöön lähettämällä selaimelle vastaukseksi _send_:in parametrina olevan merkkijonon <code>\<h1>Hello World!\</h1></code>. Koska parametri on merkkijono, asettaa Express vastauksessa <i>Content-Type</i>-headerin arvoksi <i>text/html</i>. Statuskoodiksi tulee oletusarvoisesti 200. 
+Koodissa pyyntöön vastataan käyttäen _response_-olion metodia [send](https://expressjs.com/en/5x/api/response/#ressendbody), jonka kutsumisen seurauksena palvelin vastaa HTTP-pyyntöön lähettämällä selaimelle vastaukseksi _send_:in parametrina olevan merkkijonon <code>\<h1>Hello World!\</h1></code>. Koska parametri on merkkijono, asettaa Express vastauksessa <i>Content-Type</i>-headerin arvoksi <i>text/html</i>. Statuskoodiksi tulee oletusarvoisesti 200. 
 
 Asian voi varmistaa konsolin välilehdeltä <i>Network</i>:
 
@@ -331,7 +331,7 @@ app.get('/api/notes', (request, response) => {
 })
 ```
 
-Pyyntöön vastataan _response_-olion metodilla [json](http://expressjs.com/en/4x/api.html#res.json), joka lähettää HTTP-pyynnön vastaukseksi parametrina olevaa JavaScript-olioa eli taulukkoa _notes_ vastaavan JSON-muotoisen merkkijonon. Express asettaa headerin <i>Content-Type</i> arvoksi <i>application/json</i>.
+Pyyntöön vastataan _response_-olion metodilla [json](https://expressjs.com/en/5x/api/response/#resjsonbody), joka lähettää HTTP-pyynnön vastaukseksi parametrina olevaa JavaScript-olioa eli taulukkoa _notes_ vastaavan JSON-muotoisen merkkijonon. Express asettaa headerin <i>Content-Type</i> arvoksi <i>application/json</i>.
 
 ![Selain renderöi json-muotoiset muistiinpanot](../../images/3/6new.png)
 
@@ -429,7 +429,7 @@ Laajennetaan nyt sovellusta siten, että se tarjoaa muistiinpanojen operointiin 
 
 Yksittäisen muistiinpanon identifioi URL, joka on muotoa <i>/api/notes/10</i>. Lopussa oleva luku vastaa resurssin muistiinpanon id:tä.
 
-Voimme määritellä Expressin routejen poluille [parametreja](http://expressjs.com/en/guide/routing.html) käyttämällä kaksoispistesyntaksia:
+Voimme määritellä Expressin routejen poluille [parametreja](https://expressjs.com/en/5x/guide/routing/) käyttämällä kaksoispistesyntaksia:
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -441,7 +441,7 @@ app.get('/api/notes/:id', (request, response) => {
 
 Nyt <code>app.get('/api/notes/:id', ...)</code> käsittelee kaikki HTTP GET ‑pyynnöt, jotka ovat muotoa <i>/api/notes/JOTAIN</i>, jossa <i>JOTAIN</i> on mielivaltainen merkkijono.
 
-Polun parametrin <i>id</i> arvoon päästään käsiksi pyynnön tiedot kertovan olion [request](http://expressjs.com/en/api.html#req) kautta:
+Polun parametrin <i>id</i> arvoon päästään käsiksi pyynnön tiedot kertovan olion [request](https://expressjs.com/en/5x/api/request/) kautta:
 
 ```js
 const id = request.params.id
@@ -478,7 +478,7 @@ app.get('/api/notes/:id', (request, response) => {
 })
 ```
 
-Koska vastaukseen ei nyt liity mitään dataa, käytetään statuskoodin asettavan metodin [status](http://expressjs.com/en/4x/api.html#res.status) lisäksi metodia [end](http://expressjs.com/en/4x/api.html#res.end) ilmoittamaan siitä, että pyyntöön tulee vastata ilman dataa.
+Koska vastaukseen ei nyt liity mitään dataa, käytetään statuskoodin asettavan metodin [status](https://expressjs.com/en/5x/api/response/#resstatuscode) lisäksi metodia [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) ilmoittamaan siitä, että pyyntöön tulee vastata ilman dataa.
 
 Koodin haarautumisessa hyväksikäytetään sitä, että mikä tahansa JavaScript-olio on [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), eli katsotaan todeksi vertailuoperaatiossa. _undefined_ taas on [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) eli epätosi.
 
@@ -536,7 +536,7 @@ Klikkaamalla tekstiä <i>Send Request</i>, REST client suorittaa määritellyn H
 
 Toteutetaan seuraavana uusien muistiinpanojen lisäys, joka siis tapahtuu tekemällä HTTP POST ‑pyyntö osoitteeseen http://localhost:3001/api/notes ja liittämällä pyynnön [bodyyn](https://fastapi.tiangolo.com/tutorial/body/) luotavan muistiinpanon tiedot JSON-muodossa.
 
-Jotta pääsisimme pyynnön mukana lähetettyyn dataan helposti käsiksi, tarvitsemme Expressin tarjoaman [json-parserin](https://expressjs.com/en/api.html) apua. Tämä tapahtuu lisäämällä koodiin komento _app.use(express.json())_.
+Jotta pääsisimme pyynnön mukana lähetettyyn dataan helposti käsiksi, tarvitsemme Expressin tarjoaman [json-parserin](https://expressjs.com/en/5x/api/express/#expressjsonoptions) apua. Tämä tapahtuu lisäämällä koodiin komento _app.use(express.json())_.
 
 Otetaan json-parseri käyttöön ja luodaan alustava määrittely HTTP POST ‑pyynnön käsittelyyn:
 
@@ -602,7 +602,7 @@ REST clientin eräs suuri etu Postmaniin verrattuna on se, että pyynnöt saa k�
 
 > **Tärkeä sivuhuomio**
 >
-> Välillä debugatessa tulee vastaan tilanteita, joissa backendissä on tarve selvittää, mitä headereja HTTP-pyynnöille on asetettu. Eräs menetelmä tähän on _request_-olion melko kehnosti nimetty metodi [get](http://expressjs.com/en/4x/api.html#req.get), jonka avulla voi selvittää yksittäisen headerin arvon. _request_-oliolla on myös kenttä <i>headers</i>, jonka arvona ovat kaikki pyyntöön liittyvät headerit.
+> Välillä debugatessa tulee vastaan tilanteita, joissa backendissä on tarve selvittää, mitä headereja HTTP-pyynnöille on asetettu. Eräs menetelmä tähän on _request_-olion melko kehnosti nimetty metodi [get](https://expressjs.com/en/5x/api/request/#reqgetfield), jonka avulla voi selvittää yksittäisen headerin arvon. _request_-oliolla on myös kenttä <i>headers</i>, jonka arvona ovat kaikki pyyntöön liittyvät headerit.
 >
 > Ongelmia voi syntyä esim., jos jätät vahingossa VS Coden REST clientillä ylimmän rivin ja headerit määrittelevien rivien väliin tyhjän rivin. Tällöin REST client tulkitsee, että millekään headerille ei aseteta arvoa ja näin backend ei osaa tulkita pyynnön mukana olevaa dataa JSON:iksi.
 >
@@ -801,7 +801,7 @@ HTTP-pyyntötyypeistä POST on ainoa, joka ei ole <i>safe</i> eikä <i>idempoten
 
 ### Middlewaret
 
-Äsken käyttöönottamamme Expressin [json-parseri](https://expressjs.com/en/api.html) on terminologiassa niin sanottu [middleware](http://expressjs.com/en/guide/using-middleware.html).
+Äsken käyttöönottamamme Expressin [json-parseri](https://expressjs.com/en/5x/api/express/#expressjsonoptions) on terminologiassa niin sanottu [middleware](https://expressjs.com/en/resources/middleware/body-parser/).
 
 Middlewaret ovat funktioita, joiden avulla voidaan käsitellä _request_- ja _response_-olioita.
 

--- a/src/content/3/fr/part3a.md
+++ b/src/content/3/fr/part3a.md
@@ -355,10 +355,10 @@ app.get('/', (request, response) => {
 ```
 
 
-La fonction de gestion d'événement accepte deux paramètres. Le premier paramètre [request](http://expressjs.com/en/4x/api.html#req) contient toutes les informations de la demande HTTP, et le second paramètre [response](http://expressjs.com/en/4x/api.html#res) est utilisé pour définir la réponse à la demande.
+La fonction de gestion d'événement accepte deux paramètres. Le premier paramètre [request](https://expressjs.com/en/5x/api/request/) contient toutes les informations de la demande HTTP, et le second paramètre [response](https://expressjs.com/en/5x/api/response/) est utilisé pour définir la réponse à la demande.
 
 
-Dans notre code, on répond à la requête en utilisant la méthode [send](http://expressjs.com/en/4x/api.html#res.send) de l'objet _response_. L'appel de la méthode fait que le serveur répond à la requête HTTP en envoyant une réponse contenant la chaîne de caractères <code>\<h1>Hello World!\</h1></code> qui a été passée à la méthode _send_. Comme le paramètre est une chaîne de caractères, express définit automatiquement la valeur du header <i>Content-Type</i> comme étant <i>text/html</i>. Le code d'état de la réponse a la valeur 200 par défaut.
+Dans notre code, on répond à la requête en utilisant la méthode [send](https://expressjs.com/en/5x/api/response/#ressendbody) de l'objet _response_. L'appel de la méthode fait que le serveur répond à la requête HTTP en envoyant une réponse contenant la chaîne de caractères <code>\<h1>Hello World!\</h1></code> qui a été passée à la méthode _send_. Comme le paramètre est une chaîne de caractères, express définit automatiquement la valeur du header <i>Content-Type</i> comme étant <i>text/html</i>. Le code d'état de la réponse a la valeur 200 par défaut.
 
 
 Nous pouvons le vérifier à partir de l'onglet <i>Network</i> dans les outils de développement :
@@ -375,7 +375,7 @@ app.get('/api/notes', (request, response) => {
 ```
 
 
-La requête est traitée avec la méthode [json](http://expressjs.com/en/4x/api.html#res.json) de l'objet _réponse_. L'appel de cette méthode enverra le tableau __notes__ qui lui a été transmis sous la forme d'une chaîne de caractères formatée en JSON. Express définit automatiquement le header <i>Content-Type</i> avec la valeur appropriée de <i>application/json</i>.
+La requête est traitée avec la méthode [json](https://expressjs.com/en/5x/api/response/#resjsonbody) de l'objet _réponse_. L'appel de cette méthode enverra le tableau __notes__ qui lui a été transmis sous la forme d'une chaîne de caractères formatée en JSON. Express définit automatiquement le header <i>Content-Type</i> avec la valeur appropriée de <i>application/json</i>.
 
 ![](../../images/3/6ea.png)
 
@@ -530,13 +530,13 @@ Cette façon d'interpréter REST relève du [deuxième niveau de maturité RESTf
 ### Récupération d'une seule ressource
 
 
-Développons notre application de manière à ce qu'elle offre une interface REST pour opérer sur des notes individuelles. Tout d'abord, créons une [route](http://expressjs.com/en/guide/routing.html) pour récupérer une seule ressource.
+Développons notre application de manière à ce qu'elle offre une interface REST pour opérer sur des notes individuelles. Tout d'abord, créons une [route](https://expressjs.com/en/5x/guide/routing/) pour récupérer une seule ressource.
 
 
 L'adresse unique que nous utiliserons pour une note individuelle est de la forme <i>notes/10</i>, où le nombre à la fin fait référence au numéro d'identification unique de la note.
 
 
-Nous pouvons définir des [paramètres](http://expressjs.com/en/guide/routing.html#route-parameters) pour les routes dans express en utilisant la syntaxe des deux points :
+Nous pouvons définir des [paramètres](https://expressjs.com/en/5x/guide/routing/#route-parameters) pour les routes dans express en utilisant la syntaxe des deux points :
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -550,7 +550,7 @@ app.get('/api/notes/:id', (request, response) => {
 Maintenant, <code>app.get('/api/notes/:id', ...)</code> traitera toutes les requêtes HTTP GET qui sont de la forme <i>/api/notes/SOMETHING</i>, où <i>SOMETHING</i> est une chaîne arbitraire.
 
 
-Le paramètre <i>id</i> dans la route d'une demande, est accessible par l'objet [request](http://expressjs.com/en/api.html#req) :
+Le paramètre <i>id</i> dans la route d'une demande, est accessible par l'objet [request](https://expressjs.com/en/5x/api/request/) :
 
 ```js
 const id = request.params.id
@@ -658,7 +658,7 @@ app.get('/api/notes/:id', (request, response) => {
 ```
 
 
-Comme aucune donnée n'est jointe à la réponse, nous utilisons la méthode [status](http://expressjs.com/en/4x/api.html#res.status) pour définir l'état et la méthode [end](http://expressjs.com/en/4x/api.html#res.end) pour répondre à la demande sans envoyer de données.
+Comme aucune donnée n'est jointe à la réponse, nous utilisons la méthode [status](https://expressjs.com/en/5x/api/response/#resstatuscode) pour définir l'état et la méthode [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) pour répondre à la demande sans envoyer de données.
 
 
 La condition if exploite le fait que tous les objets JavaScript sont [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), ce qui signifie qu'ils sont évalués à true dans une opération de comparaison. Cependant, _undefined_ est [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), ce qui signifie qu'il sera évalué comme faux.
@@ -726,7 +726,7 @@ Si vous utilisez *IntelliJ WebStorm* à la place, vous pouvez utiliser une proc�
 
 Ensuite, rendons possible l'ajout de nouvelles notes sur le serveur. L'ajout d'une note se fait par une requête HTTP POST à l'adresse http://localhost:3001/api/notes, et par l'envoi de toutes les informations relatives à la nouvelle note dans la requête [body](https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7) au format JSON.
 
-Afin d'accéder facilement aux données, nous avons besoin de l'aide de l'express [json-parser](https://expressjs.com/en/api.html) qui est utilisé avec la commande _app.use(express.json())_.
+Afin d'accéder facilement aux données, nous avons besoin de l'aide de l'express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) qui est utilisé avec la commande _app.use(express.json())_.
 
 Activons le json-parser et implémentons un gestionnaire initial pour traiter les requêtes HTTP POST :
 
@@ -808,7 +808,7 @@ Postman permet également aux utilisateurs de sauvegarder leurs demandes, mais l
 
 > **Remarque importante**
 >
-> Parfois, lors d'un débogage, vous pouvez vouloir savoir quels en-têtes ont été définis dans la requête HTTP.Une façon d'y parvenir est d'utiliser la méthode [get](http://expressjs.com/en/4x/api.html#req.get) de l'objet _request_, qui peut être utilisée pour obtenir la valeur d'un seul header. L'objet _request_ possède également la propriété <i>headers</i>, qui contient tous les en-têtes d'une requête spécifique.
+> Parfois, lors d'un débogage, vous pouvez vouloir savoir quels en-têtes ont été définis dans la requête HTTP.Une façon d'y parvenir est d'utiliser la méthode [get](https://expressjs.com/en/5x/api/request/#reqgetfield) de l'objet _request_, qui peut être utilisée pour obtenir la valeur d'un seul header. L'objet _request_ possède également la propriété <i>headers</i>, qui contient tous les en-têtes d'une requête spécifique.
 >
 
 > Des problèmes peuvent survenir avec le client VS REST si vous ajoutez accidentellement une ligne vide entre la ligne supérieure et la ligne spécifiant les en-têtes HTTP. Dans cette situation, le client REST interprète cela comme signifiant que tous les en-têtes sont laissés vides, ce qui conduit le serveur backend à ne pas savoir que les données qu'il a reçues sont au format JSON.>
@@ -1086,7 +1086,7 @@ POST est le seul type de requête HTTP qui n'est ni <i>sûr</i> ni <i>idempotent
 
 ### Middleware
 
-Le [json-parser](https://expressjs.com/en/api.html) d'express que nous avons utilisé précédemment est un [middleware](http://expressjs.com/en/guide/using-middleware.html).
+Le [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) d'express que nous avons utilisé précédemment est un [middleware](https://expressjs.com/en/resources/middleware/body-parser/).
 
 
 Les Middleware sont des fonctions qui peuvent être utilisées pour traiter les objets _requête_ et _réponse_.

--- a/src/content/3/ptbr/part3a.md
+++ b/src/content/3/ptbr/part3a.md
@@ -318,9 +318,9 @@ app.get('/', (request, response) => {
 })
 ```
 
-A função de gerência de evento aceita dois parâmetros. O primeiro parâmetro [request](http://expressjs.com/en/4x/api.html#req) (requisição) contém todas as informações da requisição HTTP, e o segundo parâmetro [response](http://expressjs.com/en/4x/api.html#res) (resposta) é usado para definir como a requisição é respondida.
+A função de gerência de evento aceita dois parâmetros. O primeiro parâmetro [request](https://expressjs.com/en/5x/api/request/) (requisição) contém todas as informações da requisição HTTP, e o segundo parâmetro [response](https://expressjs.com/en/5x/api/response/) (resposta) é usado para definir como a requisição é respondida.
 
-Em nosso código, a requisição é respondida usando o método [send](http://expressjs.com/en/4x/api.html#res.send) (enviar) do objeto _response_. Ao chamar o método, o servidor responde à requisição HTTP enviando uma resposta contendo a string <code>\<h1>Hello World!\</h1></code> que foi passada para o método _send_. Como o parâmetro é uma string, o express define automaticamente o valor do cabeçalho <i>Content-Type</i> como <i>text/html</i>. O código de status da resposta é definido como 200 por padrão.
+Em nosso código, a requisição é respondida usando o método [send](https://expressjs.com/en/5x/api/response/#ressendbody) (enviar) do objeto _response_. Ao chamar o método, o servidor responde à requisição HTTP enviando uma resposta contendo a string <code>\<h1>Hello World!\</h1></code> que foi passada para o método _send_. Como o parâmetro é uma string, o express define automaticamente o valor do cabeçalho <i>Content-Type</i> como <i>text/html</i>. O código de status da resposta é definido como 200 por padrão.
 
 Podemos verificar isso na guia <i>Rede</i> nas Ferramentas do Desenvolvedor:
 
@@ -334,7 +334,7 @@ app.get('/api/notes', (request, response) => {
 })
 ```
 
-A requisição é respondida com o método [json](http://expressjs.com/en/4x/api.html#res.json) do objeto _response_. Quando chamado, o método enviará o array __notes__ que foi passado como uma string formatada em JSON. O express define automaticamente o cabeçalho <i>Content-Type</i> com o valor apropriado de <i>application/json</i>.
+A requisição é respondida com o método [json](https://expressjs.com/en/5x/api/response/#resjsonbody) do objeto _response_. Quando chamado, o método enviará o array __notes__ que foi passado como uma string formatada em JSON. O express define automaticamente o cabeçalho <i>Content-Type</i> com o valor apropriado de <i>application/json</i>.
 
 ![api/notes fornece os dados JSON formatados novamente](../../images/3/6new.png)
 
@@ -460,11 +460,11 @@ Em alguns lugares (ver, por exemplo, [Richardson, Ruby: RESTful Web Services](ht
 
 ### Buscando um único recurso
 
-Vamos expandir nossa aplicação para que ela ofereça uma interface REST para operar em notas individuais. Primeiro, vamos criar uma [rota](http://expressjs.com/en/guide/routing.html) para buscar um único recurso.
+Vamos expandir nossa aplicação para que ela ofereça uma interface REST para operar em notas individuais. Primeiro, vamos criar uma [rota](https://expressjs.com/en/5x/guide/routing/) para buscar um único recurso.
 
 O endereço único que usaremos para uma nota individual é na forma <i>notes/10</i>, onde o número no final refere-se ao número de identificação único da nota.
 
-Podemos definir [parâmetros](http://expressjs.com/en/guide/routing.html#route-parameters) para rotas no Express usando a sintaxe de dois-pontos:
+Podemos definir [parâmetros](https://expressjs.com/en/5x/guide/routing/#route-parameters) para rotas no Express usando a sintaxe de dois-pontos:
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -476,7 +476,7 @@ app.get('/api/notes/:id', (request, response) => {
 
 Agora, <code>app.get('/api/notes/:id', ...)</code> gerenciará todas as requisições HTTP GET que estão na forma <i>/api/notes/X</i>, onde <i>X</i> é uma string arbitrária.
 
-O parâmetro <i>id</i> na rota de uma requisição pode ser acessado por meio do objeto [request](http://expressjs.com/en/api.html#req):
+O parâmetro <i>id</i> na rota de uma requisição pode ser acessado por meio do objeto [request](https://expressjs.com/en/5x/api/request/):
 
 ```js
 const id = request.params.id
@@ -569,7 +569,7 @@ app.get('/api/notes/:id', (request, response) => {
 })
 ```
 
-Como nenhum dado está anexado à resposta, usamos o método [status](http://expressjs.com/en/4x/api.html#res.status) para definir o status e o método [end](http://expressjs.com/en/4x/api.html#res.end) para responder à requisição sem enviar nenhum dado.
+Como nenhum dado está anexado à resposta, usamos o método [status](https://expressjs.com/en/5x/api/response/#resstatuscode) para definir o status e o método [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) para responder à requisição sem enviar nenhum dado.
 
 A condição <em>if</em> aproveita o fato de que todos os objetos JavaScript são [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) (verdade/verdadeiro), o que significa que eles avaliam como verdadeiros em uma operação de comparação. No entanto, _undefined_ é [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) (falso/falsidade), o que significa que ele avaliará como falso.
 
@@ -632,7 +632,7 @@ Se você usar o *IntelliJ WebStorm*, é possível fazer um procedimento semelhan
 
 Em seguida, vamos implementar a funcionalidade de adicionar novas notas ao servidor. É possível adicionar uma nota fazendo uma requisição HTTP POST para o endereço http://localhost:3001/api/notes e enviando todas as informações para a nova nota no [corpo](https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7) (body) da requisição em formato JSON.
 
-Para que possamos acessar os dados facilmente, precisamos da ajuda do [json-parser](https://expressjs.com/en/api.html) do Express, que é usado com o comando _app.use(express.json())_.
+Para que possamos acessar os dados facilmente, precisamos da ajuda do [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) do Express, que é usado com o comando _app.use(express.json())_.
 
 Vamos ativar o json-parser e implementar um gerenciador inicial para lidar com requisições HTTP POST:
 
@@ -713,7 +713,7 @@ O Postman também permite que os usuários salvem requisições, mas a situaçã
 
 > **Observação importante**
 >
-> Às vezes, ao depurar, é possível que você queira descobrir quais cabeçalhos foram definidos na requisição HTTP. Uma maneira de fazer isso é através do método [get](http://expressjs.com/en/4x/api.html#req.get) do objeto _request_, que pode ser usado para obter o valor de um único cabeçalho. O objeto _request_ também possui a propriedade <i>headers</i>, que contém todos os cabeçalhos de uma requisição específica.
+> Às vezes, ao depurar, é possível que você queira descobrir quais cabeçalhos foram definidos na requisição HTTP. Uma maneira de fazer isso é através do método [get](https://expressjs.com/en/5x/api/request/#reqgetfield) do objeto _request_, que pode ser usado para obter o valor de um único cabeçalho. O objeto _request_ também possui a propriedade <i>headers</i>, que contém todos os cabeçalhos de uma requisição específica.
 >
 
 > Podem ocorrer problemas com o cliente REST do VS Code se você adicionar acidentalmente uma linha vazia entre a linha superior e a linha que especifica os cabeçalhos HTTP. Nessa situação, o cliente REST interpreta como se todos os cabeçalhos estivessem vazios, o que faz com que o servidor back-end não saiba que os dados que recebeu estão no formato JSON.
@@ -948,7 +948,7 @@ POST é o único tipo de requisição HTTP que não é nem <i>seguro</i> nem <i>
 
 ### Middleware
 
-O [json-parser](https://expressjs.com/en/api.html) do Express que usamos anteriormente é um [middleware](http://expressjs.com/en/guide/using-middleware.html).
+O [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) do Express que usamos anteriormente é um [middleware](https://expressjs.com/en/resources/middleware/body-parser/).
 
 <i>Middleware</i> são funções que podem ser usadas para lidar com objetos de _request_ e _response_.
 

--- a/src/content/3/zh/part3a.md
+++ b/src/content/3/zh/part3a.md
@@ -371,11 +371,11 @@ app.get('/', (request, response) => {
 })
 ```
 
-<!-- The event handler function accepts two parameters. The first [request](http://expressjs.com/en/4x/api.html#req) parameter contains all of the information of the HTTP request, and the second [response](http://expressjs.com/en/4x/api.html#res) parameter is used to define how the request is responded to.-->
-该事件处理函数接受两个参数。第一个 [request](http://expressjs.com/en/4x/api.html#req) 参数包含 HTTP 请求的所有信息，第二个 [response](http://expressjs.com/en/4x/api.html#res) 参数用于定义如何对请求进行响应。
+<!-- The event handler function accepts two parameters. The first [request](https://expressjs.com/en/5x/api/request/) parameter contains all of the information of the HTTP request, and the second [response](https://expressjs.com/en/5x/api/response/) parameter is used to define how the request is responded to.-->
+该事件处理函数接受两个参数。第一个 [request](https://expressjs.com/en/5x/api/request/) 参数包含 HTTP 请求的所有信息，第二个 [response](https://expressjs.com/en/5x/api/response/) 参数用于定义如何对请求进行响应。
 
-<!-- In our code, the request is answered by using the [send](http://expressjs.com/en/4x/api.html#res.send) method of the _response_ object. Calling the method makes the server respond to the HTTP request by sending a response containing the string <code>\<h1>Hello World!\</h1></code> that was passed to the _send_ method. Since the parameter is a string, Express automatically sets the value of the <i>Content-Type</i> header to be <i>text/html</i>. The status code of the response defaults to 200. -->
-在我们的代码中，请求是通过使用 _response_ 对象的 [send](http://expressjs.com/en/4x/api.html#res.send) 方法响应的。调用该方法会使服务端响应 HTTP 请求，发送一个响应，内容包含传递给 _send_ 方法的 <code>\<h1>Hello World!\</h1></code> 字符串。由于参数是一个字符串，Express 自动将 <i>Content-Type</i> 标头的值设为 <i>text/html</i>。响应的状态码默认为 200。
+<!-- In our code, the request is answered by using the [send](https://expressjs.com/en/5x/api/response/#ressendbody) method of the _response_ object. Calling the method makes the server respond to the HTTP request by sending a response containing the string <code>\<h1>Hello World!\</h1></code> that was passed to the _send_ method. Since the parameter is a string, Express automatically sets the value of the <i>Content-Type</i> header to be <i>text/html</i>. The status code of the response defaults to 200. -->
+在我们的代码中，请求是通过使用 _response_ 对象的 [send](https://expressjs.com/en/5x/api/response/#ressendbody) 方法响应的。调用该方法会使服务端响应 HTTP 请求，发送一个响应，内容包含传递给 _send_ 方法的 <code>\<h1>Hello World!\</h1></code> 字符串。由于参数是一个字符串，Express 自动将 <i>Content-Type</i> 标头的值设为 <i>text/html</i>。响应的状态码默认为 200。
 
 <!-- We can verify this from the <i>Network</i> tab in developer tools:-->
 我们可以在开发者工具中的<i>网络</i>标签页中验证：
@@ -391,8 +391,8 @@ app.get('/api/notes', (request, response) => {
 })
 ```
 
-<!-- The request is responded to with the [json](http://expressjs.com/en/4x/api.html#res.json) method of the _response_ object. Calling the method will send the __notes__ array that was passed to it as a JSON formatted string. Express automatically sets the <i>Content-Type</i> header with the appropriate value of <i>application/json</i>.-->
-请求是用 _response_ 对象的 [json](http://expressjs.com/en/4x/api.html#res.json) 方法响应的。调用该方法将以 JSON 格式的字符串发送传给它的 __notes__ 数组。Express 自动将 <i>Content-Type</i> 标头设为合适值 <i>application/json</i>。
+<!-- The request is responded to with the [json](https://expressjs.com/en/5x/api/response/#resjsonbody) method of the _response_ object. Calling the method will send the __notes__ array that was passed to it as a JSON formatted string. Express automatically sets the <i>Content-Type</i> header with the appropriate value of <i>application/json</i>.-->
+请求是用 _response_ 对象的 [json](https://expressjs.com/en/5x/api/response/#resjsonbody) 方法响应的。调用该方法将以 JSON 格式的字符串发送传给它的 __notes__ 数组。Express 自动将 <i>Content-Type</i> 标头设为合适值 <i>application/json</i>。
 
 ![](../../images/3/6new.png)
 
@@ -522,14 +522,14 @@ npm run dev
 <!-- ### Fetching a single resource -->
 ### 获取单个资源
 
-<!-- Let's expand our application so that it offers a REST interface for operating on individual notes. First let's create a [route](http://expressjs.com/en/guide/routing.html) for fetching a single resource.-->
-让我们扩展我们的应用，使其提供一个 REST 接口来操作单个笔记。首先，让我们创建一个用来获取单个资源的[路由](http://expressjs.com/en/guide/routing.html)。
+<!-- Let's expand our application so that it offers a REST interface for operating on individual notes. First let's create a [route](https://expressjs.com/en/5x/guide/routing/) for fetching a single resource.-->
+让我们扩展我们的应用，使其提供一个 REST 接口来操作单个笔记。首先，让我们创建一个用来获取单个资源的[路由](https://expressjs.com/en/5x/guide/routing/)。
 
 <!-- The unique address we will use for an individual note is of the form <i>notes/10</i>, where the number at the end refers to the note's unique id number.-->
 我们将为单个笔记使用的唯一地址的形式是 <i>notes/10</i>，其中末尾的数字指笔记的唯一 id。
 
-<!-- We can define [parameters](http://expressjs.com/en/guide/routing.html#route-parameters) for routes in express by using the colon syntax:-->
-在 Express 中，可以用冒号语法来为路由定义[参数](http://expressjs.com/en/guide/routing.html#route-parameters)：
+<!-- We can define [parameters](https://expressjs.com/en/5x/guide/routing/#route-parameters) for routes in express by using the colon syntax:-->
+在 Express 中，可以用冒号语法来为路由定义[参数](https://expressjs.com/en/5x/guide/routing/#route-parameters)：
 
 ```js
 app.get('/api/notes/:id', (request, response) => {
@@ -542,8 +542,8 @@ app.get('/api/notes/:id', (request, response) => {
 <!-- Now <code>app.get('/api/notes/:id', ...)</code> will handle all HTTP GET requests that are of the form <i>/api/notes/SOMETHING</i>, where <i>SOMETHING</i> is an arbitrary string.-->
 现在 <code>app.get('/api/notes/:id', ...)</code> 将处理所有形式为 <i>/api/notes/SOMETHING</i> 的 HTTP GET 请求，其中 <i>SOMETHING</i> 是一个任意的字符串。
 
-<!-- The <i>id</i> parameter in the route of a request can be accessed through the [request](http://expressjs.com/en/api.html#req) object: -->
-请求的路由中的 <i>id</i> 参数可以通过 [request](http://expressjs.com/en/api.html#req) 对象访问：
+<!-- The <i>id</i> parameter in the route of a request can be accessed through the [request](https://expressjs.com/en/5x/api/request/) object: -->
+请求的路由中的 <i>id</i> 参数可以通过 [request](https://expressjs.com/en/5x/api/request/) 对象访问：
 
 ```js
 const id = request.params.id
@@ -591,8 +591,8 @@ app.get('/api/notes/:id', (request, response) => {
 ```
 
 
-<!-- Since no data is attached to the response, we use the [status](http://expressjs.com/en/4x/api.html#res.status) method for setting the status, and the [end](http://expressjs.com/en/4x/api.html#res.end) method for responding to the request without sending any data.-->
-由于响应中没有数据，我们使用 [status](http://expressjs.com/en/4x/api.html#res.status) 方法来设置状态，并使用 [end](http://expressjs.com/en/4x/api.html#res.end) 方法来响应请求，而不发送任何数据。
+<!-- Since no data is attached to the response, we use the [status](https://expressjs.com/en/5x/api/response/#resstatuscode) method for setting the status, and the [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) method for responding to the request without sending any data.-->
+由于响应中没有数据，我们使用 [status](https://expressjs.com/en/5x/api/response/#resstatuscode) 方法来设置状态，并使用 [end](https://expressjs.com/en/5x/api/response/#resenddata-encoding-callback) 方法来响应请求，而不发送任何数据。
 
 <!-- The if-condition leverages the fact that all JavaScript objects are [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), meaning that they evaluate to true in a comparison operation. However, _undefined_ is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) meaning that it will evaluate to false.-->
 if 条件利用了这样一个事实——所有 JavaScript 对象都是[真值](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)，也就是在比较操作中会被计算为 true。然而，_undefined_ 是[假值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，也就是会被计算为 false。
@@ -682,8 +682,8 @@ app.delete('/api/notes/:id', (request, response) => {
 <!-- Next, let's make it possible to add new notes to the server. Adding a note happens by making an HTTP POST request to the address <http://localhost:3001/api/notes>, and by sending all the information for the new note in the request [body](https://www.rfc-editor.org/rfc/rfc9112#name-message-body) in JSON format. -->
 接下来，让我们实现向服务端添加新笔记的功能。添加笔记是通过向地址 <http://localhost:3001/api/notes> 发送 HTTP POST 请求，并在请求[体](https://www.rfc-editor.org/rfc/rfc9112#name-message-body)中以 JSON 格式发送新笔记的所有信息来完成的。 
 
-<!-- To access the data easily, we need the help of the Express [json-parser](https://expressjs.com/en/api.html) that we can use with the command _app.use(express.json())_. -->
-为了方便地访问数据，我们需要借助 Express [json-parser](https://expressjs.com/en/api.html)，可以通过命令 _app.use(express.json())_ 来使用它。
+<!-- To access the data easily, we need the help of the Express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) that we can use with the command _app.use(express.json())_. -->
+为了方便地访问数据，我们需要借助 Express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions)，可以通过命令 _app.use(express.json())_ 来使用它。
 
 <!-- Let's activate the json-parser and implement an initial handler for dealing with the HTTP POST requests:-->
 让我们启用 json-parser 并实现处理 HTTP POST 请求的处理函数的初始版本。
@@ -781,8 +781,8 @@ Postman 也允许用户保存请求，但情况可能变得相当混乱，特别
 
 > <!-- **Important sidenote**-->
 > **重要的附注**
-> <!-- Sometimes when you're debugging, you may want to find out what headers have been set in the HTTP request. One way of accomplishing this is through the [get](http://expressjs.com/en/4x/api.html#req.get) method of the _request_ object, that can be used for getting the value of a single header. The _request_ object also has the <i>headers</i> property, that contains all of the headers of a specific request.-->
-> 有时当你在调试时，你可能想找出 HTTP 请求中设了哪些标头。一种方法是通过 _request_ 对象的 [get](http://expressjs.com/en/4x/api.html#req.get) 方法获取单个标头的值。_request_ 对象还有 <i>headers</i> 属性，包含某个请求的所有标头。
+> <!-- Sometimes when you're debugging, you may want to find out what headers have been set in the HTTP request. One way of accomplishing this is through the [get](https://expressjs.com/en/5x/api/request/#reqgetfield) method of the _request_ object, that can be used for getting the value of a single header. The _request_ object also has the <i>headers</i> property, that contains all of the headers of a specific request.-->
+> 有时当你在调试时，你可能想找出 HTTP 请求中设了哪些标头。一种方法是通过 _request_ 对象的 [get](https://expressjs.com/en/5x/api/request/#reqgetfield) 方法获取单个标头的值。_request_ 对象还有 <i>headers</i> 属性，包含某个请求的所有标头。
 > <!-- Problems can occur with the VS REST client if you accidentally add an empty line between the top row and the row specifying the HTTP headers. In this situation, the REST client interprets this to mean that all headers are left empty, which leads to the backend server not knowing that the data it has received is in the JSON format.-->
 > 在 VS REST Client 中，如果你不小心在第一行和指定 HTTP 标头的行之间添加了一个空行，就会出现问题。在这种情况下，REST Client 会将其解释为所有的标头都是空的，这会导致后端服务端不知道收到的数据是 JSON 格式的。
 > <!-- You will be able to spot this missing <i>Content-Type</i> header if at some point in your code you print all of the request headers with the _console.log(request.headers)_ command.-->
@@ -1069,8 +1069,8 @@ POST 是唯一的既不<i>安全</i>也不<i>幂等</i>的 HTTP 请求类型。�
 <!-- ### Middleware -->
 ### 中间件
 
-<!-- The Express [json-parser](https://expressjs.com/en/api.html) used earlier is a [middleware](http://expressjs.com/en/guide/using-middleware.html). -->
-之前使用的 Express [json-parser](https://expressjs.com/en/api.html) 是一个[中间件](http://expressjs.com/en/guide/using-middleware.html)。
+<!-- The Express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) used earlier is a [middleware](https://expressjs.com/en/resources/middleware/body-parser/). -->
+之前使用的 Express [json-parser](https://expressjs.com/en/5x/api/express/#expressjsonoptions) 是一个[中间件](https://expressjs.com/en/resources/middleware/body-parser/)。
 
 <!-- Middleware are functions that can be used for handling _request_ and _response_ objects.-->
 中间件是可以用来处理 _request_ 和 _response_ 对象的函数。


### PR DESCRIPTION
fixed and updated broken links in the text for all languages. Updated URLs point directly to the relevant Express.js v5.x documentation pages for further reading. 