### PR TITLE
fix: clarify part3b backend reference to avoid ambiguity with json-server

### DIFF
--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -101,6 +101,7 @@ There are also some other free hosting options that work well for this course, a
 Some course participants have also used the following services:
 
 - [Replit](https://replit.com)
+- [Railway](https://railway.app)
 - [CodeSandBox](https://codesandbox.io)
 
 If you know easy-to-use and free services for hosting NodeJS, please let us know!

--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -9,9 +9,7 @@ lang: en
 
 Next, let's connect the frontend we made in [part 2](/en/part2) to the Express backend we built in part 3a.
 
-In part 2, the frontend fetched notes from json-server at http://localhost:3001/notes. The Express backend we built in this part has a slightly different URL structure — notes are now at http://localhost:3001/api/notes.
-
-Our backend has a slightly different URL structure now, as the notes can be found at <http://localhost:3001/api/notes>. Let's change the attribute __baseUrl__ in the frontend notes app at <i>src/services/notes.js</i> like so:
+In part 2, the frontend fetched notes from json-server at http://localhost:3001/notes. The Express backend we built in this part has a slightly different URL structure — notes are now at http://localhost:3001/api/notes. Let's change the attribute __baseUrl__ in the frontend notes app at <i>src/services/notes.js</i> like so:
 
 ```js
 import axios from 'axios'

--- a/src/content/3/en/part3b.md
+++ b/src/content/3/en/part3b.md
@@ -7,9 +7,10 @@ lang: en
 
 <div class="content">
 
-Next, let's connect the frontend we made in [part 2](/en/part2) to our own backend.
+Next, let's connect the frontend we made in [part 2](/en/part2) to the Express backend we built in part 3a.
 
-In the previous part, the frontend could ask for the list of notes from the json-server we had as a backend, from the address <http://localhost:3001/notes>.
+In part 2, the frontend fetched notes from json-server at http://localhost:3001/notes. The Express backend we built in this part has a slightly different URL structure — notes are now at http://localhost:3001/api/notes.
+
 Our backend has a slightly different URL structure now, as the notes can be found at <http://localhost:3001/api/notes>. Let's change the attribute __baseUrl__ in the frontend notes app at <i>src/services/notes.js</i> like so:
 
 ```js


### PR DESCRIPTION
The opening instruction in part3b says:

"Next, let's connect the frontend we made in part 2 to our own backend."

The phrase "our own backend" is ambiguous. A reader could reasonably interpret it as the Part 2 json-server setup, since that backend was also built progressively through the course exercises and lives in the Part 2 project root — it qualifies just as much as "our own backend."

When a reader makes that assumption and updates baseUrl to http://localhost:3001/api/notes while json-server is still running, they get a 404 instead of the CORS error the section is trying to demonstrate. This is because json-server has no /api/notes route — it only serves /notes. The reader then has no clear signal that they are pointed at the wrong backend entirely.

The fix replaces "our own backend" with "the Express backend we built in part 3a" and updates the surrounding sentence to make the Part 3 context explicit, so the reader does not need to make the cognitive leap between parts themselves.