### PR TITLE
Update exercise range from 6.6 to 6.5

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -774,7 +774,7 @@ The current code of the application is available in its entirety on [GitHub](htt
 
 <div class="tasks">
 
-### Exercises 6.2.-6.6.
+### Exercises 6.2.-6.5.
 
 Let's implement a new version of the anecdote voting application from Part 1. Use the project at https://github.com/fullstack-hy2020/zustand-anecdotes as the base for your solution.
 


### PR DESCRIPTION
Fixed a typo in Part6a subsection heading.

While investigating, I noticed that the navigation panel appears to be subsection headings. The section heading listed 'Exercise 6.2-6.6', but the section only contains exercises up to 6.5.

To ensure the navigation accurately reflects the exercises available in Part 6a and avoid confusion for readers.