### PR TITLE
Part 5e & Part 7a: Fix broken links

### DIFF
--- a/src/content/5/en/part5e.md
+++ b/src/content/5/en/part5e.md
@@ -477,7 +477,7 @@ const Note = ({ note, id, toggleImportanceOf, deleteNote }) => {  // highlight-l
 export default Note
 ```
 
-One way is to determine the <i>id</i> of the note to be displayed within the component using React Router's [useMatch](https://reactrouter.com/en/main/hooks/use-match) hook function.
+One way is to determine the <i>id</i> of the note to be displayed within the component using React Router's [useMatch](https://reactrouter.com/api/hooks/useMatch) hook function.
 
 It is not possible to use the <i>useMatch</i> hook in the same component that defines the routable part of the application. Let’s move the <i>Router</i> component outside of <i>App</i>:
 

--- a/src/content/5/fi/osa5e.md
+++ b/src/content/5/fi/osa5e.md
@@ -478,7 +478,7 @@ export default Note
 
 ```
 
-Eräs tapa on selvittää näytettävän muistiinpanon <i>id</i> komponentissa jo <i>App</i> React Routerin hook-funktion [useMatch](https://reactrouter.com/en/main/hooks/use-match) avulla.
+Eräs tapa on selvittää näytettävän muistiinpanon <i>id</i> komponentissa jo <i>App</i> React Routerin hook-funktion [useMatch](https://reactrouter.com/api/hooks/useMatch) avulla.
 
 <i>useMatch</i>-hookin käyttö ei ole mahdollista samassa komponentissa, joka määrittelee sovelluksen reititettävän osan. Siirretään <i>Router</i> komponentin <i>App</i> ulkopuolelle:
 

--- a/src/content/7/fr/part7a.md
+++ b/src/content/7/fr/part7a.md
@@ -420,7 +420,7 @@ const Note = ({ note }) => {
 }
 ```
 
-Une façon de faire cela serait d'utiliser le hook [useMatch](https://reactrouter.com/en/v6.3.0/api#usematch) de React Router pour déterminer l'identifiant de la note à afficher dans le composant _App_.
+Une façon de faire cela serait d'utiliser le hook [useMatch](https://reactrouter.com/api/hooks/useMatch) de React Router pour déterminer l'identifiant de la note à afficher dans le composant _App_.
 
 Il n'est pas possible d'utiliser le hook <i>useMatch</i> dans le composant qui définit la partie routée de l'application. Déplaçons l'utilisation des composants Router depuis App:
 

--- a/src/content/7/zh/part7a.md
+++ b/src/content/7/zh/part7a.md
@@ -468,8 +468,8 @@ const Note = ({ note }) => {
 }
 ```
 
-<!-- One way to do this would be to use React Router's [useMatch](https://reactrouter.com/en/main/hooks/use-match) hook to figure out the id of the note to be displayed in the _App_ component.-->
- 一种方法是使用React Router's [useMatch](https://reactrouter.com/en/main/hooks/use-match)钩子来计算出要在_App_组件中显示的笔记的id。
+<!-- One way to do this would be to use React Router's [useMatch](https://reactrouter.com/api/hooks/useMatch) hook to figure out the id of the note to be displayed in the _App_ component.-->
+ 一种方法是使用React Router's [useMatch](https://reactrouter.com/api/hooks/useMatch)钩子来计算出要在_App_组件中显示的笔记的id。
 
 <!-- It is not possible to use the <i>useMatch</i> hook in the component which defines the routed part of the application. Let's move the use of the _Router_ components from _App_:-->
  在定义应用的路由部分的组件中不可能使用<i>useMatch</i>钩。让我们把_Router_组件的使用从_App_移开。


### PR DESCRIPTION
Fixes `useMatch` hook documentation links.