### PR TITLE
Fix link accessibility in part4b

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -930,7 +930,7 @@ Full stack development is <i> extremely hard</i>, that is why I will use all the
 - <i>I will write lots of _console.log_ statements to make sure I understand how the code and the tests behave and to help pinpoint problems</i>
 - If my code does not work, I will not write more code. Instead, I start deleting the code until it works or just return to a state when everything is still working
 - <i>If a test does not pass, I make sure that the tested functionality for sure works in the application</i>
-- When I ask for help in the course Discord channel or elsewhere I formulate my questions properly, see [here](/en/part0/general_info#how-to-get-help-in-discord) how to ask for help
+- When I ask for help in the course Discord channel or elsewhere I formulate my questions properly, see [how to ask for help](/en/part0/general_info#how-to-get-help-in-discord)
 
 </div>
 


### PR DESCRIPTION
This is a follow-up to the accessibility improvements in PR #2289.

This PR replaces a generic `here` link with descriptive link text. Descriptive link text is an important accessibility practice, particularly for screen reader users who may navigate pages by listing links, where generic text such as `here` provides little context.

There are additional instances of generic link text (such as `here`) in the course material. I chose to keep this PR limited to a single change to make it easy to review and to avoid unnecessary merge conflicts.