### PR TITLE
docs: clarify Promise.all execution behavior in part4b

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -888,7 +888,7 @@ The [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 
 > The returned values of each promise in the array can still be accessed when using the Promise.all method. If we wait for the promises to be resolved with the _await_ syntax <em>const results = await Promise.all(promiseArray)</em>, the operation will return an array that contains the resolved values for each promise in the _promiseArray_, and they appear in the same order as the promises in the array.
 
-Promise.all executes the promises it receives in parallel. If the promises need to be executed in a particular order, this will be problematic. In situations like this, the operations can be executed inside of a [for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) block, that guarantees a specific execution order.
+`Promise.all` waits for the promises it receives to settle concurrently. If the operations need to happen in a particular order, this would be problematic. In situations like this, the operations can be executed in a [for...of loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) using the `await` operator, which ensures that each operation completes before the next one starts.
 
 ```js
 beforeEach(async () => {


### PR DESCRIPTION
- This update tries to clarify that `Promise.all` **waits for promises to settle** rather than executing them, as promises are already running when they are passed to `Promise.all` (although "settle" might be a new term for students).
- Also clarify that sequential execution is achieved by using `await` inside a `for...of` loop, not by merely creating or handling promises inside the loop, such as:

```js
for (const note of helper.initialNotes) {
  new Note(note).save().then(() => {
    // handle success
  });
}
```