### PR TITLE
docs: use const instead of let in code example in part4b

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -894,8 +894,8 @@ Promise.all executes the promises it receives in parallel. If the promises need 
 beforeEach(async () => {
   await Note.deleteMany({})
 
-  for (let note of helper.initialNotes) {
-    let noteObject = new Note(note)
+  for (const note of helper.initialNotes) {
+    const noteObject = new Note(note)
     await noteObject.save()
   }
 })


### PR DESCRIPTION
This better reflects the intent of the example, follows modern JavaScript conventions, and avoids suggesting the `let` when reassignment of the variable binding is not intended.