### PR TITLE
Part 1a: Add proper punctuation to 'Component' section

### DIFF
--- a/src/content/1/en/part1a.md
+++ b/src/content/1/en/part1a.md
@@ -201,7 +201,7 @@ Note that you should not remove the line at the bottom of the component
 export default App
 ```
 
-The export is not shown in most of the examples of the course material. Without the export the component and the whole app breaks down.
+The export is not shown in most of the examples of the course material. Without the export, the component and the whole app breaks down.
 
 Did you remember your promise to keep the console open? What was printed out there?
 


### PR DESCRIPTION
Without proper punctuation the line is hard to read.
Original:   "Without the export the component and the whole app breaks down."
With Comma: "Without the export, the component and the whole app breaks down."

The comma separates the cause (lack of export) and the outcome (breakdown of the component and the whole app) clearly, whereas it is harder to distinguish the cause from its outcome.