### PR TITLE
Make crosses on info banners visible in dark mode

### DIFF
--- a/src/components/InfoBanner.js
+++ b/src/components/InfoBanner.js
@@ -40,7 +40,7 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: 'var(--color-text)',
+    color: '#33332D',
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner.js
+++ b/src/components/InfoBanner.js
@@ -40,7 +40,7 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: '#33332D',
+    color: style.color,
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner2.js
+++ b/src/components/InfoBanner2.js
@@ -40,7 +40,7 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: 'var(--color-text)',
+    color: '#33332D',
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner2.js
+++ b/src/components/InfoBanner2.js
@@ -40,7 +40,7 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: '#33332D',
+    color: style.color,
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner3.js
+++ b/src/components/InfoBanner3.js
@@ -40,7 +40,7 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: 'var(--color-text)',
+    color: '#33332D',
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner3.js
+++ b/src/components/InfoBanner3.js
@@ -40,7 +40,7 @@ const InfoBanner = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: '#33332D',
+    color: style.color,
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner4.js
+++ b/src/components/InfoBanner4.js
@@ -40,7 +40,7 @@ const InfoBanner4 = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: 'var(--color-text)',
+    color: '#33332D',
     cursor: 'pointer',
   };
 

--- a/src/components/InfoBanner4.js
+++ b/src/components/InfoBanner4.js
@@ -40,7 +40,7 @@ const InfoBanner4 = ({ visible, onHide }) => {
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
-    color: '#33332D',
+    color: style.color,
     cursor: 'pointer',
   };
 


### PR DESCRIPTION
Crosses on info banners were turning white in the dark mode, which made them barely visible on the light background, so I changed the buttonStyle to always use the color it uses in the light mode. Also, I had to create an empty .cache directory in the root before I could start the app, you might want to add it to the CONTRIBUTING.md