### PR TITLE
Part 2b: Remove unnecessary string conversion for note ID

### DIFF
--- a/src/content/2/en/part2b.md
+++ b/src/content/2/en/part2b.md
@@ -235,7 +235,7 @@ const addNote = (event) => {
   const noteObject = {
     content: newNote,
     important: Math.random() < 0.5,
-    id: String(notes.length + 1),
+    id: notes.length + 1,
   }
 
   setNotes(notes.concat(noteObject))


### PR DESCRIPTION
Removes the unnecessary `String()` conversion when assigning the note ID in `noteObject`. `notes.length + 1` already produces a number, and the application uses numeric IDs, so the conversion is redundant.