### PR TITLE
Part 5c: Update test coverage instructions for Vitest 4

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -811,12 +811,13 @@ report by default. To also include uncovered source files, add the following
 to the _test_ configuration in _vite.config.js_:
 
 ```js
-test: {
+export default defineConfig({
   // ...
-  coverage: {
-    include: ['src/**/*.{js,jsx}'],
+  test: {
+    // ...
+    coverage: { include: ['src/**/*.{js,jsx}'] },
   },
-},
+})
 ```
 
 A HTML report will be generated to the <i>coverage</i> directory.

--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -806,6 +806,19 @@ The first time you run the command, Vitest will ask you if you want to install t
 
 ![terminal output of test coverage](../../images/5/18new.png)
 
+With Vitest 4, only files covered by tests are included in the coverage
+report by default. To also include uncovered source files, add the following
+to the _test_ configuration in _vite.config.js_:
+
+```js
+test: {
+  // ...
+  coverage: {
+    include: ['src/**/*.{js,jsx}'],
+  },
+},
+```
+
 A HTML report will be generated to the <i>coverage</i> directory.
 The report will tell us the lines of untested code in each component:
 


### PR DESCRIPTION
Vitest 4 only includes files covered by tests in the coverage report by
default, so the output can differ from the example shown in the course.

This adds a short note showing how to configure `coverage.include` in
`vite.config.js` so uncovered source files are also included in the report.