### PR TITLE
Fix typo in part7b.md regarding transpilation

### DIFF
--- a/src/content/7/en/part7b.md
+++ b/src/content/7/en/part7b.md
@@ -216,7 +216,7 @@ Browsers understand standard JavaScript, but JSX is not valid JavaScript, no bro
 const element = <App />
 ```
 
-it must be transpiled it into something the browser can run:
+it must be transpiled into something the browser can run:
 
 ```js
 const element = React.createElement(App, null)


### PR DESCRIPTION
const element = <App />copy
it must be **transpiled it into** something the browser can run:

const element = React.createElement(App, null)


correction:  it must be **transpiled into** something the browser can run: