### PR TITLE
Part 6:  improve a11y infobanner

### DIFF
--- a/src/components/InfoBanner.js
+++ b/src/components/InfoBanner.js
@@ -37,7 +37,6 @@ const InfoBanner = ({ visible, onHide, language }) => {
   };
 
   const buttonStyle = {
-    outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',
     color: 'var(--color-text)',
@@ -81,6 +80,7 @@ const InfoBanner = ({ visible, onHide, language }) => {
       <div style={buttonDiv}>
         <button
           style={buttonStyle}
+          className="info-banner__close"
           aria-label={language === 'fi' ? 'Sulje kurssi-ilmoitus' : 'Close course notice'}
           onClick={onHide}
         >

--- a/src/components/InfoBanner.js
+++ b/src/components/InfoBanner.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const InfoBanner = ({ visible, onHide }) => {
+const InfoBanner = ({ visible, onHide, language }) => {
   if (!visible) return null;
 
   const style = {
@@ -45,7 +45,11 @@ const InfoBanner = ({ visible, onHide }) => {
   };
 
   return (
-    <div style={style}>
+    <aside
+     style={style}
+     role="status"
+     aria-label={language === 'fi' ? 'Kurssi-ilmoitus' : 'Course notice'}
+    >
       <div style={textStyle}>
         <div style={{ marginBottom: 20 }}>
           <div style={{ marginBottom: 10 }}>
@@ -75,11 +79,15 @@ const InfoBanner = ({ visible, onHide }) => {
         </div>
       </div>
       <div style={buttonDiv}>
-        <button style={buttonStyle} onClick={onHide}>
+        <button
+          style={buttonStyle}
+          aria-label={language === 'fi' ? 'Sulje kurssi-ilmoitus' : 'Close course notice'}
+          onClick={onHide}
+        >
           <div style={textStyle}>x</div>
         </button>
       </div>
-    </div>
+    </aside>
   );
 };
 

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -1,7 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Mono:400,500,600');
 @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,500,600');
 @import './common.scss';
-
 :root,
 html[data-theme='light'] {
   --color-background: #{$white};
@@ -445,5 +444,14 @@ a {
     @include from($large) {
       transform: translateY(-30%);
     }
+  }
+}
+
+.info-banner__close {
+  outline: none;
+
+  &:focus-visible {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
   }
 }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -107,7 +107,11 @@ const Layout = (props) => {
 
       <Header lang={siteLanguage} />
 
-      <InfoBanner onHide={() => hideNote()} visible={visible} />
+      <InfoBanner 
+        onHide={() => hideNote()}
+        visible={visible}
+        language={siteLanguage}
+      />
 
       <InfoBanner2 onHide={() => hideNote2()} visible={false} />
 


### PR DESCRIPTION
## Summary

Improves the accessibility semantics of the Part 6 `InfoBanner`.

## Changes

- Uses an `aside` element for the banner instead of a generic `div`.
- Adds `role="status"` so the banner is exposed as advisory status information.
- Passes the current site language to `InfoBanner` so accessible labels can match the page language.

## Notes

This PR does not change the banner text or visibility behavior.