### PR TITLE
Add missing code snippet to part3a.md

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -888,6 +888,7 @@ At the end of the function body, the _next_ function that was passed as a parame
 Middleware is used like this:
 
 ```js
+app.use(express.json())
 app.use(requestLogger)
 ```
 


### PR DESCRIPTION
The sentence that describes the importance of middleware ordering reads as follows:

> Notice that _json-parser_ is listed before _requestLogger_

However, the preceding code example only shows the _requestLogger_ in use